### PR TITLE
feat!: add SnapshotHint builder support

### DIFF
--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -34,8 +34,9 @@ Built via `Snapshot::builder_for(url).build(engine)` (latest version) or
 snapshot. Its opt-in `skip_new_checkpoints()` mode keeps the input checkpoint and every commit in
 the update window so a snapshot-derived `CommitRange` can inspect them without another log
 listing.
-Under `internal-api`, `.with_snapshot_hint(hint)` validates complete caller-supplied state without
-engine log I/O; the connector supplies the version's freshness status.
+Under `internal-api`, `.with_snapshot_hint(hint)` constructs a snapshot without engine log I/O.
+Kernel validates structural consistency; the connector owns table-root membership,
+protocol/metadata provenance, `max_published_version`, and freshness.
 
 **Snapshot loading internals:**
 1. Ordinary builds discover commits and checkpoints through **LogSegment**

--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -34,11 +34,14 @@ Built via `Snapshot::builder_for(url).build(engine)` (latest version) or
 snapshot. Its opt-in `skip_new_checkpoints()` mode keeps the input checkpoint and every commit in
 the update window so a snapshot-derived `CommitRange` can inspect them without another log
 listing.
+Under `internal-api`, `.with_snapshot_hint(hint)` validates complete caller-supplied state without
+engine log I/O; the connector supplies the version's freshness status.
 
 **Snapshot loading internals:**
-1. **LogSegment** (`kernel/src/log_segment/`): discovers commits + checkpoints for the
-   requested version, replays Protocol and Metadata (`protocol_metadata_replay.rs`), and
-   replays domain metadata (`domain_metadata_replay.rs`)
+1. Ordinary builds discover commits and checkpoints through **LogSegment**
+   (`kernel/src/log_segment/`) and resolve Protocol and Metadata through CRC state or log replay.
+   Domain metadata is resolved lazily from CRC state or log replay when queried. Snapshot-hint
+   builds validate and assemble the supplied state instead.
 2. **Log replay** (`kernel/src/log_replay/`): file-action deduplication via
    `FileActionDeduplicator` and `LogReplayProcessor` trait (distinct from Protocol/Metadata
    replay above)

--- a/ffi/examples/common/kernel_utils.c
+++ b/ffi/examples/common/kernel_utils.c
@@ -95,8 +95,17 @@ void print_table_type(TableType tt) {
   }
 }
 
-// utility to print out a log-segment load type
-void print_load_type(LogSegmentLoadType lt) {
+void print_load_type(SnapshotLoadType lt) {
+  printf("  load_type:");
+  switch (lt) {
+  case SnapshotLoadTypeFull: printf(" Full,\n"); break;
+  case SnapshotLoadTypeIncremental: printf(" Incremental,\n"); break;
+  case SnapshotLoadTypeSnapshotHint: printf(" SnapshotHint,\n"); break;
+  case SnapshotLoadTypeUnknown: printf(" Unknown,\n"); break;
+  }
+}
+
+void print_log_segment_load_type(LogSegmentLoadType lt) {
   printf("  load_type:");
   switch (lt) {
   case LogSegmentLoadTypeFull: printf(" Full,\n"); break;
@@ -121,7 +130,7 @@ void print_metric(MetricEvent event) {
     PM_ID(lsls, operation_id);
     PM_SLICE(lsls, correlation_id);
     print_table_type(lsls.table_type);
-    print_load_type(lsls.load_type);
+    print_log_segment_load_type(lsls.load_type);
     PM_U64(lsls, duration_ns);
     PM_U64(lsls, num_commit_files);
     PM_U64(lsls, num_checkpoint_files);
@@ -137,7 +146,7 @@ void print_metric(MetricEvent event) {
     PM_ID(lslf, operation_id);
     PM_SLICE(lslf, correlation_id);
     print_table_type(lslf.table_type);
-    print_load_type(lslf.load_type);
+    print_log_segment_load_type(lslf.load_type);
     PM_END;
     return;
 
@@ -147,7 +156,7 @@ void print_metric(MetricEvent event) {
     PM_ID(pmls, operation_id);
     PM_SLICE(pmls, correlation_id);
     print_table_type(pmls.table_type);
-    print_load_type(pmls.load_type);
+    print_log_segment_load_type(pmls.load_type);
     PM_U64(pmls, duration_ns);
     PM_END;
     return;
@@ -158,7 +167,7 @@ void print_metric(MetricEvent event) {
     PM_ID(pmlf, operation_id);
     PM_SLICE(pmlf, correlation_id);
     print_table_type(pmlf.table_type);
-    print_load_type(pmlf.load_type);
+    print_log_segment_load_type(pmlf.load_type);
     PM_END;
     return;
 

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -1,3 +1,4 @@
+use delta_kernel::snapshot::SnapshotHintError;
 use delta_kernel::{DeltaResult, Error};
 use tracing::warn;
 
@@ -76,6 +77,7 @@ pub enum KernelError {
     InvalidLogSegment = 47,
     UnpublishedVersionError = 48,
     EmptyLogError = 49,
+    InvalidSnapshotHint = 50,
 }
 
 impl From<Error> for KernelError {
@@ -130,6 +132,7 @@ impl From<Error> for KernelError {
             Error::InvalidExpressionEvaluation(_) => KernelError::InvalidExpression,
             Error::InvalidLogPath(_) => KernelError::InvalidLogPath,
             Error::InvalidLogSegment(_) => KernelError::InvalidLogSegment,
+            Error::SnapshotHint(_) => KernelError::InvalidSnapshotHint,
             Error::FileAlreadyExists(_) => KernelError::FileAlreadyExists,
             Error::Unsupported(_) => KernelError::UnsupportedError,
             Error::ParseIntervalError(_) => KernelError::ParseIntervalError,
@@ -322,6 +325,11 @@ impl From<EngineExecError> for Error {
             KernelError::InvalidExpression => Error::InvalidExpressionEvaluation(message),
             KernelError::InvalidLogPath => Error::InvalidLogPath(message),
             KernelError::InvalidLogSegment => Error::InvalidLogSegment(message),
+            KernelError::InvalidSnapshotHint => SnapshotHintError::Connector {
+                message,
+                source: None,
+            }
+            .into(),
             KernelError::FileAlreadyExists => Error::FileAlreadyExists(message),
             KernelError::UnsupportedError => Error::Unsupported(message),
             KernelError::InvalidCheckpoint => Error::InvalidCheckpoint(message),
@@ -441,6 +449,18 @@ mod error_code_tests {
         assert_eq!(empty_log.to_string(), "No table version found.");
         assert!(matches!(empty_log, Error::EmptyLog));
     }
+
+    #[test]
+    fn invalid_snapshot_hint_error_has_stable_ffi_mapping() {
+        assert_eq!(
+            KernelError::from(Error::from(SnapshotHintError::Connector {
+                message: "invalid".to_string(),
+                source: None,
+            })),
+            KernelError::InvalidSnapshotHint
+        );
+        assert_eq!(KernelError::InvalidSnapshotHint as i32, 50);
+    }
 }
 
 #[cfg(all(test, feature = "declarative-plans"))]
@@ -464,6 +484,7 @@ mod tests {
     #[case::invalid_expr(KernelError::InvalidExpression, "Invalid expression evaluation: boom")]
     #[case::invalid_log_segment(KernelError::InvalidLogSegment, "Invalid log segment: boom")]
     #[case::empty_log(KernelError::EmptyLogError, "No table version found.")]
+    #[case::invalid_snapshot_hint(KernelError::InvalidSnapshotHint, "Invalid snapshot hint: boom")]
     #[case::fallback_io(
         KernelError::IOErrorError,
         "Generic delta kernel error: engine execution error (IOErrorError): boom"

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -75,6 +75,7 @@ impl From<kernel::CommitFailureReason> for CommitFailureReason {
 /// Whether a table is path-based or catalog-managed.
 ///
 /// cbindgen:prefix-with-name=true
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub enum TableType {
     PathBased,
@@ -90,15 +91,28 @@ impl From<kernel::TableType> for TableType {
     }
 }
 
-/// The kind of log-segment load: a full listing from the base up to the target, or an incremental
-/// listing of the commits above an existing segment.
+/// How the snapshot was constructed.
 ///
 /// cbindgen:prefix-with-name=true
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum SnapshotLoadType {
+    Full = 0,
+    Incremental = 1,
+    Unknown = 2,
+    /// Snapshot construction used complete caller-supplied state without engine log I/O.
+    SnapshotHint = 3,
+}
+
+/// How the log segment and protocol/metadata state were loaded.
+///
+/// cbindgen:prefix-with-name=true
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub enum LogSegmentLoadType {
-    Full,
-    Incremental,
-    Unknown,
+    Full = 0,
+    Incremental = 1,
+    Unknown = 2,
 }
 
 impl From<kernel::LogSegmentLoadType> for LogSegmentLoadType {
@@ -106,6 +120,17 @@ impl From<kernel::LogSegmentLoadType> for LogSegmentLoadType {
         match t {
             kernel::LogSegmentLoadType::Full => Self::Full,
             kernel::LogSegmentLoadType::Incremental => Self::Incremental,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<kernel::SnapshotLoadType> for SnapshotLoadType {
+    fn from(t: kernel::SnapshotLoadType) -> Self {
+        match t {
+            kernel::SnapshotLoadType::Full => Self::Full,
+            kernel::SnapshotLoadType::Incremental => Self::Incremental,
+            kernel::SnapshotLoadType::SnapshotHint => Self::SnapshotHint,
             _ => Self::Unknown,
         }
     }
@@ -188,7 +213,7 @@ pub struct SnapshotBuildSuccess {
     pub operation_id: MetricId,
     pub correlation_id: KernelStringSlice,
     pub table_type: TableType,
-    pub load_type: LogSegmentLoadType,
+    pub load_type: SnapshotLoadType,
     pub version: u64,
     pub duration_ns: u64,
 }
@@ -199,7 +224,7 @@ pub struct SnapshotBuildFailure {
     pub operation_id: MetricId,
     pub correlation_id: KernelStringSlice,
     pub table_type: TableType,
-    pub load_type: LogSegmentLoadType,
+    pub load_type: SnapshotLoadType,
 }
 
 /// A transaction was committed successfully. `operation` and `correlation_id` are slices into
@@ -773,8 +798,8 @@ mod tests {
                 panic!("expected ProtocolMetadataLoadSuccess");
             };
             assert_eq!(e.operation_id.bytes, id.as_bytes());
-            assert!(matches!(e.table_type, TableType::CatalogManaged));
-            assert!(matches!(e.load_type, LogSegmentLoadType::Incremental));
+            assert_eq!(e.table_type, TableType::CatalogManaged);
+            assert_eq!(e.load_type, LogSegmentLoadType::Incremental);
             let cid: &str =
                 unsafe { TryFromStringSlice::try_from_slice(&e.correlation_id).unwrap() };
             assert_eq!(cid, "pm-req");
@@ -805,9 +830,9 @@ mod tests {
                 panic!("expected LogSegmentLoadSuccess");
             };
             assert_eq!(e.operation_id.bytes, id.as_bytes());
-            assert!(matches!(e.table_type, TableType::CatalogManaged));
+            assert_eq!(e.table_type, TableType::CatalogManaged);
             assert_eq!(e.duration_ns, 61);
-            assert!(matches!(e.load_type, LogSegmentLoadType::Full));
+            assert_eq!(e.load_type, LogSegmentLoadType::Full);
             assert_eq!(e.num_commit_files, 3);
             assert_eq!(e.num_checkpoint_files, 1);
             assert_eq!(e.num_compaction_files, 2);
@@ -817,6 +842,56 @@ mod tests {
                 unsafe { TryFromStringSlice::try_from_slice(&e.correlation_id).unwrap() };
             assert_eq!(cid, "req-42");
         });
+    }
+
+    #[test]
+    fn from_kernel_snapshot_hint_load_type_maps_to_appended_ffi_variant() {
+        let event = kernel::MetricEvent::SnapshotBuildSuccess(kernel::SnapshotBuildSuccess {
+            operation_id: kernel::MetricId::new(),
+            correlation_id: None,
+            table_type: kernel::TableType::PathBased,
+            load_type: kernel::SnapshotLoadType::SnapshotHint,
+            version: 7,
+            duration: Duration::from_nanos(11),
+        });
+        with_ffi_event(&event, |ffi| {
+            let MetricEvent::SnapshotBuildSuccess(e) = ffi else {
+                panic!("expected SnapshotBuildSuccess");
+            };
+            assert_eq!(e.load_type, SnapshotLoadType::SnapshotHint);
+            assert_eq!(e.version, 7);
+        });
+    }
+
+    #[test]
+    fn from_kernel_snapshot_hint_failure_maps_to_appended_ffi_variant() {
+        let event = kernel::MetricEvent::SnapshotBuildFailure(kernel::SnapshotBuildFailure {
+            operation_id: kernel::MetricId::new(),
+            correlation_id: None,
+            table_type: kernel::TableType::PathBased,
+            load_type: kernel::SnapshotLoadType::SnapshotHint,
+        });
+        with_ffi_event(&event, |ffi| {
+            let MetricEvent::SnapshotBuildFailure(e) = ffi else {
+                panic!("expected SnapshotBuildFailure");
+            };
+            assert_eq!(e.load_type, SnapshotLoadType::SnapshotHint);
+        });
+    }
+
+    #[test]
+    fn snapshot_load_type_discriminants_are_stable() {
+        assert_eq!(SnapshotLoadType::Full as i32, 0);
+        assert_eq!(SnapshotLoadType::Incremental as i32, 1);
+        assert_eq!(SnapshotLoadType::Unknown as i32, 2);
+        assert_eq!(SnapshotLoadType::SnapshotHint as i32, 3);
+    }
+
+    #[test]
+    fn log_segment_load_type_discriminants_are_stable() {
+        assert_eq!(LogSegmentLoadType::Full as i32, 0);
+        assert_eq!(LogSegmentLoadType::Incremental as i32, 1);
+        assert_eq!(LogSegmentLoadType::Unknown as i32, 2);
     }
 
     #[test]
@@ -836,7 +911,7 @@ mod tests {
             let MetricEvent::LogSegmentLoadSuccess(e) = ffi else {
                 panic!("expected LogSegmentLoadSuccess");
             };
-            assert!(matches!(e.table_type, TableType::PathBased));
+            assert_eq!(e.table_type, TableType::PathBased);
             assert!(!e.has_crc);
             let cid: &str =
                 unsafe { TryFromStringSlice::try_from_slice(&e.correlation_id).unwrap() };

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -110,9 +110,9 @@ pub enum SnapshotLoadType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub enum LogSegmentLoadType {
-    Full = 0,
-    Incremental = 1,
-    Unknown = 2,
+    Full,
+    Incremental,
+    Unknown,
 }
 
 impl From<kernel::LogSegmentLoadType> for LogSegmentLoadType {
@@ -899,13 +899,6 @@ mod tests {
         assert_eq!(SnapshotLoadType::Incremental as i32, 1);
         assert_eq!(SnapshotLoadType::SnapshotHint as i32, 2);
         assert_eq!(SnapshotLoadType::Unknown as i32, 3);
-    }
-
-    #[test]
-    fn log_segment_load_type_discriminants_are_stable() {
-        assert_eq!(LogSegmentLoadType::Full as i32, 0);
-        assert_eq!(LogSegmentLoadType::Incremental as i32, 1);
-        assert_eq!(LogSegmentLoadType::Unknown as i32, 2);
     }
 
     #[test]

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -99,9 +99,9 @@ impl From<kernel::TableType> for TableType {
 pub enum SnapshotLoadType {
     Full = 0,
     Incremental = 1,
-    Unknown = 2,
     /// Snapshot construction used complete caller-supplied state without engine log I/O.
-    SnapshotHint = 3,
+    SnapshotHint = 2,
+    Unknown = 3,
 }
 
 /// How the log segment and protocol/metadata state were loaded.
@@ -634,6 +634,8 @@ mod tests {
     use std::mem::discriminant;
     use std::time::Duration;
 
+    use rstest::rstest;
+
     use super::*;
     use crate::TryFromStringSlice;
 
@@ -879,12 +881,24 @@ mod tests {
         });
     }
 
+    #[rstest]
+    #[case::full(kernel::SnapshotLoadType::Full, SnapshotLoadType::Full)]
+    #[case::incremental(kernel::SnapshotLoadType::Incremental, SnapshotLoadType::Incremental)]
+    #[case::snapshot_hint(kernel::SnapshotLoadType::SnapshotHint, SnapshotLoadType::SnapshotHint)]
+    #[case::unknown(kernel::SnapshotLoadType::Unknown, SnapshotLoadType::Unknown)]
+    fn kernel_snapshot_load_type_maps_to_ffi_variant(
+        #[case] source: kernel::SnapshotLoadType,
+        #[case] expected: SnapshotLoadType,
+    ) {
+        assert_eq!(SnapshotLoadType::from(source), expected);
+    }
+
     #[test]
     fn snapshot_load_type_discriminants_are_stable() {
         assert_eq!(SnapshotLoadType::Full as i32, 0);
         assert_eq!(SnapshotLoadType::Incremental as i32, 1);
-        assert_eq!(SnapshotLoadType::Unknown as i32, 2);
-        assert_eq!(SnapshotLoadType::SnapshotHint as i32, 3);
+        assert_eq!(SnapshotLoadType::SnapshotHint as i32, 2);
+        assert_eq!(SnapshotLoadType::Unknown as i32, 3);
     }
 
     #[test]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3247,7 +3247,7 @@ mod tests {
             KernelError::GenericError,
             Some(concat!(
                 "Max catalog version error: Max catalog version is required when providing ",
-                "staged commits in the log tail. ",
+                "staged commits. ",
                 "Use with_max_catalog_version()."
             )),
         );

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 
 #[allow(unused)]
 pub(crate) use delta::{merge_domain_metadata, CrcDelta};
+use delta_kernel_derive::internal_api;
 pub use file_size_histogram::FileSizeHistogram;
 pub use file_stats::FileStats;
 #[allow(unused)]
@@ -168,7 +169,12 @@ struct CrcRaw {
 }
 
 impl Crc {
-    /// Parse a `.crc` file body. `version` comes from the filename (the body does not carry it).
+    /// Parses a `.crc` file body for `version`, which comes from the filename because the body does
+    /// not carry it.
+    ///
+    /// Returns the validated in-memory CRC state. Returns an error if the body is not valid CRC
+    /// JSON or violates CRC invariants.
+    #[internal_api]
     pub(crate) fn try_from_json_bytes(bytes: &[u8], version: Version) -> DeltaResult<Self> {
         let raw: CrcRaw = serde_json::from_slice(bytes)?;
         // Per the Delta protocol spec, numMetadata and numProtocol MUST be 1 in any CRC file.
@@ -180,6 +186,16 @@ impl Crc {
             if value != 1 {
                 return Err(Error::generic(format!(
                     "CRC file has invalid {name}: expected 1, got {value}"
+                )));
+            }
+        }
+        for (name, value) in [
+            ("numFiles", raw.num_files),
+            ("tableSizeBytes", raw.table_size_bytes),
+        ] {
+            if value < 0 {
+                return Err(Error::generic(format!(
+                    "CRC file has invalid {name}: expected a non-negative value, got {value}"
                 )));
             }
         }
@@ -272,6 +288,7 @@ where
             hist.file_counts,
             hist.total_bytes,
         )
+        .and_then(FileSizeHistogram::check_non_negative)
         .map(Some)
         .map_err(serde::de::Error::custom),
         None => Ok(None),
@@ -656,11 +673,16 @@ mod tests {
 
     /// Minimal CRC JSON with the supplied numMetadata / numProtocol values; used to construct
     /// invalid CRCs and verify rejection.
-    fn crc_json_with_counts(num_metadata: i64, num_protocol: i64) -> String {
+    fn crc_json_with_counts(
+        table_size_bytes: i64,
+        num_files: i64,
+        num_metadata: i64,
+        num_protocol: i64,
+    ) -> String {
         format!(
             r#"{{
-                "tableSizeBytes": 0,
-                "numFiles": 0,
+                "tableSizeBytes": {table_size_bytes},
+                "numFiles": {num_files},
                 "numMetadata": {num_metadata},
                 "numProtocol": {num_protocol},
                 "metadata": {{
@@ -687,13 +709,53 @@ mod tests {
         #[values(0i64, 2, 3, -1)] bad: i64,
     ) {
         let (m, p) = counts(bad);
-        let json = crc_json_with_counts(m, p);
+        let json = crc_json_with_counts(0, 0, m, p);
         let err = Crc::try_from_json_bytes(json.as_bytes(), 0)
             .unwrap_err()
             .to_string();
         assert!(
             err.contains(field),
             "expected error to mention {field} for value {bad}, got: {err}"
+        );
+    }
+
+    #[rstest]
+    #[case::num_files("numFiles", 0, -1)]
+    #[case::table_size_bytes("tableSizeBytes", -1, 0)]
+    fn de_negative_file_stat_is_rejected(
+        #[case] field: &str,
+        #[case] table_size_bytes: i64,
+        #[case] num_files: i64,
+    ) {
+        let json = crc_json_with_counts(table_size_bytes, num_files, 1, 1);
+        let err = Crc::try_from_json_bytes(json.as_bytes(), 0)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(field),
+            "expected error to mention {field}: {err}"
+        );
+    }
+
+    #[rstest]
+    #[case::file_count("fileCounts", vec![-1, 0], vec![0, 0])]
+    #[case::total_bytes("totalBytes", vec![0, 0], vec![0, -1])]
+    fn de_negative_file_size_histogram_stat_is_rejected(
+        #[case] field: &str,
+        #[case] file_counts: Vec<i64>,
+        #[case] total_bytes: Vec<i64>,
+    ) {
+        let mut crc: serde_json::Value =
+            serde_json::from_str(&crc_json_with_counts(0, 0, 1, 1)).unwrap();
+        crc["fileSizeHistogram"] = serde_json::json!({
+            "sortedBinBoundaries": [0, 1],
+            "fileCounts": file_counts,
+            "totalBytes": total_bytes,
+        });
+        let error = Crc::try_from_json_bytes(crc.to_string().as_bytes(), 0).unwrap_err();
+        assert!(
+            error.to_string().contains("negative counts or bytes"),
+            "expected invalid {field}, got {error}"
         );
     }
 

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -175,6 +175,10 @@ impl Crc {
     /// Returns parsed CRC state after validating its JSON shape, required action counts,
     /// non-negative aggregate statistics, and histogram structure. This does not compare the state
     /// with log replay.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed JSON or invalid counts, statistics, or histogram fields.
     #[internal_api]
     pub(crate) fn try_from_json_bytes(bytes: &[u8], version: Version) -> DeltaResult<Self> {
         let raw: CrcRaw = serde_json::from_slice(bytes)?;

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -284,14 +284,25 @@ where
 {
     let opt: Option<FileSizeHistogram> = Option::deserialize(deserializer)?;
     match opt {
-        Some(hist) => FileSizeHistogram::try_new(
-            hist.sorted_bin_boundaries,
-            hist.file_counts,
-            hist.total_bytes,
-        )
-        .and_then(FileSizeHistogram::check_non_negative)
-        .map(Some)
-        .map_err(serde::de::Error::custom),
+        Some(hist) => {
+            if let Some(bin) = hist
+                .file_counts
+                .iter()
+                .zip(&hist.total_bytes)
+                .position(|(count, bytes)| *count < 0 || *bytes < 0)
+            {
+                return Err(serde::de::Error::custom(format!(
+                    "CRC fileSizeHistogram has negative counts or bytes at bin {bin}"
+                )));
+            }
+            FileSizeHistogram::try_new(
+                hist.sorted_bin_boundaries,
+                hist.file_counts,
+                hist.total_bytes,
+            )
+            .map(Some)
+            .map_err(serde::de::Error::custom)
+        }
         None => Ok(None),
     }
 }
@@ -757,6 +768,10 @@ mod tests {
         assert!(
             error.to_string().contains("negative counts or bytes"),
             "expected invalid {field}, got {error}"
+        );
+        assert!(
+            !error.to_string().contains("kernel bug"),
+            "malformed external data must not be reported as a kernel bug: {error}"
         );
     }
 

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -172,8 +172,9 @@ impl Crc {
     /// Parses a `.crc` file body for `version`, which comes from the filename because the body does
     /// not carry it.
     ///
-    /// Returns the validated in-memory CRC state. Returns an error if the body is not valid CRC
-    /// JSON or violates CRC invariants.
+    /// Returns parsed CRC state after validating its JSON shape, required action counts,
+    /// non-negative aggregate statistics, and histogram structure. This does not compare the state
+    /// with log replay.
     #[internal_api]
     pub(crate) fn try_from_json_bytes(bytes: &[u8], version: Version) -> DeltaResult<Self> {
         let raw: CrcRaw = serde_json::from_slice(bytes)?;

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -91,6 +91,96 @@ pub type DeltaResultIterator<'a, T> = Box<dyn Iterator<Item = DeltaResult<T>> + 
 /// reference borrowed data.
 pub type DeltaResultIteratorStatic<T> = DeltaResultIterator<'static, T>;
 
+/// An error validating connector-provided state for snapshot construction.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SnapshotHintError {
+    /// A hint was supplied while updating an existing snapshot.
+    #[error("Invalid snapshot hint: A snapshot hint cannot be used with Snapshot::builder_from")]
+    ExistingSnapshot,
+    /// A hint was combined with a log tail.
+    #[error("Invalid snapshot hint: A snapshot hint cannot be combined with a log tail")]
+    LogTail,
+    /// A hint was combined with incremental CRC replay.
+    #[error(
+        "Invalid snapshot hint: A snapshot hint cannot be combined with incremental CRC replay"
+    )]
+    IncrementalReplay,
+    /// The builder requested a version different from the hint's version.
+    #[error(
+        "Invalid snapshot hint: Requested version {requested} does not match snapshot hint version {hint}"
+    )]
+    VersionMismatch {
+        /// The version requested from the snapshot builder.
+        requested: Version,
+        /// The version described by the snapshot hint.
+        hint: Version,
+    },
+    /// A hint marked latest conflicts with a later catalog-ratified version.
+    #[error(
+        "Invalid snapshot hint: version {hint} is marked latest but max catalog version is {max_catalog_version}"
+    )]
+    LatestVersionConflict {
+        /// The version described by the snapshot hint.
+        hint: Version,
+        /// The latest version ratified by the catalog.
+        max_catalog_version: Version,
+    },
+    /// Commit files were supplied without identifying the latest commit.
+    #[error("Invalid snapshot hint: latest_commit_file is required when commits are supplied")]
+    MissingLatestCommit,
+    /// The supplied log files contain log compaction files, which snapshot hints do not support.
+    #[error("Invalid snapshot hint: log compaction files are not supported")]
+    LogCompaction,
+    /// The supplied log files cannot form a valid log segment.
+    #[error("Invalid snapshot hint: supplied log files do not form a valid log segment")]
+    LogSegment {
+        /// The log-segment construction error.
+        #[source]
+        source: Box<Error>,
+    },
+    /// The hint includes a published version after its snapshot version.
+    #[error("Invalid snapshot hint: max_published_version exceeds snapshot hint version {hint}")]
+    MaxPublishedVersion {
+        /// The version described by the snapshot hint.
+        hint: Version,
+    },
+    /// The hint has neither a complete checkpoint nor commit version zero.
+    #[error("Invalid snapshot hint: snapshot history does not start at version 0")]
+    MissingHistoryAnchor,
+    /// The supplied CRC describes a different table version.
+    #[error(
+        "Invalid snapshot hint: CRC version {crc} does not match snapshot hint version {hint}"
+    )]
+    CrcVersion {
+        /// The version described by the CRC.
+        crc: Version,
+        /// The version described by the snapshot hint.
+        hint: Version,
+    },
+    /// The supplied CRC protocol differs from the hint protocol.
+    #[error("Invalid snapshot hint: CRC protocol does not match snapshot hint protocol")]
+    CrcProtocol,
+    /// The supplied CRC metadata differs from the hint metadata.
+    #[error("Invalid snapshot hint: CRC metadata does not match snapshot hint metadata")]
+    CrcMetadata,
+    /// A connector reported invalid snapshot-hint state, optionally with an underlying error.
+    #[error("Invalid snapshot hint: {message}")]
+    Connector {
+        /// A description of the invalid connector state.
+        message: String,
+        /// The underlying validation error, if available.
+        #[source]
+        source: Option<Box<Error>>,
+    },
+}
+
+impl From<SnapshotHintError> for Error {
+    fn from(error: SnapshotHintError) -> Self {
+        Box::new(error).into()
+    }
+}
+
 /// All the types of errors that the kernel can run into
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
@@ -299,8 +389,9 @@ pub enum Error {
     #[error("Invalid log segment: {0}")]
     InvalidLogSegment(String),
 
-    /// Snapshot-hint-specific validation failed. General builder, path, protocol, and metadata
-    /// failures retain their existing error categories.
+    /// Snapshot-hint validation failed. Log-segment errors caused by supplied hint state,
+    /// including invalid paths and checkpoints, are wrapped in `SnapshotHintError::LogSegment`.
+    /// Failures outside hint validation retain their existing categories.
     #[error(transparent)]
     SnapshotHint(#[from] Box<crate::snapshot::SnapshotHintError>),
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -299,6 +299,11 @@ pub enum Error {
     #[error("Invalid log segment: {0}")]
     InvalidLogSegment(String),
 
+    /// Snapshot-hint-specific validation failed. General builder, path, protocol, and metadata
+    /// failures retain their existing error categories.
+    #[error(transparent)]
+    SnapshotHint(#[from] Box<crate::snapshot::SnapshotHintError>),
+
     /// The file already exists at the path, prohibiting a non-overwrite write
     #[error("File already exists: {0}")]
     FileAlreadyExists(String),

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -126,9 +126,6 @@ pub enum SnapshotHintError {
         /// The latest version ratified by the catalog.
         max_catalog_version: Version,
     },
-    /// Commit files were supplied without identifying the latest commit.
-    #[error("Invalid snapshot hint: latest_commit_file is required when commits are supplied")]
-    MissingLatestCommit,
     /// The supplied log files contain log compaction files, which snapshot hints do not support.
     #[error("Invalid snapshot hint: log compaction files are not supported")]
     LogCompaction,
@@ -393,7 +390,7 @@ pub enum Error {
     /// including invalid paths and checkpoints, are wrapped in `SnapshotHintError::LogSegment`.
     /// Failures outside hint validation retain their existing categories.
     #[error(transparent)]
-    SnapshotHint(#[from] Box<crate::snapshot::SnapshotHintError>),
+    SnapshotHint(#[from] Box<SnapshotHintError>),
 
     /// The file already exists at the path, prohibiting a non-overwrite write
     #[error("File already exists: {0}")]

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -95,9 +95,6 @@ pub type DeltaResultIteratorStatic<T> = DeltaResultIterator<'static, T>;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum SnapshotHintError {
-    /// A hint was supplied while updating an existing snapshot.
-    #[error("Invalid snapshot hint: A snapshot hint cannot be used with Snapshot::builder_from")]
-    ExistingSnapshot,
     /// A hint was combined with a log tail.
     #[error("Invalid snapshot hint: A snapshot hint cannot be combined with a log tail")]
     LogTail,
@@ -113,6 +110,18 @@ pub enum SnapshotHintError {
     VersionMismatch {
         /// The version requested from the snapshot builder.
         requested: Version,
+        /// The version described by the snapshot hint.
+        hint: Version,
+    },
+    /// The maximum catalog version differs from the hint when no time-travel version was
+    /// requested.
+    #[error(
+        "Invalid snapshot hint: Max catalog version {max_catalog_version} does not match snapshot \
+         hint version {hint}"
+    )]
+    MaxCatalogVersionMismatch {
+        /// The maximum version ratified by the catalog.
+        max_catalog_version: Version,
         /// The version described by the snapshot hint.
         hint: Version,
     },

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1723,12 +1723,8 @@ fn validate_end_version(
 }
 
 fn validate_and_canonicalize_latest_commit_file(listed: &mut LogSegmentFiles) -> DeltaResult<()> {
-    require!(
-        listed.ascending_commit_files.is_empty() || listed.latest_commit_file.is_some(),
-        Error::internal_error(
-            "latest_commit_file must be Some when ascending_commit_files is non-empty"
-        )
-    );
+    // TODO(#3293): Determine whether every non-empty commit list can require `latest_commit_file`;
+    // legacy callers may omit it.
     if let Some(commit) = &listed.latest_commit_file {
         require!(
             commit.is_commit(),

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1722,8 +1722,6 @@ fn validate_end_version(
     Ok(effective_version)
 }
 
-/// Ensures `latest_commit_file` identifies the unfiltered replay tail, then replaces it with the
-/// tail's canonical location and file metadata.
 fn validate_and_canonicalize_latest_commit_file(listed: &mut LogSegmentFiles) -> DeltaResult<()> {
     require!(
         listed.ascending_commit_files.is_empty() || listed.latest_commit_file.is_some(),

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -206,10 +206,12 @@ impl LogSegment {
         end_version: Option<Version>,
         last_checkpoint_metadata: Option<LastCheckpointHint>,
     ) -> DeltaResult<Self> {
+        validate_log_path_fields(&listed_files)?;
         validate_compaction_files(&listed_files.ascending_compaction_files)?;
         validate_checkpoint_parts(&listed_files.checkpoint_parts)?;
         validate_commit_file_types(&listed_files.ascending_commit_files)?;
         validate_commit_files_sorted(&listed_files.ascending_commit_files)?;
+        validate_and_canonicalize_latest_commit_file(&mut listed_files)?;
 
         // Filter commits before/at checkpoint version
         let checkpoint_version =
@@ -230,7 +232,7 @@ impl LogSegment {
             &listed_files.checkpoint_parts,
             end_version,
         )?;
-        validate_latest_commit_file(&listed_files, effective_version)?;
+        validate_latest_commit_file_version(&listed_files, effective_version)?;
         validate_crc(
             listed_files.latest_crc_file.as_ref(),
             checkpoint_version,
@@ -1558,12 +1560,28 @@ fn validate_compaction_files(compactions: &[ParsedLogPath]) -> DeltaResult<()> {
     Ok(())
 }
 
+fn validate_log_path_fields(listed_files: &LogSegmentFiles) -> DeltaResult<()> {
+    for path in listed_files.iter_all_paths() {
+        let reparsed = ParsedLogPath::try_from(path.location.clone())?
+            .ok_or_else(|| Error::invalid_log_path(path.location.location.as_str()))?;
+        require!(
+            reparsed == *path,
+            Error::invalid_log_path(format!(
+                "Parsed log path fields do not match its location: {}",
+                path.location.location
+            ))
+        );
+    }
+    Ok(())
+}
+
 fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
     if parts.is_empty() {
         return Ok(());
     }
     let n = parts.len();
     let first_version = parts[0].version;
+    let mut seen_part_numbers = vec![false; n];
     for p in parts {
         if !p.is_checkpoint() {
             return Err(Error::invalid_checkpoint(
@@ -1576,7 +1594,27 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
             ));
         }
         match p.file_type {
-            LogPathFileType::MultiPartCheckpoint { num_parts, .. } if num_parts as usize == n => {}
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts,
+            } if num_parts > 1 && num_parts as usize == n => {
+                let index = usize::try_from(part_num)
+                    .ok()
+                    .and_then(|part_num| part_num.checked_sub(1))
+                    .filter(|part_num| *part_num < n)
+                    .ok_or_else(|| {
+                        Error::invalid_checkpoint(format!(
+                            "multi-part checkpoint part number {part_num} is outside 1..={n}"
+                        ))
+                    })?;
+                require!(
+                    !seen_part_numbers[index],
+                    Error::invalid_checkpoint(format!(
+                        "multi-part checkpoint contains duplicate part number {part_num}"
+                    ))
+                );
+                seen_part_numbers[index] = true;
+            }
             LogPathFileType::MultiPartCheckpoint { num_parts, .. } => {
                 return Err(Error::invalid_checkpoint(format!(
                     "multi-part checkpoint part count mismatch: slice has {n} parts but num_parts field says {num_parts}"
@@ -1619,7 +1657,12 @@ fn validate_commit_files_sorted(commits: &[ParsedLogPath]) -> DeltaResult<()> {
 
 fn validate_commit_files_contiguous(commits: &[ParsedLogPath]) -> DeltaResult<()> {
     for pair in commits.windows(2) {
-        let expected_version = pair[0].version + 1;
+        let Some(expected_version) = pair[0].version.checked_add(1) else {
+            return Err(Error::invalid_log_segment(format!(
+                "Expected contiguous commit files, but the version after {:?} overflows",
+                pair[0]
+            )));
+        };
         if expected_version != pair[1].version {
             return Err(Error::MissingVersion(expected_version));
         }
@@ -1637,7 +1680,11 @@ fn validate_checkpoint_commit_gap(
     commits: &[ParsedLogPath],
 ) -> DeltaResult<()> {
     if let (Some(checkpoint_version), Some(first_commit)) = (checkpoint_version, commits.first()) {
-        let expected_version = checkpoint_version + 1;
+        let Some(expected_version) = checkpoint_version.checked_add(1) else {
+            return Err(Error::invalid_checkpoint(format!(
+                "checkpoint version {checkpoint_version} cannot be followed by a commit"
+            )));
+        };
         require!(
             expected_version == first_commit.version,
             Error::MissingVersion(expected_version)
@@ -1675,20 +1722,37 @@ fn validate_end_version(
     Ok(effective_version)
 }
 
-/// Validates the `latest_commit_file` field of a [`LogSegmentFiles`]. Enforces:
-///
-/// 1. If `ascending_commit_files` is non-empty, `latest_commit_file` must be `Some`.
-/// 2. If `latest_commit_file` is `Some`, its version must equal `effective_version`.
-fn validate_latest_commit_file(
-    listed: &LogSegmentFiles,
-    effective_version: Version,
-) -> DeltaResult<()> {
+/// Ensures `latest_commit_file` identifies the unfiltered replay tail, then replaces it with the
+/// tail's canonical location and file metadata.
+fn validate_and_canonicalize_latest_commit_file(listed: &mut LogSegmentFiles) -> DeltaResult<()> {
     require!(
         listed.ascending_commit_files.is_empty() || listed.latest_commit_file.is_some(),
         Error::internal_error(
             "latest_commit_file must be Some when ascending_commit_files is non-empty"
         )
     );
+    if let Some(commit) = &listed.latest_commit_file {
+        require!(
+            commit.is_commit(),
+            Error::invalid_log_path("latest_commit_file is not a commit")
+        );
+        if let Some(last) = listed.ascending_commit_files.last() {
+            require!(
+                commit.file_type == last.file_type
+                    && commit.version == last.version
+                    && commit.filename == last.filename,
+                Error::invalid_log_path("latest_commit_file differs from replay tail")
+            );
+            listed.latest_commit_file = Some(last.clone());
+        }
+    }
+    Ok(())
+}
+
+fn validate_latest_commit_file_version(
+    listed: &LogSegmentFiles,
+    effective_version: Version,
+) -> DeltaResult<()> {
     if let Some(commit) = &listed.latest_commit_file {
         require!(
             commit.version == effective_version,
@@ -1711,6 +1775,10 @@ fn validate_crc(
     let Some(crc) = crc else {
         return Ok(());
     };
+    require!(
+        crc.file_type == LogPathFileType::Crc,
+        Error::invalid_log_path("latest_crc_file contains a non-CRC path")
+    );
     if let Some(checkpoint_version) = checkpoint_version {
         require!(
             crc.version >= checkpoint_version,

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -211,7 +211,6 @@ impl LogSegment {
         validate_checkpoint_parts(&listed_files.checkpoint_parts)?;
         validate_commit_file_types(&listed_files.ascending_commit_files)?;
         validate_commit_files_sorted(&listed_files.ascending_commit_files)?;
-        validate_and_canonicalize_latest_commit_file(&mut listed_files)?;
 
         // Filter commits before/at checkpoint version
         let checkpoint_version =
@@ -232,7 +231,7 @@ impl LogSegment {
             &listed_files.checkpoint_parts,
             end_version,
         )?;
-        validate_latest_commit_file_version(&listed_files, effective_version)?;
+        validate_latest_commit_file(&listed_files, effective_version)?;
         validate_crc(
             listed_files.latest_crc_file.as_ref(),
             checkpoint_version,
@@ -1581,7 +1580,8 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
     }
     let n = parts.len();
     let first_version = parts[0].version;
-    let mut seen_part_numbers = vec![false; n];
+    // TODO(#3297): Validate multi-part checkpoint part-number range and uniqueness, and require
+    // more than one part.
     for p in parts {
         if !p.is_checkpoint() {
             return Err(Error::invalid_checkpoint(
@@ -1594,27 +1594,7 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
             ));
         }
         match p.file_type {
-            LogPathFileType::MultiPartCheckpoint {
-                part_num,
-                num_parts,
-            } if num_parts > 1 && num_parts as usize == n => {
-                let index = usize::try_from(part_num)
-                    .ok()
-                    .and_then(|part_num| part_num.checked_sub(1))
-                    .filter(|part_num| *part_num < n)
-                    .ok_or_else(|| {
-                        Error::invalid_checkpoint(format!(
-                            "multi-part checkpoint part number {part_num} is outside 1..={n}"
-                        ))
-                    })?;
-                require!(
-                    !seen_part_numbers[index],
-                    Error::invalid_checkpoint(format!(
-                        "multi-part checkpoint contains duplicate part number {part_num}"
-                    ))
-                );
-                seen_part_numbers[index] = true;
-            }
+            LogPathFileType::MultiPartCheckpoint { num_parts, .. } if num_parts as usize == n => {}
             LogPathFileType::MultiPartCheckpoint { num_parts, .. } => {
                 return Err(Error::invalid_checkpoint(format!(
                     "multi-part checkpoint part count mismatch: slice has {n} parts but num_parts field says {num_parts}"
@@ -1682,7 +1662,8 @@ fn validate_checkpoint_commit_gap(
     if let (Some(checkpoint_version), Some(first_commit)) = (checkpoint_version, commits.first()) {
         let Some(expected_version) = checkpoint_version.checked_add(1) else {
             return Err(Error::invalid_checkpoint(format!(
-                "checkpoint version {checkpoint_version} cannot be followed by a commit"
+                "checkpoint version {checkpoint_version} is the maximum supported version and \
+                 cannot have a subsequent commit"
             )));
         };
         require!(
@@ -1722,31 +1703,22 @@ fn validate_end_version(
     Ok(effective_version)
 }
 
-fn validate_and_canonicalize_latest_commit_file(listed: &mut LogSegmentFiles) -> DeltaResult<()> {
-    // TODO(#3293): Determine whether every non-empty commit list can require `latest_commit_file`;
-    // legacy callers may omit it.
-    if let Some(commit) = &listed.latest_commit_file {
-        require!(
-            commit.is_commit(),
-            Error::invalid_log_path("latest_commit_file is not a commit")
-        );
-        if let Some(last) = listed.ascending_commit_files.last() {
-            require!(
-                commit.file_type == last.file_type
-                    && commit.version == last.version
-                    && commit.filename == last.filename,
-                Error::invalid_log_path("latest_commit_file differs from replay tail")
-            );
-            listed.latest_commit_file = Some(last.clone());
-        }
-    }
-    Ok(())
-}
-
-fn validate_latest_commit_file_version(
+/// Validates the `latest_commit_file` field of a [`LogSegmentFiles`]. Enforces:
+///
+/// 1. If `ascending_commit_files` is non-empty, `latest_commit_file` must be `Some`.
+/// 2. If `latest_commit_file` is `Some`, its version must equal `effective_version`.
+fn validate_latest_commit_file(
     listed: &LogSegmentFiles,
     effective_version: Version,
 ) -> DeltaResult<()> {
+    // TODO(#3293): Determine whether every non-empty commit list can require `latest_commit_file`;
+    // legacy callers may omit it.
+    require!(
+        listed.ascending_commit_files.is_empty() || listed.latest_commit_file.is_some(),
+        Error::internal_error(
+            "latest_commit_file must be Some when ascending_commit_files is non-empty"
+        )
+    );
     if let Some(commit) = &listed.latest_commit_file {
         require!(
             commit.version == effective_version,

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -50,6 +50,8 @@ use crate::{
     StorageHandler,
 };
 
+const VERSION_ONE_COMMIT: &str = "file:///_delta_log/00000000000000000001.json";
+
 /// Processes sidecar files for the given checkpoint batch.
 ///
 /// This function extracts any sidecar file references from the provided batch.
@@ -1331,9 +1333,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schem
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(&checkpoint_one_file)],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -1407,9 +1407,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_
                 create_log_path_with_size(&checkpoint_one_file, cp1_size),
                 create_log_path_with_size(&checkpoint_two_file, cp2_size),
             ],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -1475,9 +1473,7 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
                 &checkpoint_one_file,
                 checkpoint_size,
             )],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -1561,9 +1557,7 @@ async fn test_scan_checkpoint_read_handles_all_remove_row_groups(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -1623,9 +1617,7 @@ async fn test_scan_checkpoint_read_tolerates_unfiltered_json_rows() -> DeltaResu
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(&checkpoint_file)],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -1691,9 +1683,7 @@ async fn test_scan_checkpoint_read_handles_all_remove_sidecar_row_groups(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -1839,9 +1829,7 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
                 &checkpoint_file_path,
                 checkpoint_size,
             )],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -2399,9 +2387,7 @@ fn test_validate_listed_log_file_in_order_compaction_files() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     assert!(LogSegment::try_new(
         LogSegmentFiles {
-            ascending_commit_files: vec![create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )],
+            ascending_commit_files: vec![create_log_path(VERSION_ONE_COMMIT)],
             ascending_compaction_files: vec![
                 create_log_path(
                     "file:///_delta_log/00000000000000000000.00000000000000000004.compacted.json",
@@ -2425,9 +2411,7 @@ fn test_validate_listed_log_file_out_of_order_compaction_files() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     let result = LogSegment::try_new(
         LogSegmentFiles {
-            ascending_commit_files: vec![create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )],
+            ascending_commit_files: vec![create_log_path(VERSION_ONE_COMMIT)],
             ascending_compaction_files: vec![
                 create_log_path(
                     "file:///_delta_log/00000000000000000000.00000000000000000004.compacted.json",
@@ -2864,9 +2848,7 @@ fn test_validate_listed_log_file_compaction_files_contains_non_compaction() {
             ascending_commit_files: vec![create_log_path(
                 "file:///_delta_log/00000000000000000002.json",
             )],
-            ascending_compaction_files: vec![create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )],
+            ascending_compaction_files: vec![create_log_path(VERSION_ONE_COMMIT)],
             ..Default::default()
         },
         log_root,
@@ -3256,7 +3238,7 @@ fn test_log_segment_contiguous_commit_files() {
     assert!(LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![
-                create_log_path("file:///_delta_log/00000000000000000001.json"),
+                create_log_path(VERSION_ONE_COMMIT),
                 create_log_path("file:///_delta_log/00000000000000000002.json"),
                 create_log_path("file:///_delta_log/00000000000000000003.json"),
             ],
@@ -3275,8 +3257,8 @@ fn test_log_segment_contiguous_commit_files() {
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![
-                create_log_path("file:///_delta_log/00000000000000000001.json"),
-                create_log_path("file:///_delta_log/00000000000000000004.json"),
+                create_log_path(VERSION_ONE_COMMIT),
+                create_log_path("file:///_delta_log/00000000000000000003.json"),
             ],
             ..Default::default()
         },
@@ -3963,9 +3945,7 @@ async fn test_checkpoint_stream_resolves_stats_projection(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -4566,9 +4546,7 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,
@@ -4633,9 +4611,7 @@ async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(
-                "file:///_delta_log/00000000000000000001.json",
-            )),
+            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
             ..Default::default()
         },
         log_root,

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2800,7 +2800,7 @@ fn test_validate_listed_log_file_rejects_one_part_multipart_checkpoint() {
         None,
     )
     .unwrap_err();
-    assert!(matches!(err, Error::Generic(_)));
+    assert!(matches!(err, Error::InvalidCheckpoint(_)));
 }
 
 #[test]

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -50,8 +50,6 @@ use crate::{
     StorageHandler,
 };
 
-const VERSION_ONE_COMMIT: &str = "file:///_delta_log/00000000000000000001.json";
-
 /// Processes sidecar files for the given checkpoint batch.
 ///
 /// This function extracts any sidecar file references from the provided batch.
@@ -1333,7 +1331,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schem
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(&checkpoint_one_file)],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -1407,7 +1405,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_
                 create_log_path_with_size(&checkpoint_one_file, cp1_size),
                 create_log_path_with_size(&checkpoint_two_file, cp2_size),
             ],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -1473,7 +1471,7 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
                 &checkpoint_one_file,
                 checkpoint_size,
             )],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -1557,7 +1555,7 @@ async fn test_scan_checkpoint_read_handles_all_remove_row_groups(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -1617,7 +1615,7 @@ async fn test_scan_checkpoint_read_tolerates_unfiltered_json_rows() -> DeltaResu
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(&checkpoint_file)],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -1683,7 +1681,7 @@ async fn test_scan_checkpoint_read_handles_all_remove_sidecar_row_groups(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -1829,7 +1827,7 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
                 &checkpoint_file_path,
                 checkpoint_size,
             )],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -2387,7 +2385,9 @@ fn test_validate_listed_log_file_in_order_compaction_files() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     assert!(LogSegment::try_new(
         LogSegmentFiles {
-            ascending_commit_files: vec![create_log_path(VERSION_ONE_COMMIT)],
+            ascending_commit_files: vec![create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )],
             ascending_compaction_files: vec![
                 create_log_path(
                     "file:///_delta_log/00000000000000000000.00000000000000000004.compacted.json",
@@ -2411,7 +2411,9 @@ fn test_validate_listed_log_file_out_of_order_compaction_files() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     let result = LogSegment::try_new(
         LogSegmentFiles {
-            ascending_commit_files: vec![create_log_path(VERSION_ONE_COMMIT)],
+            ascending_commit_files: vec![create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )],
             ascending_compaction_files: vec![
                 create_log_path(
                     "file:///_delta_log/00000000000000000000.00000000000000000004.compacted.json",
@@ -2486,48 +2488,6 @@ fn test_validate_empty_log_segment(#[case] end_version: Option<Version>) {
 }
 
 #[test]
-fn test_validate_listed_log_file_duplicate_multipart_checkpoint_part() {
-    let log_root = Url::parse("file:///_delta_log/").unwrap();
-    let part = create_log_path(
-        "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000002.parquet",
-    );
-    let err = LogSegment::try_new(
-        LogSegmentFiles {
-            checkpoint_parts: vec![part.clone(), part],
-            ..Default::default()
-        },
-        log_root,
-        None,
-        None,
-    )
-    .unwrap_err();
-    assert!(matches!(err, Error::InvalidCheckpoint(_)));
-}
-
-#[rstest]
-#[case::zero(0)]
-#[case::greater_than_part_count(3)]
-fn test_validate_checkpoint_parts_rejects_out_of_range_part_number(#[case] part_num: u32) {
-    let mut part = create_log_path(
-        "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000002.parquet",
-    );
-    let LogPathFileType::MultiPartCheckpoint {
-        part_num: cached_part_num,
-        ..
-    } = &mut part.file_type
-    else {
-        panic!("expected a multi-part checkpoint");
-    };
-    *cached_part_num = part_num;
-    let other = create_log_path(
-        "file:///_delta_log/00000000000000000010.checkpoint.0000000002.0000000002.parquet",
-    );
-
-    let error = validate_checkpoint_parts(&[part, other]).unwrap_err();
-    assert!(matches!(error, Error::InvalidCheckpoint(_)));
-}
-
-#[test]
 fn test_validate_listed_log_file_cached_fields_match_location() {
     let mut commit = create_log_path("file:///_delta_log/00000000000000000000.json");
     commit.version = 1;
@@ -2547,7 +2507,7 @@ fn test_validate_listed_log_file_out_of_order_commit_files() {
         LogSegmentFiles {
             ascending_commit_files: vec![
                 create_log_path("file:///_delta_log/00000000000000000003.json"),
-                create_log_path(VERSION_ONE_COMMIT),
+                create_log_path("file:///_delta_log/00000000000000000001.json"),
             ],
             ..Default::default()
         },
@@ -2786,24 +2746,6 @@ fn test_validate_listed_log_file_single_multipart_checkpoint_num_parts_mismatch(
 }
 
 #[test]
-fn test_validate_listed_log_file_rejects_one_part_multipart_checkpoint() {
-    let log_root = Url::parse("file:///_delta_log/").unwrap();
-    let err = LogSegment::try_new(
-        LogSegmentFiles {
-            checkpoint_parts: vec![create_log_path(
-                "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000001.parquet",
-            )],
-            ..Default::default()
-        },
-        log_root,
-        None,
-        None,
-    )
-    .unwrap_err();
-    assert!(matches!(err, Error::InvalidCheckpoint(_)));
-}
-
-#[test]
 fn test_validate_listed_log_file_multiple_single_part_checkpoints() {
     // Two ClassicCheckpoints at the same version: n=2 but neither is a MultiPartCheckpoint
     let log_root = Url::parse("file:///_delta_log/").unwrap();
@@ -2848,7 +2790,9 @@ fn test_validate_listed_log_file_compaction_files_contains_non_compaction() {
             ascending_commit_files: vec![create_log_path(
                 "file:///_delta_log/00000000000000000002.json",
             )],
-            ascending_compaction_files: vec![create_log_path(VERSION_ONE_COMMIT)],
+            ascending_compaction_files: vec![create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )],
             ..Default::default()
         },
         log_root,
@@ -3238,7 +3182,7 @@ fn test_log_segment_contiguous_commit_files() {
     assert!(LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![
-                create_log_path(VERSION_ONE_COMMIT),
+                create_log_path("file:///_delta_log/00000000000000000001.json"),
                 create_log_path("file:///_delta_log/00000000000000000002.json"),
                 create_log_path("file:///_delta_log/00000000000000000003.json"),
             ],
@@ -3257,8 +3201,8 @@ fn test_log_segment_contiguous_commit_files() {
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![
-                create_log_path(VERSION_ONE_COMMIT),
-                create_log_path("file:///_delta_log/00000000000000000003.json"),
+                create_log_path("file:///_delta_log/00000000000000000001.json"),
+                create_log_path("file:///_delta_log/00000000000000000004.json"),
             ],
             ..Default::default()
         },
@@ -3284,71 +3228,9 @@ fn test_log_segment_checkpoint_gap_rejects_version_overflow() {
     let commit = create_log_path("file:///_delta_log/00000000000000000000.json");
     let err = validate_checkpoint_commit_gap(Some(Version::MAX), &[commit]).unwrap_err();
     assert!(matches!(err, Error::InvalidCheckpoint(_)));
-}
-
-#[rstest]
-#[case::checkpoint("file:///_delta_log/00000000000000000007.checkpoint.parquet")]
-#[case::different_staged_commit(
-    "file:///_delta_log/_staged_commits/00000000000000000007.11111111-1111-1111-1111-111111111111.json"
-)]
-fn test_log_segment_rejects_invalid_latest_commit_file(#[case] latest: &str) {
-    let commit = create_log_path("file:///_delta_log/00000000000000000007.json");
-    let err = LogSegment::try_new(
-        LogSegmentFiles {
-            ascending_commit_files: vec![commit],
-            latest_commit_file: Some(create_log_path(latest)),
-            ..Default::default()
-        },
-        Url::parse("file:///_delta_log/").unwrap(),
-        None,
-        None,
-    )
-    .unwrap_err();
-    assert!(matches!(err, Error::InvalidLogPath(_)));
-}
-
-#[test]
-fn test_log_segment_latest_commit_logical_identity_ignores_location_and_metadata() {
-    let commit = create_log_path_with_size(
-        "memory:///encoded%20table/_delta_log/00000000000000000007.json",
-        100,
-    );
-    let latest = create_log_path("file:///different/path/_delta_log/00000000000000000007.json");
-    let log_segment = LogSegment::try_new(
-        LogSegmentFiles {
-            ascending_commit_files: vec![commit.clone()],
-            latest_commit_file: Some(latest),
-            ..Default::default()
-        },
-        Url::parse("memory:///encoded%20table/_delta_log/").unwrap(),
-        None,
-        None,
-    )
-    .unwrap();
-    assert_eq!(log_segment.listed.latest_commit_file, Some(commit));
-}
-
-#[test]
-fn test_log_segment_checkpoint_filtering_cannot_hide_latest_commit_identity_mismatch() {
-    let published = create_log_path("file:///_delta_log/00000000000000000007.json");
-    let staged = create_log_path(
-        "file:///_delta_log/_staged_commits/00000000000000000007.11111111-1111-1111-1111-111111111111.json",
-    );
-    let err = LogSegment::try_new(
-        LogSegmentFiles {
-            checkpoint_parts: vec![create_log_path(
-                "file:///_delta_log/00000000000000000007.checkpoint.parquet",
-            )],
-            ascending_commit_files: vec![published],
-            latest_commit_file: Some(staged),
-            ..Default::default()
-        },
-        Url::parse("file:///_delta_log/").unwrap(),
-        None,
-        None,
-    )
-    .unwrap_err();
-    assert!(matches!(err, Error::InvalidLogPath(_)));
+    assert!(err
+        .to_string()
+        .contains("checkpoint version 18446744073709551615 is the maximum supported version"));
 }
 
 /// `checkpoint_sidecars()` distinguishes "the matched hint lists zero sidecars" (`Some(&[])`) from
@@ -3945,7 +3827,7 @@ async fn test_checkpoint_stream_resolves_stats_projection(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -4546,7 +4428,7 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -4611,7 +4493,7 @@ async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path(VERSION_ONE_COMMIT)),
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1331,7 +1331,9 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schem
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(&checkpoint_one_file)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -1405,7 +1407,9 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_
                 create_log_path_with_size(&checkpoint_one_file, cp1_size),
                 create_log_path_with_size(&checkpoint_two_file, cp2_size),
             ],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -1471,7 +1475,9 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
                 &checkpoint_one_file,
                 checkpoint_size,
             )],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -1555,7 +1561,9 @@ async fn test_scan_checkpoint_read_handles_all_remove_row_groups(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -1615,7 +1623,9 @@ async fn test_scan_checkpoint_read_tolerates_unfiltered_json_rows() -> DeltaResu
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(&checkpoint_file)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -1681,7 +1691,9 @@ async fn test_scan_checkpoint_read_handles_all_remove_sidecar_row_groups(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -1827,7 +1839,9 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
                 &checkpoint_file_path,
                 checkpoint_size,
             )],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -2488,6 +2502,79 @@ fn test_validate_empty_log_segment(#[case] end_version: Option<Version>) {
 }
 
 #[test]
+fn test_validate_listed_log_file_duplicate_multipart_checkpoint_part() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let part = create_log_path(
+        "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000002.parquet",
+    );
+    let err = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![part.clone(), part],
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidCheckpoint(_)));
+}
+
+#[rstest]
+#[case::zero(0)]
+#[case::greater_than_part_count(3)]
+fn test_validate_checkpoint_parts_rejects_out_of_range_part_number(#[case] part_num: u32) {
+    let mut part = create_log_path(
+        "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000002.parquet",
+    );
+    let LogPathFileType::MultiPartCheckpoint {
+        part_num: cached_part_num,
+        ..
+    } = &mut part.file_type
+    else {
+        panic!("expected a multi-part checkpoint");
+    };
+    *cached_part_num = part_num;
+    let other = create_log_path(
+        "file:///_delta_log/00000000000000000010.checkpoint.0000000002.0000000002.parquet",
+    );
+
+    let error = validate_checkpoint_parts(&[part, other]).unwrap_err();
+    assert!(matches!(error, Error::InvalidCheckpoint(_)));
+}
+
+#[test]
+fn test_validate_listed_log_file_cached_fields_match_location() {
+    let mut commit = create_log_path("file:///_delta_log/00000000000000000000.json");
+    commit.version = 1;
+    let err = validate_log_path_fields(&LogSegmentFiles {
+        ascending_commit_files: vec![commit.clone()],
+        latest_commit_file: Some(commit),
+        ..Default::default()
+    })
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidLogPath(_)));
+}
+
+#[test]
+fn test_validate_listed_log_file_out_of_order_commit_files() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    assert!(LogSegment::try_new(
+        LogSegmentFiles {
+            ascending_commit_files: vec![
+                create_log_path("file:///_delta_log/00000000000000000003.json"),
+                create_log_path(VERSION_ONE_COMMIT),
+            ],
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )
+    .is_err());
+}
+
+#[test]
 fn test_validate_truncated_log_segment_reports_first_missing_version() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     let result = LogSegment::try_new(
@@ -2586,6 +2673,25 @@ fn test_try_new_crc_at_end_version_is_ok() {
         None,
     )
     .is_ok());
+}
+
+#[test]
+fn test_try_new_crc_rejects_non_crc_path() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let commit = create_log_path("file:///_delta_log/00000000000000000002.json");
+    let err = LogSegment::try_new(
+        LogSegmentFiles {
+            ascending_commit_files: vec![commit.clone()],
+            latest_commit_file: Some(commit.clone()),
+            latest_crc_file: Some(commit),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidLogPath(_)));
 }
 
 #[test]
@@ -2693,6 +2799,24 @@ fn test_validate_listed_log_file_single_multipart_checkpoint_num_parts_mismatch(
         None,
     );
     assert!(matches!(result, Err(Error::InvalidCheckpoint(_))));
+}
+
+#[test]
+fn test_validate_listed_log_file_rejects_one_part_multipart_checkpoint() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let err = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path(
+                "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000001.parquet",
+            )],
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::Generic(_)));
 }
 
 #[test]
@@ -3161,6 +3285,88 @@ fn test_log_segment_contiguous_commit_files() {
         None,
     );
     assert!(matches!(log_segment, Err(Error::MissingVersion(2))));
+}
+
+#[test]
+fn test_log_segment_commit_contiguity_rejects_version_overflow() {
+    let err = validate_commit_files_contiguous(&[
+        create_log_path("file:///_delta_log/18446744073709551615.json"),
+        create_log_path("file:///_delta_log/00000000000000000000.json"),
+    ])
+    .unwrap_err();
+    assert!(err.to_string().contains("Expected contiguous commit files"));
+}
+
+#[test]
+fn test_log_segment_checkpoint_gap_rejects_version_overflow() {
+    let commit = create_log_path("file:///_delta_log/00000000000000000000.json");
+    let err = validate_checkpoint_commit_gap(Some(Version::MAX), &[commit]).unwrap_err();
+    assert!(matches!(err, Error::InvalidCheckpoint(_)));
+}
+
+#[rstest]
+#[case::checkpoint("file:///_delta_log/00000000000000000007.checkpoint.parquet")]
+#[case::different_staged_commit(
+    "file:///_delta_log/_staged_commits/00000000000000000007.11111111-1111-1111-1111-111111111111.json"
+)]
+fn test_log_segment_rejects_invalid_latest_commit_file(#[case] latest: &str) {
+    let commit = create_log_path("file:///_delta_log/00000000000000000007.json");
+    let err = LogSegment::try_new(
+        LogSegmentFiles {
+            ascending_commit_files: vec![commit],
+            latest_commit_file: Some(create_log_path(latest)),
+            ..Default::default()
+        },
+        Url::parse("file:///_delta_log/").unwrap(),
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidLogPath(_)));
+}
+
+#[test]
+fn test_log_segment_latest_commit_logical_identity_ignores_location_and_metadata() {
+    let commit = create_log_path_with_size(
+        "memory:///encoded%20table/_delta_log/00000000000000000007.json",
+        100,
+    );
+    let latest = create_log_path("file:///different/path/_delta_log/00000000000000000007.json");
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            ascending_commit_files: vec![commit.clone()],
+            latest_commit_file: Some(latest),
+            ..Default::default()
+        },
+        Url::parse("memory:///encoded%20table/_delta_log/").unwrap(),
+        None,
+        None,
+    )
+    .unwrap();
+    assert_eq!(log_segment.listed.latest_commit_file, Some(commit));
+}
+
+#[test]
+fn test_log_segment_checkpoint_filtering_cannot_hide_latest_commit_identity_mismatch() {
+    let published = create_log_path("file:///_delta_log/00000000000000000007.json");
+    let staged = create_log_path(
+        "file:///_delta_log/_staged_commits/00000000000000000007.11111111-1111-1111-1111-111111111111.json",
+    );
+    let err = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path(
+                "file:///_delta_log/00000000000000000007.checkpoint.parquet",
+            )],
+            ascending_commit_files: vec![published],
+            latest_commit_file: Some(staged),
+            ..Default::default()
+        },
+        Url::parse("file:///_delta_log/").unwrap(),
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::InvalidLogPath(_)));
 }
 
 /// `checkpoint_sidecars()` distinguishes "the matched hint lists zero sidecars" (`Some(&[])`) from
@@ -3757,7 +3963,9 @@ async fn test_checkpoint_stream_resolves_stats_projection(
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -4358,7 +4566,9 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,
@@ -4423,7 +4633,9 @@ async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000001.json",
+            )),
             ..Default::default()
         },
         log_root,

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -343,8 +343,8 @@ pub enum SnapshotLoadType {
     /// The segment was listed from its base (a checkpoint, else version 0) up to the target. A
     /// fresh snapshot build (`LogSegment::for_snapshot`) reads this way.
     Full,
-    /// The segment was listed as a delta above an existing base. An incremental snapshot update
-    /// (`Snapshot::try_new_from`) reads only the commits above the existing snapshot.
+    /// The build started from an existing snapshot. It may return that snapshot unchanged, replay
+    /// newer commits, or rebuild from a newly discovered checkpoint.
     Incremental,
     /// The snapshot was constructed from complete caller-supplied state without asking the engine
     /// to list or read Delta log files.
@@ -357,13 +357,7 @@ pub enum SnapshotLoadType {
 
 impl SnapshotLoadType {
     fn parse_or_unknown(s: &str) -> Self {
-        if s.is_empty() {
-            return Self::Unknown;
-        }
-        Self::from_str(s).unwrap_or_else(|e| {
-            warn!("Invalid load_type '{s}': {e}. Using Unknown.");
-            Self::Unknown
-        })
+        parse_load_type_or_unknown(s)
     }
 }
 
@@ -376,7 +370,8 @@ impl SnapshotLoadType {
 pub enum LogSegmentLoadType {
     /// The segment was listed from its base through the target version.
     Full,
-    /// The segment was listed above an existing snapshot's segment.
+    /// The segment load started from an existing snapshot. It may reuse that segment, extend it,
+    /// or replace it after discovering a newer checkpoint.
     Incremental,
     /// Decode fell back here because the span field was unset or unrecognized.
     #[default]
@@ -385,14 +380,22 @@ pub enum LogSegmentLoadType {
 
 impl LogSegmentLoadType {
     fn parse_or_unknown(s: &str) -> Self {
-        if s.is_empty() {
-            return Self::Unknown;
-        }
-        Self::from_str(s).unwrap_or_else(|e| {
-            warn!("Invalid load_type '{s}': {e}. Using Unknown.");
-            Self::Unknown
-        })
+        parse_load_type_or_unknown(s)
     }
+}
+
+fn parse_load_type_or_unknown<T>(s: &str) -> T
+where
+    T: Default + FromStr,
+    T::Err: fmt::Display,
+{
+    if s.is_empty() {
+        return T::default();
+    }
+    s.parse().unwrap_or_else(|error| {
+        warn!("Invalid load_type '{s}': {error}. Using Unknown.");
+        T::default()
+    })
 }
 
 /// A log segment was listed and assembled for a snapshot.

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -323,22 +323,62 @@ impl fmt::Display for MetricEvent {
 
 pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 
-/// The kind of log-segment load: a full listing from the base up to the target, or an
-/// incremental listing of the commits above an existing segment.
+/// How the snapshot was constructed.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    EnumString,
+    StrumDisplay,
+    AsRefStr,
+    IntoStaticStr,
 )]
 #[strum(serialize_all = "snake_case")]
 #[non_exhaustive]
-pub enum LogSegmentLoadType {
+pub enum SnapshotLoadType {
     /// The segment was listed from its base (a checkpoint, else version 0) up to the target. A
     /// fresh snapshot build (`LogSegment::for_snapshot`) reads this way.
     Full,
     /// The segment was listed as a delta above an existing base. An incremental snapshot update
     /// (`Snapshot::try_new_from`) reads only the commits above the existing snapshot.
     Incremental,
+    /// The snapshot was constructed from complete caller-supplied state without asking the engine
+    /// to list or read Delta log files.
+    SnapshotHint,
     /// Decode fell back here because the span's `load_type` field was unset or unrecognized.
     /// Kernel never emits this deliberately.
+    #[default]
+    Unknown,
+}
+
+impl SnapshotLoadType {
+    fn parse_or_unknown(s: &str) -> Self {
+        if s.is_empty() {
+            return Self::Unknown;
+        }
+        Self::from_str(s).unwrap_or_else(|e| {
+            warn!("Invalid load_type '{s}': {e}. Using Unknown.");
+            Self::Unknown
+        })
+    }
+}
+
+/// How the log segment and protocol/metadata state were loaded.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum LogSegmentLoadType {
+    /// The segment was listed from its base through the target version.
+    Full,
+    /// The segment was listed above an existing snapshot's segment.
+    Incremental,
+    /// Decode fell back here because the span field was unset or unrecognized.
     #[default]
     Unknown,
 }
@@ -655,7 +695,7 @@ pub struct SnapshotBuildSuccess {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
-    pub load_type: LogSegmentLoadType,
+    pub load_type: SnapshotLoadType,
 
     // === Set during span lifetime ===
     pub version: u64,
@@ -722,7 +762,7 @@ pub struct SnapshotBuildFailure {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
-    pub load_type: LogSegmentLoadType,
+    pub load_type: SnapshotLoadType,
 }
 
 impl fmt::Display for SnapshotBuildFailure {
@@ -1273,7 +1313,7 @@ pub struct SnapshotLoadMetricContext {
     pub(crate) operation_id: MetricId,
     pub(crate) correlation_id: Option<Arc<str>>,
     pub(crate) is_catalog_managed: bool,
-    pub(crate) load_type: LogSegmentLoadType,
+    pub(crate) load_type: SnapshotLoadType,
 }
 
 #[cfg(test)]
@@ -1285,7 +1325,7 @@ impl SnapshotLoadMetricContext {
             operation_id: MetricId::nil(),
             correlation_id: None,
             is_catalog_managed: false,
-            load_type: LogSegmentLoadType::default(),
+            load_type: SnapshotLoadType::default(),
         }
     }
 }
@@ -1345,13 +1385,13 @@ pub(crate) fn correlation_id_from_attrs(attrs: &Attributes<'_>) -> Option<Arc<st
     v.0
 }
 
-pub(crate) fn load_type_from_attrs(attrs: &Attributes<'_>) -> LogSegmentLoadType {
+pub(crate) fn load_type_from_attrs(attrs: &Attributes<'_>) -> SnapshotLoadType {
     #[derive(Default)]
-    struct V(LogSegmentLoadType);
+    struct V(SnapshotLoadType);
     impl Visit for V {
         fn record_str(&mut self, field: &Field, value: &str) {
             if field.name() == "load_type" {
-                self.0 = LogSegmentLoadType::parse_or_unknown(value);
+                self.0 = SnapshotLoadType::parse_or_unknown(value);
             }
         }
         fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
@@ -1926,6 +1966,31 @@ mod tests {
     }
 
     #[rstest]
+    #[case::full(SnapshotLoadType::Full, "full")]
+    #[case::incremental(SnapshotLoadType::Incremental, "incremental")]
+    #[case::snapshot_hint(SnapshotLoadType::SnapshotHint, "snapshot_hint")]
+    #[case::unknown(SnapshotLoadType::Unknown, "unknown")]
+    fn snapshot_load_type_serializes_to_wire_name_and_parses_back(
+        #[case] load_type: SnapshotLoadType,
+        #[case] wire: &str,
+    ) {
+        let serialized: &'static str = load_type.into();
+        assert_eq!(serialized, wire);
+        assert_eq!(SnapshotLoadType::from_str(wire).unwrap(), load_type);
+    }
+
+    #[rstest]
+    #[case::known("incremental", SnapshotLoadType::Incremental)]
+    #[case::empty_maps_to_unknown("", SnapshotLoadType::Unknown)]
+    #[case::unrecognized_maps_to_unknown("totally_unknown", SnapshotLoadType::Unknown)]
+    fn snapshot_load_type_parse_or_unknown(
+        #[case] value: &str,
+        #[case] expected: SnapshotLoadType,
+    ) {
+        assert_eq!(SnapshotLoadType::parse_or_unknown(value), expected);
+    }
+
+    #[rstest]
     #[case::full(LogSegmentLoadType::Full, "full")]
     #[case::incremental(LogSegmentLoadType::Incremental, "incremental")]
     #[case::unknown(LogSegmentLoadType::Unknown, "unknown")]
@@ -2028,7 +2093,7 @@ mod tests {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
             correlation_id: Some("snap-req-3".into()),
-            load_type: LogSegmentLoadType::Incremental,
+            load_type: SnapshotLoadType::Incremental,
             version: 0,
             duration: Duration::default(),
         };
@@ -2038,6 +2103,6 @@ mod tests {
             panic!("expected SnapshotBuildFailure");
         };
         assert_eq!(failure.correlation_id.as_deref(), Some("snap-req-3"));
-        assert_eq!(failure.load_type, LogSegmentLoadType::Incremental);
+        assert_eq!(failure.load_type, SnapshotLoadType::Incremental);
     }
 }

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -89,8 +89,8 @@ pub use events::{
     LogSegmentLoadType, MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
     ProtocolMetadataLoadSuccess, ProtocolMetadataSource, ScanMetadataCompleted, ScanType,
     SetTransactionLoadSuccess, SnapshotBuildFailure, SnapshotBuildSuccess,
-    SnapshotLoadMetricContext, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
-    TableType, TransactionCommitFailure, TransactionCommitSuccess,
+    SnapshotLoadMetricContext, SnapshotLoadType, StorageCopyCompleted, StorageListCompleted,
+    StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
 };
 pub(crate) use events::{
     emit_log_segment_load, emit_log_segment_load_failure, emit_protocol_metadata_load,

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -30,14 +30,14 @@ pub struct FromTableRoot;
 #[doc(hidden)]
 pub struct FromSnapshot;
 
-/// The connector-provided freshness status for the version carried by a [`SnapshotHint`].
+/// The connector-provided freshness of the version carried by a [`SnapshotHint`].
 ///
-/// Kernel trusts this status: [`Latest`](Self::Latest) makes
+/// Kernel trusts this value: [`Latest`](Self::Latest) makes
 /// [`Snapshot::is_built_as_latest`] true, while [`Unverified`](Self::Unverified) makes it false.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
 #[internal_api]
-pub(crate) enum SnapshotHintVersionStatus {
+pub(crate) enum SnapshotHintFreshness {
     /// The connector supplied the version without establishing that it was the latest version.
     Unverified,
     /// The connector established that the supplied version was the latest version.
@@ -47,7 +47,7 @@ pub(crate) enum SnapshotHintVersionStatus {
 /// Complete state for constructing a [`Snapshot`] without engine I/O.
 ///
 /// Kernel validates the log segment, protocol, metadata, and optional CRC before constructing the
-/// snapshot. It records the connector-provided freshness status without validating it.
+/// snapshot. It records the connector-provided freshness without validating it.
 #[derive(Debug, Clone)]
 #[internal_api]
 pub(crate) struct SnapshotHint {
@@ -57,6 +57,9 @@ pub(crate) struct SnapshotHint {
     /// versions.
     pub version: Version,
     /// The complete set of log files required by the snapshot.
+    ///
+    /// `latest_crc_file` identifies the latest CRC present in storage and may be older than
+    /// `version`.
     pub log_segment_files: LogSegmentFiles,
     /// The table protocol at `version`.
     pub protocol: Protocol,
@@ -64,10 +67,12 @@ pub(crate) struct SnapshotHint {
     pub metadata: Metadata,
     /// The optional `_last_checkpoint` contents associated with the log segment.
     pub last_checkpoint_hint: Option<LastCheckpointHint>,
-    /// The optional pre-resolved CRC state at `version`.
+    /// The optional CRC state resolved at `version`.
+    ///
+    /// This may have been advanced from an older `latest_crc_file`.
     pub crc: Option<Arc<Crc>>,
     /// Whether the connector established that `version` was latest.
-    pub version_status: SnapshotHintVersionStatus,
+    pub freshness: SnapshotHintFreshness,
 }
 
 /// Builder for creating [`Snapshot`] instances.
@@ -246,7 +251,7 @@ impl<Mode> SnapshotBuilder<Mode> {
     /// Sets the target version of the [`Snapshot`].
     ///
     /// Without a snapshot hint, omitting this targets the latest table version. With a hint,
-    /// omitting this uses the hint version and its supplied freshness status.
+    /// omitting this uses the hint version and its supplied freshness.
     pub fn at_version(mut self, version: Version) -> Self {
         self.version = Some(version);
         self
@@ -290,11 +295,12 @@ impl<Mode> SnapshotBuilder<Mode> {
 
     /// Supply a [`CancellationToken`] for snapshot builds that list or read the log.
     ///
-    /// Kernel polls the token while consuming a log listing, and a cancellation-aware [`Engine`]
-    /// additionally races its listing and log reads against it. Snapshot-hint builds perform no
-    /// listing or reads, so the token has no effect on them. On cancellation [`build`](Self::build)
-    /// returns [`Error::Cancelled`] rather than a snapshot built from a partial listing. With no
-    /// token the build is not cancellable.
+    /// Kernel polls the token while consuming a log listing. A cancellation-aware [`Engine`]
+    /// returns from [`build`](Self::build) when either the token is cancelled or the listing and
+    /// log-read work completes, whichever happens first. Snapshot-hint builds perform no listing or
+    /// reads, so the token has no effect on them. On cancellation, `build` returns
+    /// [`Error::Cancelled`] rather than a snapshot built from a partial listing. With no token the
+    /// build is not cancellable.
     ///
     /// [`CancellationToken`]: crate::CancellationToken
     /// [`Error::Cancelled`]: crate::Error::Cancelled
@@ -536,9 +542,9 @@ impl<Mode> SnapshotBuilder<Mode> {
             metadata,
             last_checkpoint_hint,
             crc,
-            version_status,
+            freshness,
         } = snapshot_hint;
-        if version_status == SnapshotHintVersionStatus::Latest {
+        if freshness == SnapshotHintFreshness::Latest {
             require!(
                 max_catalog_version.is_none_or(|max| max == version),
                 SnapshotHintError::LatestVersionConflict {
@@ -627,7 +633,7 @@ impl<Mode> SnapshotBuilder<Mode> {
             log_segment,
             table_configuration,
             crc,
-            version_status == SnapshotHintVersionStatus::Latest,
+            freshness == SnapshotHintFreshness::Latest,
             false, /* skipped_new_checkpoints */
         )
         .map(Into::into)
@@ -865,7 +871,7 @@ mod tests {
 
     fn hint_from_snapshot(
         snapshot: &SnapshotRef,
-        version_status: SnapshotHintVersionStatus,
+        freshness: SnapshotHintFreshness,
     ) -> SnapshotHint {
         SnapshotHint {
             version: snapshot.version(),
@@ -874,12 +880,12 @@ mod tests {
             metadata: snapshot.table_configuration().metadata().clone(),
             last_checkpoint_hint: snapshot.log_segment().last_checkpoint_metadata.clone(),
             crc: snapshot.crc_at_version().cloned(),
-            version_status,
+            freshness,
         }
     }
 
     async fn snapshot_and_hint(
-        version_status: SnapshotHintVersionStatus,
+        freshness: SnapshotHintFreshness,
     ) -> Result<(Arc<SyncEngine>, String, SnapshotRef, SnapshotHint), Box<dyn std::error::Error>>
     {
         let (engine, store, table_root) = setup_test();
@@ -887,7 +893,7 @@ mod tests {
         let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
         let _ = snapshot.write_checksum(engine.as_ref())?;
         let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
-        let hint = hint_from_snapshot(&snapshot, version_status);
+        let hint = hint_from_snapshot(&snapshot, freshness);
         Ok((engine, table_root, snapshot, hint))
     }
 
@@ -921,15 +927,14 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case::latest(SnapshotHintVersionStatus::Latest, true)]
-    #[case::unverified(SnapshotHintVersionStatus::Unverified, false)]
+    #[case::latest(SnapshotHintFreshness::Latest, true)]
+    #[case::unverified(SnapshotHintFreshness::Unverified, false)]
     #[test_log::test(tokio::test)]
     async fn complete_snapshot_hint_matches_storage_snapshot_without_child_loads(
-        #[case] version_status: SnapshotHintVersionStatus,
+        #[case] freshness: SnapshotHintFreshness,
         #[case] expected_built_as_latest: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let (engine, table_root, storage_snapshot, hint) =
-            snapshot_and_hint(version_status).await?;
+        let (engine, table_root, storage_snapshot, hint) = snapshot_and_hint(freshness).await?;
         assert!(storage_snapshot.crc_at_version().is_some());
 
         let token: CancellationTokenRef = Arc::new(TestCancellationToken::cancelled());
@@ -982,7 +987,7 @@ mod tests {
     async fn complete_snapshot_hint_without_crc_succeeds() -> Result<(), Box<dyn std::error::Error>>
     {
         let (engine, table_root, _snapshot, mut hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
         hint.crc = None;
 
         let hinted = SnapshotBuilder::new_for(table_root)
@@ -1010,7 +1015,7 @@ mod tests {
             .last_checkpoint_metadata
             .is_some());
 
-        let mut hint = hint_from_snapshot(&storage_snapshot, SnapshotHintVersionStatus::Unverified);
+        let mut hint = hint_from_snapshot(&storage_snapshot, SnapshotHintFreshness::Unverified);
         hint.log_segment_files.ascending_commit_files.clear();
         hint.log_segment_files.latest_commit_file = None;
         let hinted_snapshot = SnapshotBuilder::new_for(table_root)
@@ -1035,7 +1040,7 @@ mod tests {
         #[case] include_replay_commit: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root, _snapshot, mut hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
         let staged = create_log_path(concat!(
             "memory:///_delta_log/_staged_commits/00000000000000000000.",
             "11111111-1111-1111-1111-111111111111.json"
@@ -1073,7 +1078,7 @@ mod tests {
     async fn snapshot_hint_rejects_published_version_after_hint_version(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root, _snapshot, mut hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
         hint.log_segment_files.max_published_version = Some(Version::MAX);
 
         let err = SnapshotBuilder::new_for(table_root)
@@ -1088,7 +1093,7 @@ mod tests {
     async fn snapshot_hint_rejects_malformed_log_segment_and_incompatible_table_state(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root, _snapshot, hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
 
         let mut gapped = hint.clone();
         gapped.log_segment_files.ascending_commit_files[1] =
@@ -1143,7 +1148,7 @@ mod tests {
     async fn snapshot_hint_rejects_checkpoint_free_history_not_starting_at_version_zero(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root, _snapshot, mut hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
         hint.crc = None;
         hint.log_segment_files.ascending_commit_files.remove(0);
 
@@ -1156,49 +1161,6 @@ mod tests {
         Ok(())
     }
 
-    #[test_log::test(tokio::test)]
-    async fn snapshot_hint_accepts_missing_latest_commit_file(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let (engine, table_root, _snapshot, mut hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
-        hint.log_segment_files.latest_commit_file = None;
-
-        let snapshot = SnapshotBuilder::new_for(table_root)
-            .with_snapshot_hint(hint)
-            .build(engine.as_ref())?;
-        assert!(snapshot.log_segment().listed.latest_commit_file.is_none());
-        Ok(())
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn snapshot_hint_rejects_latest_commit_with_wrong_kind_or_identity(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let (engine, table_root, _snapshot, hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
-        let invalid_latest_commits = [
-            format!(
-                "memory:///_delta_log/{:020}.checkpoint.parquet",
-                hint.version
-            ),
-            format!(
-                "memory:///_delta_log/_staged_commits/{:020}.11111111-1111-1111-1111-111111111111.json",
-                hint.version
-            ),
-        ];
-
-        for latest in invalid_latest_commits {
-            let mut malformed = hint.clone();
-            malformed.log_segment_files.latest_commit_file = Some(create_log_path(&latest));
-            let err = SnapshotBuilder::new_for(&table_root)
-                .with_max_catalog_version(hint.version)
-                .with_snapshot_hint(malformed)
-                .build(engine.as_ref())
-                .unwrap_err();
-            assert!(matches!(err, Error::SnapshotHint(_)));
-        }
-        Ok(())
-    }
-
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn snapshot_hint_internal_log_invariant_preserves_source(
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -1207,7 +1169,7 @@ mod tests {
         let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
         let _ = snapshot.checkpoint(engine.as_ref(), None)?;
         let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
-        let mut hint = hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Unverified);
+        let mut hint = hint_from_snapshot(&snapshot, SnapshotHintFreshness::Unverified);
         hint.log_segment_files.latest_commit_file = Some(create_log_path(
             "memory:///_delta_log/00000000000000000000.json",
         ));
@@ -1232,7 +1194,7 @@ mod tests {
     async fn snapshot_hint_rejects_mismatched_crc_state() -> Result<(), Box<dyn std::error::Error>>
     {
         let (engine, table_root, _snapshot, hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
         let matching_crc = hint.crc.as_ref().unwrap().as_ref().clone();
 
         let mut wrong_version = hint.clone();
@@ -1277,7 +1239,7 @@ mod tests {
     async fn snapshot_hint_rejects_conflicting_builder_options_and_reports_failure(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root, snapshot, hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
         let log_path = LogPath::try_new(
             snapshot
                 .log_segment()
@@ -1328,11 +1290,12 @@ mod tests {
         );
 
         let (reporter, _guard) = measuring_reporter();
-        assert!(SnapshotBuilder::new_for(table_root)
+        let result = SnapshotBuilder::new_for(table_root)
             .with_max_catalog_version(hint.version + 1)
             .with_snapshot_hint(hint)
-            .build(engine.as_ref())
-            .is_err());
+            .build(engine.as_ref());
+        assert!(matches!(&result, Err(Error::MaxCatalogVersion(_))));
+        assert_result_error_with_message(result, "does not match snapshot hint version");
         let events = reporter.events();
         assert_eq!(events.len(), 1);
         let MetricEvent::SnapshotBuildFailure(failure) = &events[0] else {
@@ -1346,7 +1309,7 @@ mod tests {
     async fn snapshot_hint_version_must_match_log_segment_end_version(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root, _snapshot, mut hint) =
-            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
         hint.version -= 1;
         hint.crc = None;
 
@@ -1380,7 +1343,7 @@ mod tests {
         let snapshot = SnapshotBuilder::new_for(&table_root)
             .with_max_catalog_version(1)
             .build(engine.as_ref())?;
-        let hint = hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Unverified);
+        let hint = hint_from_snapshot(&snapshot, SnapshotHintFreshness::Unverified);
 
         assert_result_error_with_message(
             SnapshotBuilder::new_for(&table_root)
@@ -1403,8 +1366,7 @@ mod tests {
         assert_eq!(hinted.version(), 1);
         assert!(!hinted.is_built_as_latest());
 
-        let mut contradictory_hint =
-            hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Latest);
+        let mut contradictory_hint = hint_from_snapshot(&snapshot, SnapshotHintFreshness::Latest);
         contradictory_hint.crc = None;
         assert_hint_error(
             SnapshotBuilder::new_for("memory:///")
@@ -1783,29 +1745,6 @@ mod tests {
             .await
             .expect("Failed to write initial catalog-managed commit");
             (engine, store, table_root)
-        }
-
-        #[test_log::test(tokio::test)]
-        async fn snapshot_hint_accepts_staged_commit_without_latest_file_with_catalog_version(
-        ) -> Result<(), Box<dyn std::error::Error>> {
-            let (engine, store, table_root) = setup_catalog_managed_test().await;
-            let staged =
-                add_staged_commit(&table_root, store.as_ref(), 1, "{}".to_string()).await?;
-            let snapshot = SnapshotBuilder::new_for(&table_root)
-                .with_log_tail(vec![create_log_path(&table_root, staged)])
-                .with_max_catalog_version(1)
-                .build(engine.as_ref())?;
-            let mut hint = hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Unverified);
-            hint.log_segment_files.latest_commit_file = None;
-
-            let hinted = SnapshotBuilder::new_for(&table_root)
-                .with_max_catalog_version(1)
-                .with_snapshot_hint(hint)
-                .build(engine.as_ref())?;
-
-            assert_eq!(hinted.version(), 1);
-            assert!(hinted.table_configuration().is_catalog_managed());
-            Ok(())
         }
 
         #[test_log::test(tokio::test)]

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -3,16 +3,21 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use delta_kernel_derive::internal_api;
 use tracing::{info, instrument};
 
+use crate::actions::{Metadata, Protocol};
 use crate::cancellation::CancellationTokenRef;
+use crate::crc::Crc;
+use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
-use crate::log_segment_files::CheckpointHandling;
+use crate::log_segment_files::{CheckpointHandling, LogSegmentFiles};
 use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
-use crate::metrics::{LogSegmentLoadType, MetricId, SnapshotLoadMetricContext};
+use crate::metrics::{MetricId, SnapshotLoadMetricContext, SnapshotLoadType};
 use crate::path::LogPathFileType;
 use crate::snapshot::SnapshotRef;
+use crate::table_configuration::TableConfiguration;
 use crate::utils::{require, try_parse_uri};
 use crate::{DeltaResult, Engine, Error, Snapshot, Version};
 
@@ -23,6 +28,43 @@ pub struct FromTableRoot;
 /// Marker for builders that incrementally update an existing snapshot.
 #[doc(hidden)]
 pub struct FromSnapshot;
+
+/// The connector-provided freshness status for the version carried by a [`SnapshotHint`].
+///
+/// Kernel trusts this status: [`Latest`](Self::Latest) makes
+/// [`Snapshot::is_built_as_latest`] true, while [`Unverified`](Self::Unverified) makes it false.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+#[internal_api]
+pub(crate) enum SnapshotHintVersionStatus {
+    /// The connector supplied the version without establishing that it was the latest version.
+    Unverified,
+    /// The connector established that the supplied version was the latest version.
+    Latest,
+}
+
+/// Complete state for constructing a [`Snapshot`] without engine I/O.
+///
+/// Kernel validates the log segment, protocol, metadata, and optional CRC before constructing the
+/// snapshot. It records the connector-provided freshness status without validating it.
+#[derive(Debug, Clone)]
+#[internal_api]
+pub(crate) struct SnapshotHint {
+    /// The table version described by every component of this hint.
+    pub version: Version,
+    /// The complete set of log files required by the snapshot.
+    pub log_segment_files: LogSegmentFiles,
+    /// The table protocol at `version`.
+    pub protocol: Protocol,
+    /// The table metadata at `version`.
+    pub metadata: Metadata,
+    /// The optional `_last_checkpoint` contents associated with the log segment.
+    pub last_checkpoint_hint: Option<LastCheckpointHint>,
+    /// The optional pre-resolved CRC state at `version`.
+    pub crc: Option<Arc<Crc>>,
+    /// Whether the connector established that `version` was latest.
+    pub version_status: SnapshotHintVersionStatus,
+}
 
 /// Builder for creating [`Snapshot`] instances.
 ///
@@ -50,6 +92,7 @@ pub struct SnapshotBuilder<Mode = FromTableRoot> {
     max_catalog_version: Option<Version>,
     incremental_replay: IncrementalReplay,
     checkpoint_handling: CheckpointHandling,
+    snapshot_hint: Option<SnapshotHint>,
     /// Kernel-minted id correlating this build's metric events with its child events.
     operation_id: MetricId,
     /// Opaque, caller-supplied id recorded on this build's metric events. Not interpreted by
@@ -78,6 +121,7 @@ impl<Mode> std::fmt::Debug for SnapshotBuilder<Mode> {
             .field("max_catalog_version", &self.max_catalog_version)
             .field("incremental_replay", &self.incremental_replay)
             .field("checkpoint_handling", &self.checkpoint_handling)
+            .field("snapshot_hint", &self.snapshot_hint)
             .field("operation_id", &self.operation_id)
             .field("correlation_id", &self.correlation_id)
             .field("cancellable", &self.cancellation_token.is_some())
@@ -106,6 +150,10 @@ pub enum IncrementalReplay {
 }
 
 impl IncrementalReplay {
+    fn is_disabled(self) -> bool {
+        self == Self::Disabled || self == Self::UpToCommits(0)
+    }
+
     /// Whether the configured budget permits advancing a CRC at `crc_version` to `target_version`.
     /// Errors if `crc_version` is ahead of `target_version`, which violates a caller invariant.
     ///
@@ -143,6 +191,7 @@ impl SnapshotBuilder<FromTableRoot> {
             max_catalog_version: None,
             incremental_replay: IncrementalReplay::default(),
             checkpoint_handling: CheckpointHandling::Adopt,
+            snapshot_hint: None,
             operation_id: MetricId::new(),
             correlation_id: None,
             cancellation_token: None,
@@ -161,6 +210,7 @@ impl SnapshotBuilder<FromSnapshot> {
             max_catalog_version: None,
             incremental_replay: IncrementalReplay::default(),
             checkpoint_handling: CheckpointHandling::Adopt,
+            snapshot_hint: None,
             operation_id: MetricId::new(),
             correlation_id: None,
             cancellation_token: None,
@@ -189,8 +239,10 @@ impl<Mode> SnapshotBuilder<Mode> {
     // Chainable configuration
     // ============================================================================
 
-    /// Set the target version of the [`Snapshot`]. When omitted, the Snapshot is created at the
-    /// latest version of the table.
+    /// Sets the target version of the [`Snapshot`].
+    ///
+    /// Without a snapshot hint, omitting this targets the latest table version. With a hint,
+    /// omitting this uses the hint version and its supplied freshness status.
     pub fn at_version(mut self, version: Version) -> Self {
         self.version = Some(version);
         self
@@ -232,12 +284,13 @@ impl<Mode> SnapshotBuilder<Mode> {
         self
     }
 
-    /// Supply a [`CancellationToken`] so building the snapshot can be abandoned partway.
+    /// Supply a [`CancellationToken`] for snapshot builds that list or read the log.
     ///
-    /// Kernel polls the token as it consumes the log listing, and a cancellation-aware [`Engine`]
-    /// additionally races its listing and log reads against it. On cancellation
-    /// [`build`](Self::build) returns [`Error::Cancelled`] rather than a snapshot built from a
-    /// partial listing. With no token the build is not cancellable.
+    /// Kernel polls the token while consuming a log listing, and a cancellation-aware [`Engine`]
+    /// additionally races its listing and log reads against it. Snapshot-hint builds perform no
+    /// listing or reads, so the token has no effect on them. On cancellation [`build`](Self::build)
+    /// returns [`Error::Cancelled`] rather than a snapshot built from a partial listing. With no
+    /// token the build is not cancellable.
     ///
     /// [`CancellationToken`]: crate::CancellationToken
     /// [`Error::Cancelled`]: crate::Error::Cancelled
@@ -258,6 +311,28 @@ impl<Mode> SnapshotBuilder<Mode> {
     /// Applies to both fresh and incremental builds.
     pub fn with_incremental_crc_replay(mut self, mode: IncrementalReplay) -> Self {
         self.incremental_replay = mode;
+        self
+    }
+
+    /// Supply complete snapshot state that Kernel can validate and construct without engine I/O.
+    ///
+    /// The hint conflicts with [`with_log_tail`](Self::with_log_tail),
+    /// [`builder_from`](Snapshot::builder_from), and non-disabled incremental CRC replay. An
+    /// explicit [`at_version`](Self::at_version) must equal the hint version. When no explicit
+    /// version is set, a supplied maximum catalog version must also equal the hint version.
+    /// Kernel validates structural consistency without reading the supplied files. The caller must
+    /// ensure every path belongs to this builder's table root, the protocol and metadata came from
+    /// those files, and `max_published_version` accurately describes the published commit prefix.
+    ///
+    /// # Errors
+    ///
+    /// [`build`](Self::build) returns [`Error::SnapshotHint`] for hint-specific conflicts or
+    /// inconsistencies. General builder, path, protocol, and metadata failures retain their normal
+    /// error variants.
+    #[allow(dead_code)]
+    #[internal_api]
+    pub(crate) fn with_snapshot_hint(mut self, hint: SnapshotHint) -> Self {
+        self.snapshot_hint = Some(hint);
         self
     }
 
@@ -319,6 +394,7 @@ impl<Mode> SnapshotBuilder<Mode> {
             max_catalog_version,
             incremental_replay,
             checkpoint_handling,
+            snapshot_hint,
             operation_id,
             correlation_id,
             cancellation_token,
@@ -332,56 +408,68 @@ impl<Mode> SnapshotBuilder<Mode> {
             load_type,
         };
 
-        let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
-
-        // Pre-build validations for catalog-managed tables
-        Self::validate_catalog_managed_build_inputs(version, max_catalog_version, &log_tail)?;
-
-        // Use time-travel version if set, otherwise fall back to max_catalog_version. Passing this
-        // as the version to LogSegment::for_snapshot does NOT skip the _last_checkpoint hint --
-        // the hint is still used when its version <= effective_version.
-        let effective_version = version.or(max_catalog_version);
-
-        // A snapshot is latest when no explicit time-travel version is requested, or when the
-        // requested version is exactly the max_catalog_version.
-        let built_as_latest = version.is_none() || version == max_catalog_version;
-
-        let snapshot = if let Some(table_root) = table_root {
-            let table_url = try_parse_uri(table_root)?;
-            let log_segment = LogSegment::for_snapshot(
-                engine.storage_handler().as_ref(),
-                table_url.join("_delta_log/")?,
-                log_tail,
-                effective_version,
-                metric_context.clone(),
-                cancellation_token.as_ref(),
-            )?;
-            Snapshot::try_new_from_log_segment(
-                table_url,
-                log_segment,
-                engine,
-                metric_context,
-                incremental_replay,
-                built_as_latest,
-            )
-            .map(Into::into)?
-        } else {
-            let Some(existing_snapshot) = existing_snapshot else {
-                return Err(Error::internal_error(
-                    "SnapshotBuilder should have either table_root or existing_snapshot",
-                ));
-            };
-            Snapshot::try_new_from(
+        let snapshot = if let Some(snapshot_hint) = snapshot_hint {
+            Self::build_from_snapshot_hint(
+                table_root,
                 existing_snapshot,
+                version,
                 log_tail,
-                engine,
-                effective_version,
-                metric_context,
+                max_catalog_version,
                 incremental_replay,
-                checkpoint_handling,
-                built_as_latest,
-                cancellation_token.as_ref(),
+                snapshot_hint,
             )?
+        } else {
+            let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
+
+            // Pre-build validations for catalog-managed tables
+            Self::validate_catalog_managed_build_inputs(version, max_catalog_version, &log_tail)?;
+
+            // Use time-travel version if set, otherwise fall back to max_catalog_version. Passing
+            // this as the version to LogSegment::for_snapshot does NOT skip the _last_checkpoint
+            // hint -- the hint is still used when its version <= effective_version.
+            let effective_version = version.or(max_catalog_version);
+
+            // A snapshot is latest when no explicit time-travel version is requested, or when the
+            // requested version is exactly the max_catalog_version.
+            let built_as_latest = version.is_none() || version == max_catalog_version;
+
+            if let Some(table_root) = table_root {
+                let table_url = try_parse_uri(table_root)?;
+                let log_segment = LogSegment::for_snapshot(
+                    engine.storage_handler().as_ref(),
+                    table_url.join("_delta_log/")?,
+                    log_tail,
+                    effective_version,
+                    metric_context.clone(),
+                    cancellation_token.as_ref(),
+                )?;
+                Snapshot::try_new_from_log_segment(
+                    table_url,
+                    log_segment,
+                    engine,
+                    metric_context,
+                    incremental_replay,
+                    built_as_latest,
+                )
+                .map(Into::into)?
+            } else {
+                let Some(existing_snapshot) = existing_snapshot else {
+                    return Err(Error::internal_error(
+                        "SnapshotBuilder should have either table_root or existing_snapshot",
+                    ));
+                };
+                Snapshot::try_new_from(
+                    existing_snapshot,
+                    log_tail,
+                    engine,
+                    effective_version,
+                    metric_context,
+                    incremental_replay,
+                    checkpoint_handling,
+                    built_as_latest,
+                    cancellation_token.as_ref(),
+                )?
+            }
         };
 
         // Post-build validations for catalog-managed tables
@@ -394,6 +482,153 @@ impl<Mode> SnapshotBuilder<Mode> {
     // Helpers
     // ============================================================================
 
+    fn build_from_snapshot_hint(
+        table_root: Option<String>,
+        existing_snapshot: Option<SnapshotRef>,
+        version: Option<Version>,
+        log_tail: Vec<LogPath>,
+        max_catalog_version: Option<Version>,
+        incremental_replay: IncrementalReplay,
+        snapshot_hint: SnapshotHint,
+    ) -> DeltaResult<SnapshotRef> {
+        Self::validate_catalog_managed_build_inputs(version, max_catalog_version, &[])?;
+        require!(
+            existing_snapshot.is_none(),
+            SnapshotHintError::ExistingSnapshot.into()
+        );
+        require!(log_tail.is_empty(), SnapshotHintError::LogTail.into());
+        require!(
+            incremental_replay.is_disabled(),
+            SnapshotHintError::IncrementalReplay.into()
+        );
+        if let Some(version) = version {
+            require!(
+                version == snapshot_hint.version,
+                SnapshotHintError::VersionMismatch {
+                    requested: version,
+                    hint: snapshot_hint.version,
+                }
+                .into()
+            );
+        } else if let Some(max_catalog_version) = max_catalog_version {
+            require!(
+                max_catalog_version == snapshot_hint.version,
+                Error::MaxCatalogVersion(format!(
+                    "Max catalog version {max_catalog_version} does not match snapshot hint \
+                     version {}",
+                    snapshot_hint.version
+                ))
+            );
+        }
+
+        let table_root = table_root.ok_or_else(|| {
+            Error::internal_error("SnapshotBuilder with a snapshot hint must have a table root")
+        })?;
+        let table_url = try_parse_uri(table_root)?;
+        let log_root = table_url.join("_delta_log/")?;
+        let SnapshotHint {
+            version,
+            log_segment_files,
+            protocol,
+            metadata,
+            last_checkpoint_hint,
+            crc,
+            version_status,
+        } = snapshot_hint;
+        if version_status == SnapshotHintVersionStatus::Latest {
+            require!(
+                max_catalog_version.is_none_or(|max| max == version),
+                SnapshotHintError::LatestVersionConflict {
+                    hint: version,
+                    max_catalog_version: max_catalog_version.unwrap_or(version),
+                }
+                .into()
+            );
+        }
+        let has_staged_commits = log_segment_files
+            .ascending_commit_files
+            .iter()
+            .chain(log_segment_files.latest_commit_file.iter())
+            .any(|path| path.file_type == LogPathFileType::StagedCommit);
+
+        require!(
+            log_segment_files.ascending_compaction_files.is_empty(),
+            Error::unsupported("Snapshot hints cannot include log compaction files")
+        );
+
+        // Hinted locations are connector-resolved storage URLs. Kernel cannot determine root
+        // membership through lexical URL comparison because equivalent locations may use
+        // filesystem aliases or connector-specific URI forms. The connector must ensure that all
+        // hinted locations belong to this table. Kernel validates only path self-consistency and
+        // log-segment semantics.
+        require!(
+            log_segment_files.ascending_commit_files.is_empty()
+                || log_segment_files.latest_commit_file.is_some(),
+            SnapshotHintError::MissingLatestCommit.into()
+        );
+        let log_segment = LogSegment::try_new(
+            log_segment_files,
+            log_root,
+            Some(version),
+            last_checkpoint_hint,
+        )
+        .map_err(|source| SnapshotHintError::LogSegment {
+            source: Box::new(source),
+        })?;
+        require!(
+            log_segment
+                .listed
+                .max_published_version
+                .is_none_or(|published_version| published_version <= version),
+            SnapshotHintError::MaxPublishedVersion { hint: version }.into()
+        );
+        require!(
+            !has_staged_commits || max_catalog_version.is_some(),
+            Error::MaxCatalogVersion(
+                "Max catalog version is required when providing staged commits in the log tail. \
+                 Use with_max_catalog_version()."
+                    .to_string()
+            )
+        );
+        require!(
+            log_segment.checkpoint_version.is_some()
+                || log_segment
+                    .listed
+                    .ascending_commit_files
+                    .first()
+                    .is_some_and(|path| path.version == 0),
+            SnapshotHintError::MissingHistoryAnchor.into()
+        );
+        let table_configuration =
+            TableConfiguration::try_new(metadata, protocol, table_url, version)?;
+        if let Some(crc) = crc.as_ref() {
+            require!(
+                crc.version == version,
+                SnapshotHintError::CrcVersion {
+                    crc: crc.version,
+                    hint: version,
+                }
+                .into()
+            );
+            require!(
+                crc.protocol == *table_configuration.protocol(),
+                SnapshotHintError::CrcProtocol.into()
+            );
+            require!(
+                crc.metadata == *table_configuration.metadata(),
+                SnapshotHintError::CrcMetadata.into()
+            );
+        }
+
+        Snapshot::new_with_crc(
+            log_segment,
+            table_configuration,
+            crc,
+            version_status == SnapshotHintVersionStatus::Latest,
+        )
+        .map(Into::into)
+    }
+
     // ===== Catalog-managed Validations =====
 
     /// Pre-build validations for catalog-managed table invariants.
@@ -405,7 +640,7 @@ impl<Mode> SnapshotBuilder<Mode> {
         // Log tail must be sorted ascending and contiguous (no gaps or duplicates)
         for pair in log_tail.windows(2) {
             require!(
-                pair[0].version + 1 == pair[1].version,
+                pair[0].version.checked_add(1) == Some(pair[1].version),
                 Error::LogTailVersionsNotContiguous {
                     first_version: pair[0].version,
                     second_version: pair[1].version,
@@ -510,11 +745,13 @@ impl<Mode> SnapshotBuilder<Mode> {
 
     /// A build from a table root is a fresh, full log listing; a build from an existing snapshot
     /// reuses that snapshot's log root and lists only the commits above it (`table_root` is None).
-    fn load_type(&self) -> LogSegmentLoadType {
-        if self.table_root.is_some() {
-            LogSegmentLoadType::Full
+    fn load_type(&self) -> SnapshotLoadType {
+        if self.snapshot_hint.is_some() {
+            SnapshotLoadType::SnapshotHint
+        } else if self.table_root.is_some() {
+            SnapshotLoadType::Full
         } else {
-            LogSegmentLoadType::Incremental
+            SnapshotLoadType::Incremental
         }
     }
 
@@ -532,22 +769,117 @@ impl<Mode> SnapshotBuilder<Mode> {
     }
 }
 
+/// An error validating connector-provided state for snapshot construction.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SnapshotHintError {
+    /// A hint was supplied while updating an existing snapshot.
+    #[error("Invalid snapshot hint: A snapshot hint cannot be used with Snapshot::builder_from")]
+    ExistingSnapshot,
+    /// A hint was combined with a log tail.
+    #[error("Invalid snapshot hint: A snapshot hint cannot be combined with a log tail")]
+    LogTail,
+    /// A hint was combined with incremental CRC replay.
+    #[error(
+        "Invalid snapshot hint: A snapshot hint cannot be combined with incremental CRC replay"
+    )]
+    IncrementalReplay,
+    /// The builder requested a version different from the hint's version.
+    #[error(
+        "Invalid snapshot hint: Requested version {requested} does not match snapshot hint version {hint}"
+    )]
+    VersionMismatch {
+        /// The version requested from the snapshot builder.
+        requested: Version,
+        /// The version described by the snapshot hint.
+        hint: Version,
+    },
+    /// A hint marked latest conflicts with a later catalog-ratified version.
+    #[error(
+        "Invalid snapshot hint: version {hint} is marked latest but max catalog version is {max_catalog_version}"
+    )]
+    LatestVersionConflict {
+        /// The version described by the snapshot hint.
+        hint: Version,
+        /// The latest version ratified by the catalog.
+        max_catalog_version: Version,
+    },
+    /// Commit files were supplied without identifying the latest commit.
+    #[error("Invalid snapshot hint: latest_commit_file is required when commits are supplied")]
+    MissingLatestCommit,
+    /// The supplied log files cannot form a valid log segment.
+    #[error("Invalid snapshot hint: supplied log files do not form a valid log segment")]
+    LogSegment {
+        /// The log-segment construction error.
+        #[source]
+        source: Box<Error>,
+    },
+    /// The hint includes a published version after its snapshot version.
+    #[error("Invalid snapshot hint: max_published_version exceeds snapshot hint version {hint}")]
+    MaxPublishedVersion {
+        /// The version described by the snapshot hint.
+        hint: Version,
+    },
+    /// The hint has neither a complete checkpoint nor commit version zero.
+    #[error("Invalid snapshot hint: snapshot history does not start at version 0")]
+    MissingHistoryAnchor,
+    /// The supplied CRC describes a different table version.
+    #[error(
+        "Invalid snapshot hint: CRC version {crc} does not match snapshot hint version {hint}"
+    )]
+    CrcVersion {
+        /// The version described by the CRC.
+        crc: Version,
+        /// The version described by the snapshot hint.
+        hint: Version,
+    },
+    /// The supplied CRC protocol differs from the hint protocol.
+    #[error("Invalid snapshot hint: CRC protocol does not match snapshot hint protocol")]
+    CrcProtocol,
+    /// The supplied CRC metadata differs from the hint metadata.
+    #[error("Invalid snapshot hint: CRC metadata does not match snapshot hint metadata")]
+    CrcMetadata,
+    /// A connector reported invalid snapshot-hint state, optionally with an underlying error.
+    #[error("Invalid snapshot hint: {message}")]
+    Connector {
+        /// A description of the invalid connector state.
+        message: String,
+        /// The underlying validation error, if available.
+        #[source]
+        source: Option<Box<Error>>,
+    },
+}
+
+impl From<SnapshotHintError> for Error {
+    fn from(error: SnapshotHintError) -> Self {
+        Box::new(error).into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
     use std::sync::Arc;
     use std::time::Duration;
 
     use itertools::Itertools;
     use serde_json::json;
-    use test_utils::{actions_to_string, add_commit, TestAction};
+    use test_utils::{
+        actions_to_string, actions_to_string_catalog_managed, add_commit,
+        assert_result_error_with_message, TestAction,
+    };
 
     use super::*;
     use crate::engine::sync::SyncEngine;
-    use crate::metrics::MetricEvent;
+    use crate::metrics::{LogSegmentLoadType, MetricEvent};
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::{DynObjectStore, ObjectStoreExt as _};
-    use crate::unit_test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+    use crate::schema::schema_ref;
+    use crate::unit_test_utils::{
+        create_log_path, install_thread_local_metrics_reporter, CapturingReporter,
+        TestCancellationToken,
+    };
     use crate::utils::FoldWithOption as _;
 
     fn setup_test() -> (Arc<SyncEngine>, Arc<DynObjectStore>, String) {
@@ -572,9 +904,552 @@ mod tests {
             table_root,
             store.as_ref(),
             1,
+            format!(
+                "{}\n{}",
+                json!({"commitInfo": {"operation": "WRITE"}}),
+                actions_to_string(vec![TestAction::Add("part-00000-test.parquet".into())])
+            ),
+        )
+        .await?;
+        Ok(())
+    }
+
+    fn hint_from_snapshot(
+        snapshot: &SnapshotRef,
+        version_status: SnapshotHintVersionStatus,
+    ) -> SnapshotHint {
+        SnapshotHint {
+            version: snapshot.version(),
+            log_segment_files: snapshot.log_segment().listed.clone(),
+            protocol: snapshot.table_configuration().protocol().clone(),
+            metadata: snapshot.table_configuration().metadata().clone(),
+            last_checkpoint_hint: snapshot.log_segment().last_checkpoint_metadata.clone(),
+            crc: snapshot.crc_at_version().cloned(),
+            version_status,
+        }
+    }
+
+    async fn snapshot_and_hint(
+        version_status: SnapshotHintVersionStatus,
+    ) -> Result<(Arc<SyncEngine>, String, SnapshotRef, SnapshotHint), Box<dyn std::error::Error>>
+    {
+        let (engine, store, table_root) = setup_test();
+        create_table(&store, &table_root).await?;
+        let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
+        let _ = snapshot.write_checksum(engine.as_ref())?;
+        let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
+        let hint = hint_from_snapshot(&snapshot, version_status);
+        Ok((engine, table_root, snapshot, hint))
+    }
+
+    fn assert_hint_error(
+        builder: SnapshotBuilder,
+        hint: SnapshotHint,
+        engine: &dyn Engine,
+        expected: &str,
+    ) {
+        let error = builder.with_snapshot_hint(hint).build(engine).unwrap_err();
+        assert!(matches!(&error, Error::SnapshotHint(_)));
+        assert!(
+            error.to_string().contains(expected),
+            "expected error to contain {expected:?}, got {error}"
+        );
+    }
+
+    fn assert_log_segment_hint_error(result: DeltaResult<SnapshotRef>, expected_source: &str) {
+        let error = result.unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Invalid snapshot hint: supplied log files do not form a valid log segment"
+        );
+        let Error::SnapshotHint(source) = error else {
+            panic!("expected SnapshotHint")
+        };
+        let source = source
+            .source()
+            .expect("LogSegment error must preserve its source");
+        assert!(source.to_string().contains(expected_source));
+    }
+
+    #[rstest::rstest]
+    #[case::latest(SnapshotHintVersionStatus::Latest, true)]
+    #[case::unverified(SnapshotHintVersionStatus::Unverified, false)]
+    #[test_log::test(tokio::test)]
+    async fn complete_snapshot_hint_matches_storage_snapshot_without_child_loads(
+        #[case] version_status: SnapshotHintVersionStatus,
+        #[case] expected_built_as_latest: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, storage_snapshot, hint) =
+            snapshot_and_hint(version_status).await?;
+        assert!(storage_snapshot.crc_at_version().is_some());
+
+        let token: CancellationTokenRef = Arc::new(TestCancellationToken::cancelled());
+        let (reporter, _guard) = measuring_reporter();
+        let hinted_snapshot = SnapshotBuilder::new_for(&table_root)
+            .with_snapshot_hint(hint)
+            .with_correlation_id("hint-request")
+            .with_cancellation_token(token)
+            .build(engine.as_ref())?;
+
+        assert_eq!(hinted_snapshot.version(), storage_snapshot.version());
+        assert_eq!(hinted_snapshot.schema(), storage_snapshot.schema());
+        assert_eq!(
+            hinted_snapshot.table_configuration().protocol(),
+            storage_snapshot.table_configuration().protocol()
+        );
+        assert_eq!(
+            hinted_snapshot.table_configuration().metadata(),
+            storage_snapshot.table_configuration().metadata()
+        );
+        assert_eq!(
+            hinted_snapshot.log_segment(),
+            storage_snapshot.log_segment()
+        );
+        assert_eq!(
+            hinted_snapshot.crc_at_version(),
+            storage_snapshot.crc_at_version()
+        );
+        assert_eq!(hinted_snapshot.table_root(), storage_snapshot.table_root());
+        assert_eq!(
+            hinted_snapshot.is_built_as_latest(),
+            expected_built_as_latest
+        );
+
+        let events = reporter.events();
+        assert_eq!(
+            events.len(),
+            1,
+            "hint build must emit only its completion event"
+        );
+        let MetricEvent::SnapshotBuildSuccess(success) = &events[0] else {
+            panic!("expected SnapshotBuildSuccess");
+        };
+        assert_eq!(success.load_type, SnapshotLoadType::SnapshotHint);
+        assert_eq!(success.correlation_id.as_deref(), Some("hint-request"));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn complete_snapshot_hint_without_crc_succeeds() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let (engine, table_root, _snapshot, mut hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        hint.crc = None;
+
+        let hinted = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())?;
+        assert!(hinted.crc_at_version().is_none());
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn complete_snapshot_hint_preserves_checkpoint_state(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, store, table_root) = setup_test();
+        create_table(&store, &table_root).await?;
+        let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
+        let _ = snapshot.checkpoint(engine.as_ref(), None)?;
+        let storage_snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
+        assert!(!storage_snapshot
+            .log_segment()
+            .listed
+            .checkpoint_parts
+            .is_empty());
+        assert!(storage_snapshot
+            .log_segment()
+            .last_checkpoint_metadata
+            .is_some());
+
+        let mut hint = hint_from_snapshot(&storage_snapshot, SnapshotHintVersionStatus::Unverified);
+        hint.log_segment_files.ascending_commit_files.clear();
+        hint.log_segment_files.latest_commit_file = None;
+        let hinted_snapshot = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())?;
+        assert_eq!(
+            hinted_snapshot.log_segment().checkpoint_version,
+            storage_snapshot.log_segment().checkpoint_version
+        );
+        assert_eq!(
+            hinted_snapshot.log_segment().listed.checkpoint_parts,
+            storage_snapshot.log_segment().listed.checkpoint_parts
+        );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_rejects_staged_commit_without_catalog_version(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, _snapshot, mut hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        let staged = create_log_path(concat!(
+            "memory:///_delta_log/_staged_commits/00000000000000000000.",
+            "11111111-1111-1111-1111-111111111111.json"
+        ));
+        hint.version = 0;
+        hint.crc = None;
+        hint.last_checkpoint_hint = None;
+        hint.log_segment_files = LogSegmentFiles {
+            ascending_commit_files: vec![staged.clone()],
+            latest_commit_file: Some(staged),
+            ..Default::default()
+        };
+
+        let err = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())
+            .unwrap_err();
+        assert!(matches!(err, Error::MaxCatalogVersion(_)));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_rejects_published_version_after_hint_version(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, _snapshot, mut hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        hint.log_segment_files.max_published_version = Some(Version::MAX);
+
+        let err = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())
+            .unwrap_err();
+        assert!(matches!(err, Error::SnapshotHint(_)));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_rejects_malformed_log_segment_and_incompatible_table_state(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, _snapshot, hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+
+        let mut gapped = hint.clone();
+        gapped.log_segment_files.ascending_commit_files[1] =
+            create_log_path("memory:///_delta_log/00000000000000000003.json");
+        assert_log_segment_hint_error(
+            SnapshotBuilder::new_for(&table_root)
+                .with_snapshot_hint(gapped)
+                .build(engine.as_ref()),
+            "Expected contiguous commit files",
+        );
+
+        let mut inconsistent_path = hint.clone();
+        inconsistent_path.log_segment_files.ascending_commit_files[0].version = 1;
+        assert_log_segment_hint_error(
+            SnapshotBuilder::new_for(&table_root)
+                .with_snapshot_hint(inconsistent_path)
+                .build(engine.as_ref()),
+            "Parsed log path fields do not match its location",
+        );
+
+        let mut compacted = hint.clone();
+        compacted
+            .log_segment_files
+            .ascending_compaction_files
+            .push(create_log_path(
+                "memory:///_delta_log/00000000000000000000.00000000000000000001.compacted.json",
+            ));
+        let err = SnapshotBuilder::new_for(&table_root)
+            .with_snapshot_hint(compacted)
+            .build(engine.as_ref())
+            .unwrap_err();
+        assert!(matches!(err, Error::Unsupported(_)));
+
+        let mut incompatible = hint;
+        incompatible.metadata = incompatible
+            .metadata
+            .with_schema(schema_ref! { nullable "ts": TIMESTAMP_NTZ })?;
+        assert_result_error_with_message(
+            SnapshotBuilder::new_for(&table_root)
+                .with_snapshot_hint(incompatible)
+                .build(engine.as_ref()),
+            "does not have the required 'timestampNtz' feature",
+        );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_rejects_checkpoint_free_history_not_starting_at_version_zero(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, _snapshot, mut hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        hint.crc = None;
+        hint.log_segment_files.ascending_commit_files.remove(0);
+
+        let err = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())
+            .unwrap_err();
+        assert!(matches!(&err, Error::SnapshotHint(_)));
+        assert!(err
+            .to_string()
+            .contains("snapshot history does not start at version 0"));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_requires_latest_commit_file_when_commits_are_supplied(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, _snapshot, mut hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        hint.log_segment_files.latest_commit_file = None;
+
+        let err = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())
+            .unwrap_err();
+        assert!(matches!(&err, Error::SnapshotHint(_)));
+        assert!(err
+            .to_string()
+            .contains("latest_commit_file is required when commits are supplied"));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_rejects_latest_commit_with_wrong_kind_or_identity(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, _snapshot, hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        let invalid_latest_commits = [
+            format!(
+                "memory:///_delta_log/{:020}.checkpoint.parquet",
+                hint.version
+            ),
+            format!(
+                "memory:///_delta_log/_staged_commits/{:020}.11111111-1111-1111-1111-111111111111.json",
+                hint.version
+            ),
+        ];
+
+        for latest in invalid_latest_commits {
+            let mut malformed = hint.clone();
+            malformed.log_segment_files.latest_commit_file = Some(create_log_path(&latest));
+            let err = SnapshotBuilder::new_for(&table_root)
+                .with_snapshot_hint(malformed)
+                .build(engine.as_ref())
+                .unwrap_err();
+            assert!(matches!(err, Error::SnapshotHint(_)));
+        }
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn snapshot_hint_internal_log_invariant_preserves_source(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, store, table_root) = setup_test();
+        create_table(&store, &table_root).await?;
+        let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
+        let _ = snapshot.checkpoint(engine.as_ref(), None)?;
+        let snapshot = SnapshotBuilder::new_for(&table_root).build(engine.as_ref())?;
+        let mut hint = hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Unverified);
+        hint.log_segment_files.latest_commit_file = Some(create_log_path(
+            "memory:///_delta_log/00000000000000000000.json",
+        ));
+
+        let err = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())
+            .unwrap_err();
+        let Error::SnapshotHint(source) = err else {
+            panic!("expected SnapshotHint")
+        };
+        let source = source
+            .source()
+            .expect("LogSegment error must preserve its source");
+        assert!(source
+            .to_string()
+            .contains("latest_commit_file version 0 does not match end_version 1"));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_rejects_mismatched_crc_state() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let (engine, table_root, _snapshot, hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        let matching_crc = hint.crc.as_ref().unwrap().as_ref().clone();
+
+        let mut wrong_version = hint.clone();
+        wrong_version.crc = Some(Arc::new(Crc {
+            version: hint.version - 1,
+            ..matching_crc.clone()
+        }));
+        assert_hint_error(
+            SnapshotBuilder::new_for(&table_root),
+            wrong_version,
+            engine.as_ref(),
+            "does not match snapshot hint version",
+        );
+
+        let mut wrong_protocol = hint.clone();
+        wrong_protocol.crc = Some(Arc::new(Crc {
+            protocol: Protocol::try_new_legacy(1, 1)?,
+            ..matching_crc.clone()
+        }));
+        assert_hint_error(
+            SnapshotBuilder::new_for(&table_root),
+            wrong_protocol,
+            engine.as_ref(),
+            "CRC protocol does not match",
+        );
+
+        let mut wrong_metadata = hint;
+        wrong_metadata.crc = Some(Arc::new(Crc {
+            metadata: Metadata::default(),
+            ..matching_crc
+        }));
+        assert_hint_error(
+            SnapshotBuilder::new_for(&table_root),
+            wrong_metadata,
+            engine.as_ref(),
+            "CRC metadata does not match",
+        );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_rejects_conflicting_builder_options_and_reports_failure(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, snapshot, hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        let log_path = LogPath::try_new(
+            snapshot
+                .log_segment()
+                .listed
+                .latest_commit_file
+                .as_ref()
+                .unwrap()
+                .location
+                .clone(),
+        )?;
+
+        assert_hint_error(
+            SnapshotBuilder::new_for(&table_root).at_version(hint.version - 1),
+            hint.clone(),
+            engine.as_ref(),
+            "does not match snapshot hint version",
+        );
+        assert_hint_error(
+            SnapshotBuilder::new_for(&table_root).with_log_tail(vec![log_path]),
+            hint.clone(),
+            engine.as_ref(),
+            "cannot be combined with a log tail",
+        );
+        assert_hint_error(
+            SnapshotBuilder::new_from(snapshot),
+            hint.clone(),
+            engine.as_ref(),
+            "cannot be used with Snapshot::builder_from",
+        );
+        let zero_budget = SnapshotBuilder::new_for(&table_root)
+            .with_incremental_crc_replay(IncrementalReplay::UpToCommits(0))
+            .with_snapshot_hint(hint.clone())
+            .build(engine.as_ref())?;
+        assert_eq!(zero_budget.version(), hint.version);
+        assert_hint_error(
+            SnapshotBuilder::new_for(&table_root)
+                .with_incremental_crc_replay(IncrementalReplay::UpToCommits(1)),
+            hint.clone(),
+            engine.as_ref(),
+            "cannot be combined with incremental CRC replay",
+        );
+        assert_result_error_with_message(
+            SnapshotBuilder::new_for(&table_root)
+                .with_max_catalog_version(hint.version)
+                .with_snapshot_hint(hint.clone())
+                .build(engine.as_ref()),
+            "must not be set for a non-catalog-managed table",
+        );
+
+        let (reporter, _guard) = measuring_reporter();
+        assert!(SnapshotBuilder::new_for(table_root)
+            .with_max_catalog_version(hint.version + 1)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())
+            .is_err());
+        let events = reporter.events();
+        assert_eq!(events.len(), 1);
+        let MetricEvent::SnapshotBuildFailure(failure) = &events[0] else {
+            panic!("expected SnapshotBuildFailure");
+        };
+        assert_eq!(failure.load_type, SnapshotLoadType::SnapshotHint);
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_version_must_match_log_segment_end_version(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, _snapshot, mut hint) =
+            snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
+        hint.version -= 1;
+        hint.crc = None;
+
+        assert_log_segment_hint_error(
+            SnapshotBuilder::new_for(table_root)
+                .with_snapshot_hint(hint)
+                .build(engine.as_ref()),
+            "LogSegment end version",
+        );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn time_travel_snapshot_hint_accepts_later_max_catalog_version(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, store, table_root) = setup_test();
+        add_commit(
+            &table_root,
+            store.as_ref(),
+            0,
+            actions_to_string_catalog_managed(vec![TestAction::Metadata]),
+        )
+        .await?;
+        add_commit(
+            &table_root,
+            store.as_ref(),
+            1,
             actions_to_string(vec![TestAction::Add("part-00000-test.parquet".into())]),
         )
         .await?;
+        let snapshot = SnapshotBuilder::new_for(&table_root)
+            .with_max_catalog_version(1)
+            .build(engine.as_ref())?;
+        let hint = hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Unverified);
+
+        assert_result_error_with_message(
+            SnapshotBuilder::new_for(&table_root)
+                .with_snapshot_hint(hint.clone())
+                .build(engine.as_ref()),
+            "Max catalog version is required",
+        );
+        let latest = SnapshotBuilder::new_for(&table_root)
+            .with_max_catalog_version(1)
+            .with_snapshot_hint(hint.clone())
+            .build(engine.as_ref())?;
+        assert_eq!(latest.version(), 1);
+        assert!(!latest.is_built_as_latest());
+
+        let hinted = SnapshotBuilder::new_for(table_root)
+            .at_version(1)
+            .with_max_catalog_version(2)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())?;
+        assert_eq!(hinted.version(), 1);
+        assert!(!hinted.is_built_as_latest());
+
+        let mut contradictory_hint =
+            hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Latest);
+        contradictory_hint.crc = None;
+        assert_hint_error(
+            SnapshotBuilder::new_for("memory:///")
+                .at_version(1)
+                .with_max_catalog_version(2),
+            contradictory_hint,
+            engine.as_ref(),
+            "marked latest but max catalog version is 2",
+        );
         Ok(())
     }
 

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -9,6 +9,7 @@ use tracing::{info, instrument};
 use crate::actions::{Metadata, Protocol};
 use crate::cancellation::CancellationTokenRef;
 use crate::crc::Crc;
+use crate::error::SnapshotHintError;
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
@@ -50,7 +51,10 @@ pub(crate) enum SnapshotHintVersionStatus {
 #[derive(Debug, Clone)]
 #[internal_api]
 pub(crate) struct SnapshotHint {
-    /// The table version described by every component of this hint.
+    /// The target table version to construct.
+    ///
+    /// Historical commits and checkpoints in [`Self::log_segment_files`] may describe earlier
+    /// versions.
     pub version: Version,
     /// The complete set of log files required by the snapshot.
     pub log_segment_files: LogSegmentFiles,
@@ -485,13 +489,12 @@ impl<Mode> SnapshotBuilder<Mode> {
     fn build_from_snapshot_hint(
         table_root: Option<String>,
         existing_snapshot: Option<SnapshotRef>,
-        version: Option<Version>,
+        requested_version: Option<Version>,
         log_tail: Vec<LogPath>,
         max_catalog_version: Option<Version>,
         incremental_replay: IncrementalReplay,
         snapshot_hint: SnapshotHint,
     ) -> DeltaResult<SnapshotRef> {
-        Self::validate_catalog_managed_build_inputs(version, max_catalog_version, &[])?;
         require!(
             existing_snapshot.is_none(),
             SnapshotHintError::ExistingSnapshot.into()
@@ -501,7 +504,7 @@ impl<Mode> SnapshotBuilder<Mode> {
             incremental_replay.is_disabled(),
             SnapshotHintError::IncrementalReplay.into()
         );
-        if let Some(version) = version {
+        if let Some(version) = requested_version {
             require!(
                 version == snapshot_hint.version,
                 SnapshotHintError::VersionMismatch {
@@ -550,10 +553,19 @@ impl<Mode> SnapshotBuilder<Mode> {
             .iter()
             .chain(log_segment_files.latest_commit_file.iter())
             .any(|path| path.file_type == LogPathFileType::StagedCommit);
+        Self::validate_catalog_managed_versions(
+            requested_version,
+            max_catalog_version,
+            has_staged_commits,
+            log_segment_files
+                .latest_commit_file
+                .as_ref()
+                .map(|path| path.version),
+        )?;
 
         require!(
             log_segment_files.ascending_compaction_files.is_empty(),
-            Error::unsupported("Snapshot hints cannot include log compaction files")
+            SnapshotHintError::LogCompaction.into()
         );
 
         // Hinted locations are connector-resolved storage URLs. Kernel cannot determine root
@@ -575,20 +587,14 @@ impl<Mode> SnapshotBuilder<Mode> {
         .map_err(|source| SnapshotHintError::LogSegment {
             source: Box::new(source),
         })?;
+        // Regular construction derives this field from storage listing. A hint supplies it, so
+        // only the hint path needs to validate it explicitly.
         require!(
             log_segment
                 .listed
                 .max_published_version
                 .is_none_or(|published_version| published_version <= version),
             SnapshotHintError::MaxPublishedVersion { hint: version }.into()
-        );
-        require!(
-            !has_staged_commits || max_catalog_version.is_some(),
-            Error::MaxCatalogVersion(
-                "Max catalog version is required when providing staged commits in the log tail. \
-                 Use with_max_catalog_version()."
-                    .to_string()
-            )
         );
         require!(
             log_segment.checkpoint_version.is_some()
@@ -654,50 +660,82 @@ impl<Mode> SnapshotBuilder<Mode> {
             .iter()
             .any(|p| p.file_type == LogPathFileType::StagedCommit);
 
-        // Staged commits require max_catalog_version
-        require!(
-            !has_catalog_commits || max_catalog_version.is_some(),
-            Error::MaxCatalogVersion(
-                "Max catalog version is required when providing staged commits in the log tail. \
-                 Use with_max_catalog_version()."
-                    .to_string()
-            )
-        );
+        Self::validate_catalog_managed_versions(
+            version,
+            max_catalog_version,
+            has_catalog_commits,
+            log_tail.last().map(|path| path.version),
+        )
+    }
 
-        // Time-travel version must not exceed max_catalog_version
-        if let (Some(ver), Some(max_cv)) = (version, max_catalog_version) {
-            require!(
-                ver <= max_cv,
-                Error::MaxCatalogVersion(format!(
-                    "Requested version {ver} exceeds max catalog version {max_cv}"
-                ))
-            );
-        }
+    fn validate_catalog_managed_versions(
+        version: Option<Version>,
+        max_catalog_version: Option<Version>,
+        has_staged_commits: bool,
+        latest_commit_version: Option<Version>,
+    ) -> DeltaResult<()> {
+        Self::validate_catalog_version_bounds(version, max_catalog_version)?;
+        Self::require_max_catalog_version_for_staged_commits(
+            has_staged_commits,
+            max_catalog_version,
+        )?;
 
         // Log tail end version validation when max_catalog_version is set
-        if let (Some(max_cv), Some(last)) = (max_catalog_version, log_tail.last()) {
+        if let (Some(max_cv), Some(latest_commit_version)) =
+            (max_catalog_version, latest_commit_version)
+        {
             if let Some(ver) = version {
                 // With time-travel: last log_tail entry must be >= requested version
                 require!(
-                    last.version >= ver,
+                    latest_commit_version >= ver,
                     Error::MaxCatalogVersion(format!(
                         "Log tail version {} is less than requested version {ver} for max catalog \
                          version {max_cv}",
-                        last.version
+                        latest_commit_version
                     ))
                 );
             } else {
                 // Without time-travel: last log_tail entry must == max_catalog_version
                 require!(
-                    last.version == max_cv,
+                    latest_commit_version == max_cv,
                     Error::MaxCatalogVersion(format!(
                         "Log tail version {} does not match max catalog version {max_cv}",
-                        last.version
+                        latest_commit_version
                     ))
                 );
             }
         }
 
+        Ok(())
+    }
+
+    fn validate_catalog_version_bounds(
+        version: Option<Version>,
+        max_catalog_version: Option<Version>,
+    ) -> DeltaResult<()> {
+        if let (Some(version), Some(max_catalog_version)) = (version, max_catalog_version) {
+            require!(
+                version <= max_catalog_version,
+                Error::MaxCatalogVersion(format!(
+                    "Requested version {version} exceeds max catalog version {max_catalog_version}"
+                ))
+            );
+        }
+        Ok(())
+    }
+
+    fn require_max_catalog_version_for_staged_commits(
+        has_staged_commits: bool,
+        max_catalog_version: Option<Version>,
+    ) -> DeltaResult<()> {
+        require!(
+            !has_staged_commits || max_catalog_version.is_some(),
+            Error::MaxCatalogVersion(
+                "Max catalog version is required when providing staged commits. \
+                 Use with_max_catalog_version()."
+                    .to_string()
+            )
+        );
         Ok(())
     }
 
@@ -766,93 +804,6 @@ impl<Mode> SnapshotBuilder<Mode> {
         self.version
             .map(|v| v.to_string())
             .unwrap_or_else(|| "LATEST".into())
-    }
-}
-
-/// An error validating connector-provided state for snapshot construction.
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum SnapshotHintError {
-    /// A hint was supplied while updating an existing snapshot.
-    #[error("Invalid snapshot hint: A snapshot hint cannot be used with Snapshot::builder_from")]
-    ExistingSnapshot,
-    /// A hint was combined with a log tail.
-    #[error("Invalid snapshot hint: A snapshot hint cannot be combined with a log tail")]
-    LogTail,
-    /// A hint was combined with incremental CRC replay.
-    #[error(
-        "Invalid snapshot hint: A snapshot hint cannot be combined with incremental CRC replay"
-    )]
-    IncrementalReplay,
-    /// The builder requested a version different from the hint's version.
-    #[error(
-        "Invalid snapshot hint: Requested version {requested} does not match snapshot hint version {hint}"
-    )]
-    VersionMismatch {
-        /// The version requested from the snapshot builder.
-        requested: Version,
-        /// The version described by the snapshot hint.
-        hint: Version,
-    },
-    /// A hint marked latest conflicts with a later catalog-ratified version.
-    #[error(
-        "Invalid snapshot hint: version {hint} is marked latest but max catalog version is {max_catalog_version}"
-    )]
-    LatestVersionConflict {
-        /// The version described by the snapshot hint.
-        hint: Version,
-        /// The latest version ratified by the catalog.
-        max_catalog_version: Version,
-    },
-    /// Commit files were supplied without identifying the latest commit.
-    #[error("Invalid snapshot hint: latest_commit_file is required when commits are supplied")]
-    MissingLatestCommit,
-    /// The supplied log files cannot form a valid log segment.
-    #[error("Invalid snapshot hint: supplied log files do not form a valid log segment")]
-    LogSegment {
-        /// The log-segment construction error.
-        #[source]
-        source: Box<Error>,
-    },
-    /// The hint includes a published version after its snapshot version.
-    #[error("Invalid snapshot hint: max_published_version exceeds snapshot hint version {hint}")]
-    MaxPublishedVersion {
-        /// The version described by the snapshot hint.
-        hint: Version,
-    },
-    /// The hint has neither a complete checkpoint nor commit version zero.
-    #[error("Invalid snapshot hint: snapshot history does not start at version 0")]
-    MissingHistoryAnchor,
-    /// The supplied CRC describes a different table version.
-    #[error(
-        "Invalid snapshot hint: CRC version {crc} does not match snapshot hint version {hint}"
-    )]
-    CrcVersion {
-        /// The version described by the CRC.
-        crc: Version,
-        /// The version described by the snapshot hint.
-        hint: Version,
-    },
-    /// The supplied CRC protocol differs from the hint protocol.
-    #[error("Invalid snapshot hint: CRC protocol does not match snapshot hint protocol")]
-    CrcProtocol,
-    /// The supplied CRC metadata differs from the hint metadata.
-    #[error("Invalid snapshot hint: CRC metadata does not match snapshot hint metadata")]
-    CrcMetadata,
-    /// A connector reported invalid snapshot-hint state, optionally with an underlying error.
-    #[error("Invalid snapshot hint: {message}")]
-    Connector {
-        /// A description of the invalid connector state.
-        message: String,
-        /// The underlying validation error, if available.
-        #[source]
-        source: Option<Box<Error>>,
-    },
-}
-
-impl From<SnapshotHintError> for Error {
-    fn from(error: SnapshotHintError) -> Self {
-        Box::new(error).into()
     }
 }
 
@@ -1078,8 +1029,12 @@ mod tests {
         Ok(())
     }
 
+    #[rstest::rstest]
+    #[case::replay_and_latest(true)]
+    #[case::latest_only(false)]
     #[test_log::test(tokio::test)]
     async fn snapshot_hint_rejects_staged_commit_without_catalog_version(
+        #[case] include_replay_commit: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root, _snapshot, mut hint) =
             snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
@@ -1090,17 +1045,29 @@ mod tests {
         hint.version = 0;
         hint.crc = None;
         hint.last_checkpoint_hint = None;
+        let (ascending_commit_files, checkpoint_parts) = if include_replay_commit {
+            (vec![staged.clone()], vec![])
+        } else {
+            (
+                vec![],
+                vec![create_log_path(
+                    "memory:///_delta_log/00000000000000000000.checkpoint.parquet",
+                )],
+            )
+        };
         hint.log_segment_files = LogSegmentFiles {
-            ascending_commit_files: vec![staged.clone()],
+            ascending_commit_files,
+            checkpoint_parts,
             latest_commit_file: Some(staged),
             ..Default::default()
         };
 
-        let err = SnapshotBuilder::new_for(table_root)
-            .with_snapshot_hint(hint)
-            .build(engine.as_ref())
-            .unwrap_err();
-        assert!(matches!(err, Error::MaxCatalogVersion(_)));
+        assert_result_error_with_message(
+            SnapshotBuilder::new_for(table_root)
+                .with_snapshot_hint(hint)
+                .build(engine.as_ref()),
+            "Max catalog version is required when providing staged commits",
+        );
         Ok(())
     }
 
@@ -1151,11 +1118,12 @@ mod tests {
             .push(create_log_path(
                 "memory:///_delta_log/00000000000000000000.00000000000000000001.compacted.json",
             ));
-        let err = SnapshotBuilder::new_for(&table_root)
-            .with_snapshot_hint(compacted)
-            .build(engine.as_ref())
-            .unwrap_err();
-        assert!(matches!(err, Error::Unsupported(_)));
+        assert_hint_error(
+            SnapshotBuilder::new_for(&table_root),
+            compacted,
+            engine.as_ref(),
+            "log compaction files are not supported",
+        );
 
         let mut incompatible = hint;
         incompatible.metadata = incompatible
@@ -1178,14 +1146,12 @@ mod tests {
         hint.crc = None;
         hint.log_segment_files.ascending_commit_files.remove(0);
 
-        let err = SnapshotBuilder::new_for(table_root)
-            .with_snapshot_hint(hint)
-            .build(engine.as_ref())
-            .unwrap_err();
-        assert!(matches!(&err, Error::SnapshotHint(_)));
-        assert!(err
-            .to_string()
-            .contains("snapshot history does not start at version 0"));
+        assert_hint_error(
+            SnapshotBuilder::new_for(table_root),
+            hint,
+            engine.as_ref(),
+            "snapshot history does not start at version 0",
+        );
         Ok(())
     }
 
@@ -1196,14 +1162,12 @@ mod tests {
             snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
         hint.log_segment_files.latest_commit_file = None;
 
-        let err = SnapshotBuilder::new_for(table_root)
-            .with_snapshot_hint(hint)
-            .build(engine.as_ref())
-            .unwrap_err();
-        assert!(matches!(&err, Error::SnapshotHint(_)));
-        assert!(err
-            .to_string()
-            .contains("latest_commit_file is required when commits are supplied"));
+        assert_hint_error(
+            SnapshotBuilder::new_for(table_root),
+            hint,
+            engine.as_ref(),
+            "latest_commit_file is required when commits are supplied",
+        );
         Ok(())
     }
 
@@ -1819,6 +1783,28 @@ mod tests {
             .await
             .expect("Failed to write initial catalog-managed commit");
             (engine, store, table_root)
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn snapshot_hint_accepts_staged_commit_with_catalog_version(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_catalog_managed_test().await;
+            let staged =
+                add_staged_commit(&table_root, store.as_ref(), 1, "{}".to_string()).await?;
+            let snapshot = SnapshotBuilder::new_for(&table_root)
+                .with_log_tail(vec![create_log_path(&table_root, staged)])
+                .with_max_catalog_version(1)
+                .build(engine.as_ref())?;
+            let hint = hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Unverified);
+
+            let hinted = SnapshotBuilder::new_for(&table_root)
+                .with_max_catalog_version(1)
+                .with_snapshot_hint(hint)
+                .build(engine.as_ref())?;
+
+            assert_eq!(hinted.version(), 1);
+            assert!(hinted.table_configuration().is_catalog_managed());
+            Ok(())
         }
 
         #[test_log::test(tokio::test)]

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -207,6 +207,28 @@ impl SnapshotBuilder<FromTableRoot> {
             mode: PhantomData,
         }
     }
+
+    /// Supply complete snapshot state that Kernel can validate and construct without engine I/O.
+    ///
+    /// The hint conflicts with [`with_log_tail`](Self::with_log_tail) and non-disabled incremental
+    /// CRC replay. An explicit [`at_version`](Self::at_version) must equal the hint version. When
+    /// no explicit version is set, a supplied maximum catalog version must also equal the hint
+    /// version. Kernel validates structural consistency without reading the supplied files. The
+    /// caller must ensure every path belongs to this builder's table root, the protocol and
+    /// metadata came from those files, and `max_published_version` accurately describes the
+    /// published commit prefix.
+    ///
+    /// # Errors
+    ///
+    /// [`build`](Self::build) returns [`Error::SnapshotHint`] for hint conflicts and hinted
+    /// log-segment validation failures. Catalog-version, table-root URI, protocol, and metadata
+    /// failures retain their normal error variants.
+    #[allow(dead_code)]
+    #[internal_api]
+    pub(crate) fn with_snapshot_hint(mut self, hint: SnapshotHint) -> Self {
+        self.snapshot_hint = Some(hint);
+        self
+    }
 }
 
 impl SnapshotBuilder<FromSnapshot> {
@@ -324,28 +346,6 @@ impl<Mode> SnapshotBuilder<Mode> {
         self
     }
 
-    /// Supply complete snapshot state that Kernel can validate and construct without engine I/O.
-    ///
-    /// The hint conflicts with [`with_log_tail`](Self::with_log_tail),
-    /// [`builder_from`](Snapshot::builder_from), and non-disabled incremental CRC replay. An
-    /// explicit [`at_version`](Self::at_version) must equal the hint version. When no explicit
-    /// version is set, a supplied maximum catalog version must also equal the hint version.
-    /// Kernel validates structural consistency without reading the supplied files. The caller must
-    /// ensure every path belongs to this builder's table root, the protocol and metadata came from
-    /// those files, and `max_published_version` accurately describes the published commit prefix.
-    ///
-    /// # Errors
-    ///
-    /// [`build`](Self::build) returns [`Error::SnapshotHint`] for hint-specific conflicts or
-    /// inconsistencies. General builder, path, protocol, and metadata failures retain their normal
-    /// error variants.
-    #[allow(dead_code)]
-    #[internal_api]
-    pub(crate) fn with_snapshot_hint(mut self, hint: SnapshotHint) -> Self {
-        self.snapshot_hint = Some(hint);
-        self
-    }
-
     /// Attach an opaque, caller-supplied correlation id for joining this build's metric events to
     /// the caller's own request or operation id. An empty id is treated as unset. When unset,
     /// behavior is unchanged.
@@ -421,7 +421,6 @@ impl<Mode> SnapshotBuilder<Mode> {
         let snapshot = if let Some(snapshot_hint) = snapshot_hint {
             Self::build_from_snapshot_hint(
                 table_root,
-                existing_snapshot,
                 version,
                 log_tail,
                 max_catalog_version,
@@ -494,17 +493,12 @@ impl<Mode> SnapshotBuilder<Mode> {
 
     fn build_from_snapshot_hint(
         table_root: Option<String>,
-        existing_snapshot: Option<SnapshotRef>,
         requested_version: Option<Version>,
         log_tail: Vec<LogPath>,
         max_catalog_version: Option<Version>,
         incremental_replay: IncrementalReplay,
         snapshot_hint: SnapshotHint,
     ) -> DeltaResult<SnapshotRef> {
-        require!(
-            existing_snapshot.is_none(),
-            SnapshotHintError::ExistingSnapshot.into()
-        );
         require!(log_tail.is_empty(), SnapshotHintError::LogTail.into());
         require!(
             incremental_replay.is_disabled(),
@@ -522,11 +516,11 @@ impl<Mode> SnapshotBuilder<Mode> {
         } else if let Some(max_catalog_version) = max_catalog_version {
             require!(
                 max_catalog_version == snapshot_hint.version,
-                Error::MaxCatalogVersion(format!(
-                    "Max catalog version {max_catalog_version} does not match snapshot hint \
-                     version {}",
-                    snapshot_hint.version
-                ))
+                SnapshotHintError::MaxCatalogVersionMismatch {
+                    max_catalog_version,
+                    hint: snapshot_hint.version,
+                }
+                .into()
             );
         }
 
@@ -546,7 +540,7 @@ impl<Mode> SnapshotBuilder<Mode> {
         } = snapshot_hint;
         if freshness == SnapshotHintFreshness::Latest {
             require!(
-                max_catalog_version.is_none_or(|max| max == version),
+                max_catalog_version.is_none_or(|max| max <= version),
                 SnapshotHintError::LatestVersionConflict {
                     hint: version,
                     max_catalog_version: max_catalog_version.unwrap_or(version),
@@ -897,8 +891,8 @@ mod tests {
         Ok((engine, table_root, snapshot, hint))
     }
 
-    fn assert_hint_error<Mode>(
-        builder: SnapshotBuilder<Mode>,
+    fn assert_hint_error(
+        builder: SnapshotBuilder<FromTableRoot>,
         hint: SnapshotHint,
         engine: &dyn Engine,
         expected: &str,
@@ -1263,12 +1257,6 @@ mod tests {
             engine.as_ref(),
             "cannot be combined with a log tail",
         );
-        assert_hint_error(
-            SnapshotBuilder::new_from(snapshot),
-            hint.clone(),
-            engine.as_ref(),
-            "cannot be used with Snapshot::builder_from",
-        );
         let zero_budget = SnapshotBuilder::new_for(&table_root)
             .with_incremental_crc_replay(IncrementalReplay::UpToCommits(0))
             .with_snapshot_hint(hint.clone())
@@ -1294,7 +1282,7 @@ mod tests {
             .with_max_catalog_version(hint.version + 1)
             .with_snapshot_hint(hint)
             .build(engine.as_ref());
-        assert!(matches!(&result, Err(Error::MaxCatalogVersion(_))));
+        assert!(matches!(&result, Err(Error::SnapshotHint(_))));
         assert_result_error_with_message(result, "does not match snapshot hint version");
         let events = reporter.events();
         assert_eq!(events.len(), 1);
@@ -1351,6 +1339,12 @@ mod tests {
                 .build(engine.as_ref()),
             "Max catalog version is required",
         );
+        assert_hint_error(
+            SnapshotBuilder::new_for(&table_root).with_max_catalog_version(2),
+            hint.clone(),
+            engine.as_ref(),
+            "Max catalog version 2 does not match snapshot hint version 1",
+        );
         let latest = SnapshotBuilder::new_for(&table_root)
             .with_max_catalog_version(1)
             .with_snapshot_hint(hint.clone())
@@ -1358,7 +1352,16 @@ mod tests {
         assert_eq!(latest.version(), 1);
         assert!(!latest.is_built_as_latest());
 
-        let hinted = SnapshotBuilder::new_for(table_root)
+        let mut lower_bound_hint = hint.clone();
+        lower_bound_hint.freshness = SnapshotHintFreshness::Latest;
+        let result = SnapshotBuilder::new_for(&table_root)
+            .at_version(1)
+            .with_max_catalog_version(0)
+            .with_snapshot_hint(lower_bound_hint)
+            .build(engine.as_ref());
+        assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
+
+        let hinted = SnapshotBuilder::new_for(&table_root)
             .at_version(1)
             .with_max_catalog_version(2)
             .with_snapshot_hint(hint)
@@ -1766,6 +1769,28 @@ mod tests {
         }
 
         #[test_log::test(tokio::test)]
+        async fn snapshot_hint_accepts_staged_commit_with_catalog_version(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_catalog_managed_test().await;
+            let actions = actions_to_string(vec![TestAction::Add("file_1.parquet".to_string())]);
+            let staged_path = add_staged_commit(&table_root, store.as_ref(), 1, actions).await?;
+            let source = SnapshotBuilder::new_for(&table_root)
+                .with_log_tail(vec![create_log_path(&table_root, staged_path)])
+                .with_max_catalog_version(1)
+                .build(engine.as_ref())?;
+            let hint = hint_from_snapshot(&source, SnapshotHintFreshness::Latest);
+
+            let hinted = SnapshotBuilder::new_for(table_root)
+                .with_max_catalog_version(1)
+                .with_snapshot_hint(hint)
+                .build(engine.as_ref())?;
+
+            assert_eq!(hinted.version(), 1);
+            assert!(hinted.is_built_as_latest());
+            Ok(())
+        }
+
+        #[test_log::test(tokio::test)]
         async fn test_version_exceeds_max_catalog_version_errors(
         ) -> Result<(), Box<dyn std::error::Error>> {
             let (engine, _store, table_root) = setup_catalog_managed_test().await;
@@ -1916,6 +1941,7 @@ mod tests {
         #[case::gap(vec![1, 3], vec![1, 3], 3)]
         #[case::duplicates(vec![1], vec![1, 1], 1)]
         #[case::unsorted(vec![1, 2], vec![2, 1], 2)]
+        #[case::overflow(vec![], vec![Version::MAX, 0], 0)]
         #[test_log::test(tokio::test)]
         async fn test_non_contiguous_log_tail_errors(
             #[case] commit_versions: Vec<u64>,

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -553,14 +553,16 @@ impl<Mode> SnapshotBuilder<Mode> {
             .iter()
             .chain(log_segment_files.latest_commit_file.iter())
             .any(|path| path.file_type == LogPathFileType::StagedCommit);
+        let latest_commit_version = log_segment_files
+            .latest_commit_file
+            .as_ref()
+            .or_else(|| log_segment_files.ascending_commit_files.last())
+            .map(|path| path.version);
         Self::validate_catalog_managed_versions(
             requested_version,
             max_catalog_version,
             has_staged_commits,
-            log_segment_files
-                .latest_commit_file
-                .as_ref()
-                .map(|path| path.version),
+            latest_commit_version,
         )?;
 
         require!(
@@ -573,11 +575,6 @@ impl<Mode> SnapshotBuilder<Mode> {
         // filesystem aliases or connector-specific URI forms. The connector must ensure that all
         // hinted locations belong to this table. Kernel validates only path self-consistency and
         // log-segment semantics.
-        require!(
-            log_segment_files.ascending_commit_files.is_empty()
-                || log_segment_files.latest_commit_file.is_some(),
-            SnapshotHintError::MissingLatestCommit.into()
-        );
         let log_segment = LogSegment::try_new(
             log_segment_files,
             log_root,
@@ -631,6 +628,7 @@ impl<Mode> SnapshotBuilder<Mode> {
             table_configuration,
             crc,
             version_status == SnapshotHintVersionStatus::Latest,
+            false, /* skipped_new_checkpoints */
         )
         .map(Into::into)
     }
@@ -893,8 +891,8 @@ mod tests {
         Ok((engine, table_root, snapshot, hint))
     }
 
-    fn assert_hint_error(
-        builder: SnapshotBuilder,
+    fn assert_hint_error<Mode>(
+        builder: SnapshotBuilder<Mode>,
         hint: SnapshotHint,
         engine: &dyn Engine,
         expected: &str,
@@ -1095,11 +1093,14 @@ mod tests {
         let mut gapped = hint.clone();
         gapped.log_segment_files.ascending_commit_files[1] =
             create_log_path("memory:///_delta_log/00000000000000000003.json");
+        gapped.log_segment_files.latest_commit_file = Some(create_log_path(
+            "memory:///_delta_log/00000000000000000003.json",
+        ));
         assert_log_segment_hint_error(
             SnapshotBuilder::new_for(&table_root)
                 .with_snapshot_hint(gapped)
                 .build(engine.as_ref()),
-            "Expected contiguous commit files",
+            "Table version 1 is missing",
         );
 
         let mut inconsistent_path = hint.clone();
@@ -1156,18 +1157,16 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    async fn snapshot_hint_requires_latest_commit_file_when_commits_are_supplied(
+    async fn snapshot_hint_accepts_missing_latest_commit_file(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root, _snapshot, mut hint) =
             snapshot_and_hint(SnapshotHintVersionStatus::Unverified).await?;
         hint.log_segment_files.latest_commit_file = None;
 
-        assert_hint_error(
-            SnapshotBuilder::new_for(table_root),
-            hint,
-            engine.as_ref(),
-            "latest_commit_file is required when commits are supplied",
-        );
+        let snapshot = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref())?;
+        assert!(snapshot.log_segment().listed.latest_commit_file.is_none());
         Ok(())
     }
 
@@ -1191,6 +1190,7 @@ mod tests {
             let mut malformed = hint.clone();
             malformed.log_segment_files.latest_commit_file = Some(create_log_path(&latest));
             let err = SnapshotBuilder::new_for(&table_root)
+                .with_max_catalog_version(hint.version)
                 .with_snapshot_hint(malformed)
                 .build(engine.as_ref())
                 .unwrap_err();
@@ -1354,7 +1354,7 @@ mod tests {
             SnapshotBuilder::new_for(table_root)
                 .with_snapshot_hint(hint)
                 .build(engine.as_ref()),
-            "LogSegment end version",
+            "newer than requested end version",
         );
         Ok(())
     }
@@ -1786,7 +1786,7 @@ mod tests {
         }
 
         #[test_log::test(tokio::test)]
-        async fn snapshot_hint_accepts_staged_commit_with_catalog_version(
+        async fn snapshot_hint_accepts_staged_commit_without_latest_file_with_catalog_version(
         ) -> Result<(), Box<dyn std::error::Error>> {
             let (engine, store, table_root) = setup_catalog_managed_test().await;
             let staged =
@@ -1795,7 +1795,8 @@ mod tests {
                 .with_log_tail(vec![create_log_path(&table_root, staged)])
                 .with_max_catalog_version(1)
                 .build(engine.as_ref())?;
-            let hint = hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Unverified);
+            let mut hint = hint_from_snapshot(&snapshot, SnapshotHintVersionStatus::Unverified);
+            hint.log_segment_files.latest_commit_file = None;
 
             let hinted = SnapshotBuilder::new_for(&table_root)
                 .with_max_catalog_version(1)

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -44,6 +44,10 @@ mod snapshot_crc;
 #[doc(hidden)]
 pub use builder::{FromSnapshot, FromTableRoot};
 pub use builder::{IncrementalReplay, IncrementalSnapshotBuilder, SnapshotBuilder};
+pub use builder::SnapshotHintError;
+#[allow(unused_imports)]
+#[internal_api]
+pub(crate) use builder::{SnapshotHint, SnapshotHintVersionStatus};
 use snapshot_crc::SnapshotCrc;
 
 /// A shared, thread-safe reference to a [`Snapshot`].
@@ -345,11 +349,11 @@ impl Snapshot {
 
     /// Whether this snapshot was at the latest table version when it was built.
     ///
-    /// This is best-effort: `true` when the build knows this was the newest version. That holds for
-    /// a build (fresh or incremental) with no time-travel version, a build (fresh or incremental)
-    /// at the catalog's ratified latest version, and a post-commit snapshot. It is not a
-    /// liveness guarantee: another writer may commit a newer version afterward, so a `true`
-    /// snapshot can already be stale.
+    /// This is best-effort: `true` for an ordinary latest-version build, the catalog's ratified
+    /// latest version, a post-commit snapshot, or a snapshot hint marked `Latest` by its connector.
+    /// Kernel does not independently verify hint freshness. This is not a liveness guarantee:
+    /// another writer may commit a newer version afterward, so a `true` snapshot can already be
+    /// stale.
     ///
     /// Version-preserving derivations ([`Self::checkpoint`], [`Self::write_checksum`],
     /// [`Self::publish`]) do not change this flag: they carry it over from the source snapshot.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -46,7 +46,7 @@ pub use builder::{FromSnapshot, FromTableRoot};
 pub use builder::{IncrementalReplay, IncrementalSnapshotBuilder, SnapshotBuilder};
 #[allow(unused_imports)]
 #[internal_api]
-pub(crate) use builder::{SnapshotHint, SnapshotHintVersionStatus};
+pub(crate) use builder::{SnapshotHint, SnapshotHintFreshness};
 use snapshot_crc::SnapshotCrc;
 
 pub use crate::error::SnapshotHintError;

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -44,11 +44,12 @@ mod snapshot_crc;
 #[doc(hidden)]
 pub use builder::{FromSnapshot, FromTableRoot};
 pub use builder::{IncrementalReplay, IncrementalSnapshotBuilder, SnapshotBuilder};
-pub use builder::SnapshotHintError;
 #[allow(unused_imports)]
 #[internal_api]
 pub(crate) use builder::{SnapshotHint, SnapshotHintVersionStatus};
 use snapshot_crc::SnapshotCrc;
+
+pub use crate::error::SnapshotHintError;
 
 /// A shared, thread-safe reference to a [`Snapshot`].
 pub type SnapshotRef = Arc<Snapshot>;

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -16,7 +16,7 @@ use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::snapshot::IncrementalReplay;
 #[cfg(feature = "internal-api")]
-use delta_kernel::snapshot::{SnapshotHint, SnapshotHintVersionStatus};
+use delta_kernel::snapshot::{SnapshotHint, SnapshotHintFreshness};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{DeltaResult, Snapshot};
@@ -56,7 +56,7 @@ fn external_snapshot_hint_api_builds_without_storage_io() -> DeltaResult<()> {
         metadata: snapshot.table_configuration().metadata().clone(),
         last_checkpoint_hint: snapshot.log_segment().checkpoint_hint().cloned(),
         crc: snapshot.crc_at_version().cloned(),
-        version_status: SnapshotHintVersionStatus::Latest,
+        freshness: SnapshotHintFreshness::Latest,
     };
     reporter.reset();
 

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -10,22 +10,63 @@ use std::sync::Arc;
 use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::to_json_bytes;
+use delta_kernel::metrics::SnapshotLoadType;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::snapshot::IncrementalReplay;
+#[cfg(feature = "internal-api")]
+use delta_kernel::snapshot::{SnapshotHint, SnapshotHintVersionStatus};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{DeltaResult, Snapshot};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
-use test_utils::{insert_data, test_table_setup, test_table_setup_mt};
+use test_utils::{insert_data, test_table_setup, test_table_setup_mt, SnapshotCompletionStatus};
 use url::Url;
 
 use super::{
     insert_rows, measuring_engine, setup_table_with_v1_checkpoint, simple_schema, LogState,
     TestTableBuilder,
 };
+
+#[cfg(feature = "internal-api")]
+#[test]
+fn external_snapshot_hint_api_builds_without_storage_io() -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(1))
+        .with_data(1, 1)
+        .build()?;
+    let (engine, reporter, _guard) = measuring_engine(table.store().clone());
+    let snapshot = Snapshot::builder_for(table.table_root()).build(&engine)?;
+    let hint = SnapshotHint {
+        version: snapshot.version(),
+        log_segment_files: snapshot.log_segment().listed.clone(),
+        protocol: snapshot.table_configuration().protocol().clone(),
+        metadata: snapshot.table_configuration().metadata().clone(),
+        last_checkpoint_hint: snapshot.log_segment().checkpoint_hint().cloned(),
+        crc: snapshot.crc_at_version().cloned(),
+        version_status: SnapshotHintVersionStatus::Latest,
+    };
+    reporter.reset();
+
+    let hinted = Snapshot::builder_for(table.table_root())
+        .with_snapshot_hint(hint)
+        .build(&engine)?;
+
+    assert_eq!(hinted.version(), snapshot.version());
+    assert_eq!(reporter.list_calls.get(), 0);
+    assert_eq!(reporter.json_read_calls.get(), 0);
+    assert_eq!(reporter.parquet_read_calls.get(), 0);
+    assert_eq!(
+        reporter.snapshot_completion_count(
+            SnapshotCompletionStatus::Success,
+            SnapshotLoadType::SnapshotHint,
+        ),
+        1
+    );
+    Ok(())
+}
 
 // ============================================================================
 // Scenario 1: delta-only (2 commits, no checkpoint, no compaction)
@@ -44,7 +85,11 @@ fn delta_only_snapshot_emits_expected_metrics() -> DeltaResult<()> {
     let (engine, reporter, _guard) = measuring_engine(table.store().clone());
     let _snap = Snapshot::builder_for(table.table_root()).build(&engine)?;
 
-    assert_eq!(reporter.snapshot_completions.get(), 1);
+    assert_eq!(
+        reporter
+            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
+        1
+    );
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 2);
     assert_eq!(reporter.checkpoint_files.get(), 0);
@@ -87,7 +132,11 @@ async fn snapshot_with_v1_checkpoint_and_tail_commit_emits_expected_metrics() ->
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let _snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
 
-    assert_eq!(reporter.snapshot_completions.get(), 1);
+    assert_eq!(
+        reporter
+            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
+        1
+    );
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 1); // only tail commit (v2)
     assert_eq!(reporter.checkpoint_files.get(), 1);
@@ -124,7 +173,11 @@ async fn snapshot_at_checkpoint_tip_emits_expected_metrics() -> DeltaResult<()> 
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let _snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
 
-    assert_eq!(reporter.snapshot_completions.get(), 1);
+    assert_eq!(
+        reporter
+            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
+        1
+    );
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 0);
     assert_eq!(reporter.checkpoint_files.get(), 1);
@@ -182,7 +235,11 @@ async fn snapshot_with_log_compaction_emits_expected_metrics() -> DeltaResult<()
     let (engine, reporter, _guard) = measuring_engine(store);
     let _snap = Snapshot::builder_for(table.table_root()).build(&engine)?;
 
-    assert_eq!(reporter.snapshot_completions.get(), 1);
+    assert_eq!(
+        reporter
+            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
+        1
+    );
     assert_eq!(reporter.log_segment_loads.get(), 1);
     // ascending_commit_files contains all 4 individual .json files (0, 1, 2, 3)
     assert_eq!(reporter.commit_files.get(), 4);
@@ -215,7 +272,11 @@ async fn snapshot_with_crc_at_target_version_skips_json_replay() -> DeltaResult<
     let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let _snap = Snapshot::builder_for(table_root).build(&engine)?;
 
-    assert_eq!(reporter.snapshot_completions.get(), 1);
+    assert_eq!(
+        reporter
+            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
+        1
+    );
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 1);
     assert_eq!(reporter.checkpoint_files.get(), 0);
@@ -301,7 +362,11 @@ async fn crc_at_prior_version_roots_replay_at_crc_for_both_modes(
         expected_crc_version
     );
 
-    assert_eq!(reporter.snapshot_completions.get(), 1);
+    assert_eq!(
+        reporter
+            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
+        1
+    );
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 3); // v0, v1, v2
 
@@ -346,7 +411,11 @@ async fn checkpoint_with_multiple_tail_commits_emits_expected_metrics() -> Delta
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let _snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
 
-    assert_eq!(reporter.snapshot_completions.get(), 1);
+    assert_eq!(
+        reporter
+            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
+        1
+    );
     assert_eq!(reporter.log_segment_loads.get(), 1);
     // Checkpoint at v1 -- listing starts from v2; tail is v2, v3, v4
     assert_eq!(reporter.commit_files.get(), 3);

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -22,13 +22,23 @@ use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{DeltaResult, Snapshot};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
-use test_utils::{insert_data, test_table_setup, test_table_setup_mt, SnapshotCompletionStatus};
+use test_utils::{
+    insert_data, test_table_setup, test_table_setup_mt, CountingReporter, SnapshotCompletionStatus,
+};
 use url::Url;
 
 use super::{
     insert_rows, measuring_engine, setup_table_with_v1_checkpoint, simple_schema, LogState,
     TestTableBuilder,
 };
+
+fn assert_full_snapshot_completed(reporter: &CountingReporter) {
+    assert_eq!(
+        reporter
+            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
+        1
+    );
+}
 
 #[cfg(feature = "internal-api")]
 #[test]
@@ -68,6 +78,31 @@ fn external_snapshot_hint_api_builds_without_storage_io() -> DeltaResult<()> {
     Ok(())
 }
 
+#[test]
+fn incremental_snapshot_build_emits_incremental_completion() -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(1))
+        .with_data(1, 1)
+        .build()?;
+    let (engine, reporter, _guard) = measuring_engine(table.store().clone());
+    let base = Snapshot::builder_for(table.table_root())
+        .at_version(0)
+        .build(&engine)?;
+    reporter.reset();
+
+    let snapshot = Snapshot::builder_from(base).build(&engine)?;
+
+    assert_eq!(snapshot.version(), 1);
+    assert_eq!(
+        reporter.snapshot_completion_count(
+            SnapshotCompletionStatus::Success,
+            SnapshotLoadType::Incremental,
+        ),
+        1
+    );
+    Ok(())
+}
+
 // ============================================================================
 // Scenario 1: delta-only (2 commits, no checkpoint, no compaction)
 // ============================================================================
@@ -85,11 +120,7 @@ fn delta_only_snapshot_emits_expected_metrics() -> DeltaResult<()> {
     let (engine, reporter, _guard) = measuring_engine(table.store().clone());
     let _snap = Snapshot::builder_for(table.table_root()).build(&engine)?;
 
-    assert_eq!(
-        reporter
-            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
-        1
-    );
+    assert_full_snapshot_completed(&reporter);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 2);
     assert_eq!(reporter.checkpoint_files.get(), 0);
@@ -132,11 +163,7 @@ async fn snapshot_with_v1_checkpoint_and_tail_commit_emits_expected_metrics() ->
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let _snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
 
-    assert_eq!(
-        reporter
-            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
-        1
-    );
+    assert_full_snapshot_completed(&reporter);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 1); // only tail commit (v2)
     assert_eq!(reporter.checkpoint_files.get(), 1);
@@ -173,11 +200,7 @@ async fn snapshot_at_checkpoint_tip_emits_expected_metrics() -> DeltaResult<()> 
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let _snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
 
-    assert_eq!(
-        reporter
-            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
-        1
-    );
+    assert_full_snapshot_completed(&reporter);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 0);
     assert_eq!(reporter.checkpoint_files.get(), 1);
@@ -235,11 +258,7 @@ async fn snapshot_with_log_compaction_emits_expected_metrics() -> DeltaResult<()
     let (engine, reporter, _guard) = measuring_engine(store);
     let _snap = Snapshot::builder_for(table.table_root()).build(&engine)?;
 
-    assert_eq!(
-        reporter
-            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
-        1
-    );
+    assert_full_snapshot_completed(&reporter);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     // ascending_commit_files contains all 4 individual .json files (0, 1, 2, 3)
     assert_eq!(reporter.commit_files.get(), 4);
@@ -272,11 +291,7 @@ async fn snapshot_with_crc_at_target_version_skips_json_replay() -> DeltaResult<
     let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let _snap = Snapshot::builder_for(table_root).build(&engine)?;
 
-    assert_eq!(
-        reporter
-            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
-        1
-    );
+    assert_full_snapshot_completed(&reporter);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 1);
     assert_eq!(reporter.checkpoint_files.get(), 0);
@@ -362,11 +377,7 @@ async fn crc_at_prior_version_roots_replay_at_crc_for_both_modes(
         expected_crc_version
     );
 
-    assert_eq!(
-        reporter
-            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
-        1
-    );
+    assert_full_snapshot_completed(&reporter);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 3); // v0, v1, v2
 
@@ -411,11 +422,7 @@ async fn checkpoint_with_multiple_tail_commits_emits_expected_metrics() -> Delta
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let _snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
 
-    assert_eq!(
-        reporter
-            .snapshot_completion_count(SnapshotCompletionStatus::Success, SnapshotLoadType::Full,),
-        1
-    );
+    assert_full_snapshot_completed(&reporter);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     // Checkpoint at v1 -- listing starts from v2; tail is v2, v3, v4
     assert_eq!(reporter.commit_files.get(), 3);

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -9,6 +9,8 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::committer::FileSystemCommitter;
+#[cfg(feature = "internal-api")]
+use delta_kernel::crc::Crc;
 use delta_kernel::engine::to_json_bytes;
 use delta_kernel::metrics::SnapshotLoadType;
 use delta_kernel::object_store::local::LocalFileSystem;
@@ -75,6 +77,51 @@ fn external_snapshot_hint_api_builds_without_storage_io() -> DeltaResult<()> {
         ),
         1
     );
+    Ok(())
+}
+
+#[cfg(feature = "internal-api")]
+#[test]
+fn external_snapshot_hint_accepts_parsed_advanced_crc() -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(2).with_crc_at([1]))
+        .with_data(1, 1)
+        .build()?;
+    let (engine, reporter, _guard) = measuring_engine(table.store().clone());
+    let snapshot = Snapshot::builder_for(table.table_root())
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
+        .build(&engine)?;
+    assert_eq!(
+        snapshot
+            .log_segment()
+            .listed
+            .latest_crc_file
+            .as_ref()
+            .unwrap()
+            .version,
+        1
+    );
+    let crc_bytes = serde_json::to_vec(snapshot.crc_at_version().unwrap())?;
+    let parsed_crc = Arc::new(Crc::try_from_json_bytes(&crc_bytes, snapshot.version())?);
+    let hint = SnapshotHint {
+        version: snapshot.version(),
+        log_segment_files: snapshot.log_segment().listed.clone(),
+        protocol: snapshot.table_configuration().protocol().clone(),
+        metadata: snapshot.table_configuration().metadata().clone(),
+        last_checkpoint_hint: snapshot.log_segment().checkpoint_hint().cloned(),
+        crc: Some(parsed_crc),
+        freshness: SnapshotHintFreshness::Latest,
+    };
+    reporter.reset();
+
+    let hinted = Snapshot::builder_for(table.table_root())
+        .with_snapshot_hint(hint)
+        .build(&engine)?;
+
+    assert_eq!(hinted.crc_at_version().unwrap().version, hinted.version());
+    assert_eq!(reporter.list_calls.get(), 0);
+    assert_eq!(reporter.json_read_calls.get(), 0);
+    assert_eq!(reporter.parquet_read_calls.get(), 0);
     Ok(())
 }
 

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -1,14 +1,17 @@
-//! A [`MetricsReporter`] implementation that accumulates operation counts via atomic counters.
+//! A [`MetricsReporter`] implementation that accumulates operation counts via thread-safe counters.
 //!
 //! Useful in tests to assert exact IO costs and in benchmarks to print per-call IO profiles.
 //! Attach it to a `DefaultEngine` via `DefaultEngineBuilder::with_metrics_reporter`, then
 //! inspect the counters or call [`CountingReporter::print_summary`].
 
+use std::collections::HashMap;
+use std::hash::Hash;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use delta_kernel::metrics::{
-    CommitFailureReason, MetricEvent, MetricsReporter, WithMetricsReporterLayer as _,
+    CommitFailureReason, MetricEvent, MetricsReporter, SnapshotLoadType,
+    WithMetricsReporterLayer as _,
 };
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::util::SubscriberInitExt as _;
@@ -114,6 +117,45 @@ impl RelaxedCounter {
     }
 }
 
+/// Status label for a snapshot completion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SnapshotCompletionStatus {
+    /// The snapshot was constructed successfully.
+    Success,
+    /// Snapshot construction failed.
+    Failure,
+}
+
+#[derive(Debug)]
+struct LabeledCounter<L>(Mutex<HashMap<L, u64>>);
+
+impl<L> Default for LabeledCounter<L> {
+    fn default() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+}
+
+impl<L: Eq + Hash> LabeledCounter<L> {
+    fn counts(&self) -> MutexGuard<'_, HashMap<L, u64>> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn get(&self, labels: &L) -> u64 {
+        self.counts().get(labels).copied().unwrap_or_default()
+    }
+
+    fn reset(&self) {
+        self.counts().clear();
+    }
+
+    fn inc(&self, labels: L) {
+        let mut counts = self.counts();
+        *counts.entry(labels).or_default() += 1;
+    }
+}
+
 /// Accumulates storage and operation metrics via the [`MetricsReporter`] interface.
 ///
 /// # Note: update [`reset`] and the `MetricsReporter` impl when adding fields.
@@ -153,8 +195,7 @@ pub struct CountingReporter {
     pub parquet_bytes_read: RelaxedCounter,
 
     // Operation-level counters
-    /// Number of completed snapshot constructions.
-    pub snapshot_completions: RelaxedCounter,
+    snapshot_completions: LabeledCounter<(SnapshotCompletionStatus, SnapshotLoadType)>,
     /// Number of full (non-incremental) log segment loads. Each fresh snapshot construction
     /// from a table root contributes one load; incremental snapshot updates do not.
     pub log_segment_loads: RelaxedCounter,
@@ -206,6 +247,15 @@ impl CountingReporter {
     /// Create a new reporter with all counters at zero.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Returns the number of snapshot completions with the supplied status and load type.
+    pub fn snapshot_completion_count(
+        &self,
+        status: SnapshotCompletionStatus,
+        load_type: SnapshotLoadType,
+    ) -> u64 {
+        self.snapshot_completions.get(&(status, load_type))
     }
 
     /// Reset all counters to zero.
@@ -310,8 +360,9 @@ impl MetricsReporter for CountingReporter {
                 self.parquet_files_read.add(e.num_files);
                 self.parquet_bytes_read.add(e.bytes_read);
             }
-            MetricEvent::SnapshotBuildSuccess(_) => {
-                self.snapshot_completions.inc();
+            MetricEvent::SnapshotBuildSuccess(e) => {
+                self.snapshot_completions
+                    .inc((SnapshotCompletionStatus::Success, e.load_type));
             }
             MetricEvent::LogSegmentLoadSuccess(e) => {
                 self.log_segment_loads.inc();
@@ -348,6 +399,10 @@ impl MetricsReporter for CountingReporter {
             MetricEvent::SetTransactionLoadFailure => {
                 self.set_transaction_load_failures.inc();
             }
+            MetricEvent::SnapshotBuildFailure(e) => {
+                self.snapshot_completions
+                    .inc((SnapshotCompletionStatus::Failure, e.load_type));
+            }
             MetricEvent::TransactionCommitSuccess(e) => {
                 self.transaction_commits.inc();
                 self.commit_add_files.add(e.num_add_files);
@@ -364,7 +419,6 @@ impl MetricsReporter for CountingReporter {
             MetricEvent::ProtocolMetadataLoadSuccess(_)
             | MetricEvent::ProtocolMetadataLoadFailure(_)
             | MetricEvent::LogSegmentLoadFailure(_)
-            | MetricEvent::SnapshotBuildFailure(_)
             | MetricEvent::CrcReadFailure
             | MetricEvent::ScanMetadataCompleted(_) => {}
         }
@@ -399,9 +453,11 @@ mod tests {
     use delta_kernel::metrics::{
         CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, LogSegmentLoadType,
         MetricId, ProtocolMetadataLoadSuccess, ProtocolMetadataSource, SetTransactionLoadSuccess,
-        SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
-        StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
+        SnapshotBuildFailure, SnapshotBuildSuccess, SnapshotLoadType, StorageCopyCompleted,
+        StorageListCompleted, StorageReadCompleted, TableType, TransactionCommitFailure,
+        TransactionCommitSuccess,
     };
+    use rstest::rstest;
 
     use super::*;
 
@@ -446,18 +502,48 @@ mod tests {
         assert_eq!(reporter.copy_calls.get(), 1);
     }
 
-    #[test]
-    fn report_snapshot_completed_increments_snapshot_counter() {
+    #[rstest]
+    #[case::success(SnapshotCompletionStatus::Success)]
+    #[case::failure(SnapshotCompletionStatus::Failure)]
+    fn report_snapshot_completions_share_one_counter_across_load_types(
+        #[case] status: SnapshotCompletionStatus,
+    ) {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::SnapshotBuildSuccess(SnapshotBuildSuccess {
-            operation_id: MetricId::new(),
-            table_type: TableType::PathBased,
-            correlation_id: None,
-            load_type: LogSegmentLoadType::Full,
-            version: 0,
-            duration: dur(),
-        }));
-        assert_eq!(reporter.snapshot_completions.get(), 1);
+        for load_type in [
+            SnapshotLoadType::Full,
+            SnapshotLoadType::Incremental,
+            SnapshotLoadType::SnapshotHint,
+        ] {
+            match status {
+                SnapshotCompletionStatus::Success => {
+                    reporter.report(MetricEvent::SnapshotBuildSuccess(SnapshotBuildSuccess {
+                        operation_id: MetricId::new(),
+                        table_type: TableType::PathBased,
+                        correlation_id: None,
+                        load_type,
+                        version: 7,
+                        duration: dur(),
+                    }));
+                }
+                SnapshotCompletionStatus::Failure => {
+                    reporter.report(MetricEvent::SnapshotBuildFailure(SnapshotBuildFailure {
+                        operation_id: MetricId::new(),
+                        table_type: TableType::PathBased,
+                        correlation_id: None,
+                        load_type,
+                    }));
+                }
+            }
+            let other_status = match status {
+                SnapshotCompletionStatus::Success => SnapshotCompletionStatus::Failure,
+                SnapshotCompletionStatus::Failure => SnapshotCompletionStatus::Success,
+            };
+            assert_eq!(reporter.snapshot_completion_count(status, load_type), 1);
+            assert_eq!(
+                reporter.snapshot_completion_count(other_status, load_type),
+                0
+            );
+        }
     }
 
     #[test]
@@ -623,13 +709,20 @@ mod tests {
                 duration: dur(),
             },
         ));
-        reporter.report(MetricEvent::SnapshotBuildFailure(SnapshotBuildFailure {
-            operation_id: MetricId::new(),
-            table_type: TableType::PathBased,
-            correlation_id: None,
-            load_type: LogSegmentLoadType::Full,
-        }));
-        assert_eq!(reporter.snapshot_completions.get(), 0);
+        assert_eq!(
+            reporter.snapshot_completion_count(
+                SnapshotCompletionStatus::Success,
+                SnapshotLoadType::Full,
+            ),
+            0
+        );
+        assert_eq!(
+            reporter.snapshot_completion_count(
+                SnapshotCompletionStatus::Failure,
+                SnapshotLoadType::Full,
+            ),
+            0
+        );
     }
 
     #[test]
@@ -676,6 +769,20 @@ mod tests {
                 duration: dur(),
             },
         ));
+        reporter.report(MetricEvent::SnapshotBuildSuccess(SnapshotBuildSuccess {
+            operation_id: MetricId::new(),
+            table_type: TableType::PathBased,
+            correlation_id: None,
+            load_type: SnapshotLoadType::SnapshotHint,
+            version: 0,
+            duration: dur(),
+        }));
+        reporter.report(MetricEvent::SnapshotBuildFailure(SnapshotBuildFailure {
+            operation_id: MetricId::new(),
+            table_type: TableType::PathBased,
+            correlation_id: None,
+            load_type: SnapshotLoadType::SnapshotHint,
+        }));
 
         reporter.reset();
 
@@ -691,7 +798,20 @@ mod tests {
         assert_eq!(reporter.parquet_read_calls.get(), 0);
         assert_eq!(reporter.parquet_files_read.get(), 0);
         assert_eq!(reporter.parquet_bytes_read.get(), 0);
-        assert_eq!(reporter.snapshot_completions.get(), 0);
+        assert_eq!(
+            reporter.snapshot_completion_count(
+                SnapshotCompletionStatus::Success,
+                SnapshotLoadType::SnapshotHint,
+            ),
+            0
+        );
+        assert_eq!(
+            reporter.snapshot_completion_count(
+                SnapshotCompletionStatus::Failure,
+                SnapshotLoadType::SnapshotHint,
+            ),
+            0
+        );
         assert_eq!(reporter.log_segment_loads.get(), 0);
         assert_eq!(reporter.commit_files.get(), 0);
         assert_eq!(reporter.checkpoint_files.get(), 0);

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -166,7 +166,7 @@ use std::sync::{Arc, Mutex};
 
 pub use counting_reporter::{
     ensure_metrics_compatible_global_subscriber, install_thread_local_metrics_reporter,
-    CapturingReporter, CountingReporter, RelaxedCounter,
+    CapturingReporter, CountingReporter, RelaxedCounter, SnapshotCompletionStatus,
 };
 use delta_kernel::actions::{
     LOG_ADD_SCHEMA, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3222/files) to review incremental changes.
- [**snapshot-hint**](https://github.com/delta-io/delta-kernel-rs/pull/3222) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3222/files)] <- _this PR_
  - [snapshot-hint-ffi](https://github.com/delta-io/delta-kernel-rs/pull/3284) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3284/files/aa3f34296d2e93a7d257ef633cf53add8dc22b48..2c1a56ec5d7fdccfbc1dfdb6ad46fbd6dc6ae9d9)]

---------
## What changes are proposed in this pull request?

This PR adds an `internal-api` path for building a snapshot from complete caller-supplied state.
It lets a connector reuse state it already has without asking the engine to list or read the Delta
log again.

```rust
let hint = SnapshotHint {
    version,
    log_segment_files,
    protocol,
    metadata,
    last_checkpoint_hint,
    crc,
    version_status: SnapshotHintVersionStatus::Latest,
};

let snapshot = Snapshot::builder_for(table_root)
    .with_snapshot_hint(hint)
    .build(engine)?;
```

The existing `build(engine)` API is unchanged. The engine is accepted but is not used when a
complete hint is present.

Kernel still validates the supplied state:

- The log segment must be complete and valid for the hinted version.
- Protocol and metadata must form a valid table configuration.
- A supplied CRC must match the hint version, protocol, and metadata.
- Conflicting builder options, such as a log tail or incremental CRC replay, are rejected.
- `Latest` marks the snapshot as latest. `Unverified` does not; freshness remains the connector's
  responsibility.

Snapshot metrics now include `load_type = snapshot_hint`. A hinted build emits the normal snapshot
success or failure event, but no child log-load or I/O events because it performs no engine I/O.
`CountingReporter` exposes this as one counter family labeled by completion status and load type:

```rust
let successes = reporter.snapshot_completion_count(
    SnapshotCompletionStatus::Success,
    SnapshotLoadType::SnapshotHint,
);
```

The Rust-to-C metric mapping appends the new load type, and the FFI error mapping appends
`InvalidSnapshotHint`. 

### This PR affects the following public APIs

- Under `internal-api`, adds `SnapshotHint`, `SnapshotHintVersionStatus`, and
  `SnapshotBuilder::with_snapshot_hint`.
- Adds `SnapshotLoadType::SnapshotHint` and `Error::SnapshotHint`.
- `CountingReporter::snapshot_completion_count` queries the completion counter by
  `SnapshotCompletionStatus` and `SnapshotLoadType`.
- Appends matching FFI enum variants for the new load type and error.

## How was this change tested?

```shell
cargo nextest run --locked --workspace --all-features \
  -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
cargo +nightly fmt
cargo clippy --workspace --benches --tests --all-features -- -D warnings
cargo doc --workspace --all-features --no-deps
```
