### PR TITLE
feat: support reading stable row commit version

### DIFF
--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1482,6 +1482,8 @@ mod tests {
             ScanPartitionValuesOptions::default(),
         )?;
 
+        let mut iter = iter.peekable();
+        assert!(iter.peek().is_some(), "scan metadata must not be empty");
         for scan_metadata in iter {
             let transforms = scan_metadata?.scan_file_transforms;
             assert_eq!(transforms.len(), 1);

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -21,7 +21,9 @@ use crate::log_replay::{
     ParallelLogReplayProcessor,
 };
 use crate::log_segment::CheckpointReadInfo;
-use crate::scan::transform_spec::{get_transform_expr, parse_partition_values, TransformSpec};
+use crate::scan::transform_spec::{
+    get_transform_expr, parse_partition_values, FileRowTrackingMetadata, TransformSpec,
+};
 use crate::schema::{
     lazy_schema_ref, ColumnNamesAndTypes, DataType, MapType, SchemaRef, SchemaStructPatchBuilder,
     StructField, StructType, ToSchema as _,
@@ -183,14 +185,17 @@ struct RetryTransformAndDataSkipOutput {
 
 impl ScanLogReplayProcessor {
     // These index positions correspond to the order of columns defined in
-    // `selected_column_names_and_types()`
+    // `AddRemoveDedupVisitor::selected_column_names_and_types()`
     const ADD_PATH_INDEX: usize = 0; // Position of "add.path" in getters
     const ADD_PARTITION_VALUES_INDEX: usize = 1; // Position of "add.partitionValues" in getters
     const ADD_SIZE_INDEX: usize = 2; // Position of "add.size" in getters
     const ADD_DV_START_INDEX: usize = 3; // Start position of add deletion vector columns
     const BASE_ROW_ID_INDEX: usize = 6; // Position of add.baseRowId in getters
-    const REMOVE_PATH_INDEX: usize = 7; // Position of "remove.path" in getters
-    const REMOVE_DV_START_INDEX: usize = 8; // Start position of remove deletion vector columns
+
+    // Position of add.defaultRowCommitVersion in getters
+    const DEFAULT_ROW_COMMIT_VERSION_INDEX: usize = 7;
+    const REMOVE_PATH_INDEX: usize = 8; // Position of "remove.path" in getters
+    const REMOVE_DV_START_INDEX: usize = 9; // Start position of remove deletion vector columns
 
     /// Create a new [`ScanLogReplayProcessor`] instance
     pub(crate) fn new(
@@ -599,8 +604,8 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         // action type:
         // - For Add actions: path is at index 0, size at 2, then followed by DV fields at indexes
         //   3-5
-        // - For Remove actions (in log batches only): path is at index 7, followed by DV fields at
-        //   indexes 8-10
+        // - For Remove actions (in log batches only): path is at index 8, followed by DV fields at
+        //   indexes 9-11
         // The file extraction logic selects the appropriate indexes based on whether we found a
         // valid path. Remove getters are not included when visiting a non-log batch
         // (checkpoint batch), so do not try to extract remove actions in that case.
@@ -658,6 +663,9 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         if !self.state_info.skip_row_transforms {
             let base_row_id: Option<i64> =
                 getters[ScanLogReplayProcessor::BASE_ROW_ID_INDEX].get_opt(row, "add.baseRowId")?;
+            let default_row_commit_version: Option<i64> = getters
+                [ScanLogReplayProcessor::DEFAULT_ROW_COMMIT_VERSION_INDEX]
+                .get_opt(row, "add.defaultRowCommitVersion")?;
             let patch_expr = self
                 .state_info
                 .transform_spec
@@ -667,7 +675,10 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
                         transform_spec,
                         partition_values,
                         &self.state_info.physical_schema,
-                        base_row_id,
+                        FileRowTrackingMetadata {
+                            base_row_id,
+                            default_row_commit_version,
+                        },
                     )
                 })
                 .transpose()?;
@@ -698,6 +709,7 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
                 (STRING, column_name!("add.deletionVector.pathOrInlineDv")),
                 (INTEGER, column_name!("add.deletionVector.offset")),
                 (LONG, column_name!("add.baseRowId")),
+                (LONG, column_name!("add.defaultRowCommitVersion")),
                 (STRING, column_name!("remove.path")),
                 (STRING, column_name!("remove.deletionVector.storageType")),
                 (STRING, column_name!("remove.deletionVector.pathOrInlineDv")),
@@ -721,7 +733,7 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
         let start = std::time::Instant::now();
 
         let is_log_batch = self.deduplicator.is_log_batch();
-        let expected_getters = if is_log_batch { 11 } else { 7 };
+        let expected_getters = if is_log_batch { 12 } else { 8 };
         require!(
             getters.len() == expected_getters,
             Error::InternalError(format!(
@@ -1171,11 +1183,12 @@ mod tests {
     use crate::log_segment::CheckpointReadInfo;
     use crate::scan::state::ScanFile;
     use crate::scan::state_info::tests::{
-        assert_transform_spec, get_simple_state_info, get_state_info, ROW_TRACKING_FEATURES,
+        assert_transform_spec, get_simple_state_info, get_state_info, RowTrackingState,
+        ROW_TRACKING_FEATURES,
     };
     use crate::scan::state_info::StateInfo;
     use crate::scan::test_utils::{
-        add_batch_for_row_id, add_batch_simple, add_batch_with_partition_col,
+        add_batch_for_row_tracking, add_batch_simple, add_batch_with_partition_col,
         add_batch_with_remove, add_batch_with_remove_and_partition, run_with_validate_callback,
     };
     use crate::scan::PhysicalPredicate;
@@ -1394,7 +1407,7 @@ mod tests {
             "row_indexes_for_row_id_0",
         );
 
-        let batch = vec![add_batch_for_row_id(get_commit_schema().clone())];
+        let batch = vec![add_batch_for_row_tracking(get_commit_schema().clone())];
         let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
             batch
@@ -1433,6 +1446,61 @@ mod tests {
                 panic!("Should have been a StructPatch expression");
             }
         }
+    }
+
+    #[rstest]
+    #[case::supported_not_enabled(RowTrackingState::SupportedNotEnabled)]
+    #[case::enabled(RowTrackingState::Enabled)]
+    #[case::suspended(RowTrackingState::Suspended)]
+    fn test_row_commit_version_patch(
+        #[case] row_tracking_state: RowTrackingState,
+    ) -> DeltaResult<()> {
+        let schema: SchemaRef = schema_ref! { nullable "value": INTEGER };
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            None,
+            row_tracking_state.features(),
+            row_tracking_state.properties(),
+            vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
+        );
+        if row_tracking_state != RowTrackingState::Enabled {
+            assert_result_error_with_message(
+                state_info,
+                "Row commit versions are not enabled on this table",
+            );
+            return Ok(());
+        }
+
+        let batch = add_batch_for_row_tracking(get_commit_schema().clone());
+        let (iter, _metrics) = scan_action_iter(
+            &SyncEngine::new(),
+            [Ok(ActionsBatch::new(batch, true))].into_iter(),
+            Arc::new(state_info?),
+            test_checkpoint_info(),
+            ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
+        )?;
+
+        for scan_metadata in iter {
+            let transforms = scan_metadata?.scan_file_transforms;
+            assert_eq!(transforms.len(), 1);
+            let Some(Expr::StructPatch(patch)) = transforms[0].as_ref().map(Arc::as_ref) else {
+                panic!("Expected a StructPatch expression");
+            };
+            let row_commit_version_patch = patch
+                .field_patches
+                .get("row_commit_version_col")
+                .expect("Should have row_commit_version_col patch");
+            assert_eq!(
+                row_commit_version_patch.insertions,
+                [Arc::new(Expr::coalesce([
+                    col!("row_commit_version_col"),
+                    lit(5i64),
+                ]))]
+            );
+        }
+        Ok(())
     }
 
     #[test]

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -285,8 +285,8 @@ impl ScanBuilder {
     /// have been filtered out but were kept).
     ///
     /// NOTE: Predicates referencing metadata columns the caller added to the projection via
-    /// [`StructType::add_metadata_column`] (row indexes, row ids, file paths) are not supported
-    /// and will error at build time.
+    /// [`StructType::add_metadata_column`] (row indexes, row ids, row commit versions, file paths)
+    /// are not supported and will error at build time.
     ///
     /// A predicate alone enables internal data skipping; kernel does not surface stats
     /// to the engine by default. Use [`with_stats`](Self::with_stats) if the engine

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -330,9 +330,9 @@ impl ScanBuilder {
     /// empty (each row's transform is `None`); use [`Scan::scan_metadata`] for listing.
     ///
     /// With this set the engine must itself apply every physical-to-logical fixup the transform
-    /// would normally perform: partition column injection, column-mapping renames, and generated
-    /// row ids. Deletion vectors are unaffected: they are delivered per file in the scan metadata
-    /// regardless. [`Scan::execute`] returns an error.
+    /// would normally perform: partition column injection, column-mapping renames, generated Row
+    /// IDs, and generated Row Commit Versions. Deletion vectors are unaffected: they are delivered
+    /// per file in the scan metadata regardless. [`Scan::execute`] returns an error.
     pub fn without_row_transforms(mut self) -> Self {
         self.without_row_transforms = true;
         self

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -819,6 +819,7 @@ pub(crate) mod tests {
     pub(crate) const ROW_TRACKING_FEATURES: &[TableFeature] =
         &[TableFeature::RowTracking, TableFeature::DomainMetadata];
 
+    // TODO(#3248): Add tests for row id.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub(crate) enum RowTrackingState {
         Unsupported,

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -13,7 +13,7 @@ use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
 use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions, StructStats};
 use crate::schema::{DataType, MetadataColumnSpec, SchemaRef, StructType};
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
+use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode, TableFeature};
 use crate::{DeltaResult, Error, PredicateRef, StructField};
 
 /// All the state needed to process a scan.
@@ -72,6 +72,9 @@ struct MetadataInfo<'a> {
     /// the materializedRowIdColumnName extracted from the table config if row ids are requested,
     /// or None if they are not requested
     materialized_row_id_column_name: Option<&'a String>,
+    /// the materializedRowCommitVersionColumnName extracted from the table config if row commit
+    /// versions are requested, or None if they are not requested
+    materialized_row_commit_version_column_name: Option<&'a String>,
 }
 
 /// This validates that we have sensible metadata columns, and that the requested metadata is
@@ -108,7 +111,23 @@ fn validate_metadata_columns<'a>(
                     .ok_or(Error::generic("No delta.rowTracking.materializedRowIdColumnName key found in metadata configuration"))?;
                 metadata_info.materialized_row_id_column_name = Some(row_id_col);
             }
-            Some(MetadataColumnSpec::RowCommitVersion) => {}
+            Some(MetadataColumnSpec::RowCommitVersion) => {
+                if !table_configuration.is_feature_enabled(&TableFeature::RowTracking) {
+                    return Err(Error::unsupported(
+                        "Row commit versions are not enabled on this table",
+                    ));
+                }
+                let row_commit_version_col = table_configuration
+                    .table_properties()
+                    .materialized_row_commit_version_column_name
+                    .as_ref()
+                    .ok_or(Error::generic(
+                        "No delta.rowTracking.materializedRowCommitVersionColumnName key found in \
+                         metadata configuration",
+                    ))?;
+                metadata_info.materialized_row_commit_version_column_name =
+                    Some(row_commit_version_col);
+            }
             Some(MetadataColumnSpec::FilePath) => {
                 // FilePath metadata column is handled by the parquet reader
             }
@@ -302,14 +321,33 @@ impl StateInfo {
                             ));
                         };
 
-                        read_fields.push(StructField::nullable(row_id_col_name, DataType::LONG));
+                        let row_id_col_name = row_id_col_name.to_string();
+                        read_fields.push(StructField::nullable(&row_id_col_name, DataType::LONG));
                         transform_spec.push(FieldTransformSpec::GenerateRowId {
-                            field_name: row_id_col_name.to_string(),
+                            field_name: row_id_col_name.clone(),
                             row_index_field_name: index_column_name,
                         });
+                        last_physical_field = Some(row_id_col_name);
                     }
                     Some(MetadataColumnSpec::RowCommitVersion) => {
-                        return Err(Error::unsupported("Row commit versions not supported"));
+                        let Some(row_commit_version_col_name) =
+                            metadata_info.materialized_row_commit_version_column_name
+                        else {
+                            return Err(Error::internal_error(
+                                "missing materialized Row Commit Version column name when row \
+                                 tracking is enabled",
+                            ));
+                        };
+
+                        let row_commit_version_col_name = row_commit_version_col_name.to_string();
+                        read_fields.push(StructField::nullable(
+                            &row_commit_version_col_name,
+                            DataType::LONG,
+                        ));
+                        transform_spec.push(FieldTransformSpec::GenerateRowCommitVersion {
+                            field_name: row_commit_version_col_name.clone(),
+                        });
+                        last_physical_field = Some(row_commit_version_col_name);
                     }
                     Some(MetadataColumnSpec::RowIndex)
                     | Some(MetadataColumnSpec::FilePath)
@@ -781,6 +819,46 @@ pub(crate) mod tests {
     pub(crate) const ROW_TRACKING_FEATURES: &[TableFeature] =
         &[TableFeature::RowTracking, TableFeature::DomainMetadata];
 
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) enum RowTrackingState {
+        Unsupported,
+        SupportedNotEnabled,
+        Enabled,
+        Suspended,
+    }
+
+    impl RowTrackingState {
+        pub(crate) fn features(self) -> &'static [TableFeature] {
+            match self {
+                Self::Unsupported => &[],
+                Self::SupportedNotEnabled | Self::Enabled | Self::Suspended => {
+                    ROW_TRACKING_FEATURES
+                }
+            }
+        }
+
+        pub(crate) fn properties(self) -> HashMap<String, String> {
+            let mut properties = get_string_map(&[
+                (
+                    "delta.rowTracking.materializedRowIdColumnName",
+                    "row_id_col",
+                ),
+                (
+                    "delta.rowTracking.materializedRowCommitVersionColumnName",
+                    "row_commit_version_col",
+                ),
+            ]);
+            if self == Self::Enabled {
+                properties.insert("delta.enableRowTracking".to_string(), "true".to_string());
+            }
+            if self == Self::Suspended {
+                properties.insert("delta.enableRowTracking".to_string(), "false".to_string());
+                properties.insert("delta.rowTrackingSuspended".to_string(), "true".to_string());
+            }
+            properties
+        }
+    }
+
     fn get_string_map(slice: &[(&str, &str)]) -> HashMap<String, String> {
         slice
             .iter()
@@ -833,6 +911,47 @@ pub(crate) mod tests {
             false, // we did not request row indexes
             "some_row_id_col",
             "row_indexes_for_row_id_0",
+        );
+    }
+
+    #[test]
+    fn request_row_commit_versions() {
+        let schema = schema_ref! { nullable "id": STRING };
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            None,
+            ROW_TRACKING_FEATURES,
+            get_string_map(&[
+                ("delta.enableRowTracking", "true"),
+                (
+                    "delta.rowTracking.materializedRowIdColumnName",
+                    "some_row_id_col",
+                ),
+                (
+                    "delta.rowTracking.materializedRowCommitVersionColumnName",
+                    "some_row_commit_version_col",
+                ),
+            ]),
+            vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
+        )
+        .unwrap();
+
+        assert_eq!(
+            state_info
+                .physical_schema
+                .field("some_row_commit_version_col")
+                .map(StructField::data_type),
+            Some(&DataType::LONG)
+        );
+        assert_eq!(
+            state_info.transform_spec.as_deref().map(Vec::as_slice),
+            Some(
+                [FieldTransformSpec::GenerateRowCommitVersion {
+                    field_name: "some_row_commit_version_col".to_string(),
+                }]
+                .as_slice()
+            )
         );
     }
 
@@ -909,7 +1028,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn invalid_rowtracking_config() {
+    fn invalid_row_id_config() {
         let schema = schema_ref! { nullable "id": STRING };
 
         // Row IDs requested but row tracking not enabled → error
@@ -935,6 +1054,46 @@ pub(crate) mod tests {
         assert_result_error_with_message(
             res,
             "Generic delta kernel error: No delta.rowTracking.materializedRowIdColumnName key found in metadata configuration",
+        );
+    }
+
+    #[rstest]
+    #[case::unsupported(RowTrackingState::Unsupported)]
+    #[case::supported_not_enabled(RowTrackingState::SupportedNotEnabled)]
+    #[case::suspended(RowTrackingState::Suspended)]
+    fn request_row_commit_versions_requires_enabled_row_tracking(
+        #[case] row_tracking_state: RowTrackingState,
+    ) {
+        let schema = schema_ref! { nullable "id": STRING };
+        let res = get_state_info(
+            schema,
+            vec![],
+            None,
+            row_tracking_state.features(),
+            row_tracking_state.properties(),
+            vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
+        );
+        assert_result_error_with_message(
+            res,
+            "Unsupported: Row commit versions are not enabled on this table",
+        );
+    }
+
+    #[test]
+    fn request_row_commit_versions_requires_materialized_column_name() {
+        let schema = schema_ref! { nullable "id": STRING };
+        let res = get_state_info(
+            schema,
+            vec![],
+            None,
+            ROW_TRACKING_FEATURES,
+            get_string_map(&[("delta.enableRowTracking", "true")]),
+            vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
+        );
+        assert_result_error_with_message(
+            res,
+            "No delta.rowTracking.materializedRowCommitVersionColumnName key found in metadata \
+             configuration",
         );
     }
 

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -75,11 +75,11 @@ pub(crate) fn add_batch_simple(output_schema: SchemaRef) -> Box<ArrowEngineData>
 
 // Generates a batch with an add action.
 // The schema is provided as null columns affect equality checks.
-pub(crate) fn add_batch_for_row_id(output_schema: SchemaRef) -> Box<ArrowEngineData> {
+pub(crate) fn add_batch_for_row_tracking(output_schema: SchemaRef) -> Box<ArrowEngineData> {
     parse_batch(
         [
-            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","baseRowId": 42, "tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
-            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none", "delta.enableRowTracking": "true", "delta.rowTracking.materializedRowIdColumnName":"row_id_col"},"createdTime":1677811175819}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","baseRowId":42,"defaultRowCommitVersion":5,"tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none", "delta.enableRowTracking": "true", "delta.rowTracking.materializedRowIdColumnName":"row_id_col", "delta.rowTracking.materializedRowCommitVersionColumnName":"row_commit_version_col"},"createdTime":1677811175819}}"#,
         ],
         output_schema,
     )

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -524,10 +524,12 @@ fn test_without_row_transforms_rejects_execute() {
     );
 }
 
-/// Row commit version metadata columns are unsupported by scans, so requesting one errors at
-/// build time regardless of `without_row_transforms`.
+/// Row commit version metadata columns require a row-tracking-enabled table, including when row
+/// transforms are disabled.
 #[rstest]
-fn test_scan_rejects_row_commit_version(#[values(false, true)] without_row_transforms: bool) {
+fn test_scan_rejects_row_commit_version_when_row_tracking_is_disabled(
+    #[values(false, true)] without_row_transforms: bool,
+) {
     let (_engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
     let schema = Arc::new(
         snapshot
@@ -541,10 +543,10 @@ fn test_scan_rejects_row_commit_version(#[values(false, true)] without_row_trans
     }
     let err = builder
         .build()
-        .expect_err("row commit version columns are unsupported by scans");
+        .expect_err("row commit version columns require row tracking");
     assert!(
         err.to_string()
-            .contains("Row commit versions not supported"),
+            .contains("Row commit versions are not enabled on this table"),
         "unexpected error: {err}"
     );
 }

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -23,6 +23,12 @@ use crate::{DeltaResult, Error};
 // description for that concept.
 pub(crate) type TransformSpec = Vec<FieldTransformSpec>;
 
+#[derive(Debug, Default)]
+pub(crate) struct FileRowTrackingMetadata {
+    pub(crate) base_row_id: Option<i64>,
+    pub(crate) default_row_commit_version: Option<i64>,
+}
+
 /// Describes a single field transformation to apply when converting physical data to logical
 /// schema.
 ///
@@ -49,6 +55,11 @@ pub(crate) enum FieldTransformSpec {
         field_name: String,
         /// column name which contains row indexes
         row_index_field_name: String,
+    },
+    /// Generate the stable Row Commit Version column.
+    GenerateRowCommitVersion {
+        /// Column containing the materialized Row Commit Version.
+        field_name: String,
     },
     /// Insert a partition column after the named input column.
     /// The partition column is identified by its field index in the logical table schema.
@@ -109,6 +120,7 @@ pub(crate) fn parse_partition_values(
             FieldTransformSpec::DynamicColumn { .. }
             | FieldTransformSpec::StaticInsert { .. }
             | FieldTransformSpec::GenerateRowId { .. }
+            | FieldTransformSpec::GenerateRowCommitVersion { .. }
             | FieldTransformSpec::StaticDrop { .. } => None,
         })
         .try_collect()
@@ -123,7 +135,7 @@ pub(crate) fn get_transform_expr(
     transform_spec: &TransformSpec,
     mut metadata_values: HashMap<usize, (String, Scalar)>,
     physical_schema: &StructType,
-    base_row_id: Option<i64>,
+    row_tracking_metadata: FileRowTrackingMetadata,
 ) -> DeltaResult<ExpressionRef> {
     let mut patch = ExpressionStructPatchBuilder::new();
 
@@ -138,12 +150,24 @@ pub(crate) fn get_transform_expr(
                 field_name,
                 row_index_field_name,
             } => {
-                let base_row_id = base_row_id.ok_or_else(|| {
+                let base_row_id = row_tracking_metadata.base_row_id.ok_or_else(|| {
                     Error::generic("Asked to generate RowIds, but no baseRowId found.")
                 })?;
                 let expr = Arc::new(Expression::coalesce([
                     Expression::column([field_name]),
                     lit(base_row_id) + Expression::column([row_index_field_name]),
+                ]));
+                patch.replace(field_name.clone(), expr)
+            }
+            GenerateRowCommitVersion { field_name } => {
+                let default_row_commit_version = row_tracking_metadata
+                    .default_row_commit_version
+                    .ok_or(Error::missing_data(
+                    "Missing defaultRowCommitVersion for Row Commit Version reconstruction",
+                ))?;
+                let expr = Arc::new(Expression::coalesce([
+                    Expression::column([field_name]),
+                    lit(default_row_commit_version),
                 ]));
                 patch.replace(field_name.clone(), expr)
             }
@@ -391,7 +415,7 @@ mod tests {
             &transform_spec,
             partition_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         assert_result_error_with_message(result, "missing partition value");
     }
@@ -419,7 +443,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         )
         .unwrap();
 
@@ -461,7 +485,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         let patch_expr = result.expect("StructPatch expression should be created successfully");
 
@@ -508,7 +532,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         let patch_expr = result.expect("StructPatch expression should be created successfully");
 
@@ -545,7 +569,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         let patch_expr = result.expect("StructPatch expression should be created successfully");
 
@@ -584,7 +608,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         assert_result_error_with_message(result, "missing partition value for dynamic column");
     }
@@ -607,7 +631,10 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            Some(4), /* base_row_id */
+            FileRowTrackingMetadata {
+                base_row_id: Some(4),
+                ..Default::default()
+            },
         );
         let patch_expr = result.expect("StructPatch expression should be created successfully");
 
@@ -649,9 +676,66 @@ mod tests {
                 &transform_spec,
                 metadata_values,
                 &physical_schema,
-                None, /* base_row_id */
+                FileRowTrackingMetadata::default(),
             ),
             "Asked to generate RowIds, but no baseRowId found",
+        );
+    }
+
+    #[test]
+    fn get_transform_expr_generates_stable_row_commit_versions() -> DeltaResult<()> {
+        let transform_spec = vec![FieldTransformSpec::GenerateRowCommitVersion {
+            field_name: "row_commit_version_col".to_string(),
+        }];
+        let physical_schema = schema! {
+            nullable "id": STRING,
+            nullable "row_commit_version_col": LONG,
+        };
+
+        let expression = get_transform_expr(
+            &transform_spec,
+            HashMap::new(),
+            &physical_schema,
+            FileRowTrackingMetadata {
+                default_row_commit_version: Some(5),
+                ..Default::default()
+            },
+        )?;
+        let Expression::StructPatch(patch) = expression.as_ref() else {
+            panic!("Expected StructPatch expression");
+        };
+        let row_commit_version_patch = patch
+            .field_patches
+            .get("row_commit_version_col")
+            .expect("Should have row_commit_version_col patch");
+        assert!(!row_commit_version_patch.keep_input);
+        assert_eq!(
+            row_commit_version_patch.insertions,
+            [Arc::new(Expression::coalesce([
+                col!("row_commit_version_col"),
+                lit(5i64),
+            ]))]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn get_transform_expr_rejects_missing_default_row_commit_version() {
+        let transform_spec = vec![FieldTransformSpec::GenerateRowCommitVersion {
+            field_name: "row_commit_version_col".to_string(),
+        }];
+        let physical_schema = schema! {
+            nullable "row_commit_version_col": LONG,
+        };
+
+        assert_result_error_with_message(
+            get_transform_expr(
+                &transform_spec,
+                HashMap::new(),
+                &physical_schema,
+                FileRowTrackingMetadata::default(),
+            ),
+            "Missing defaultRowCommitVersion",
         );
     }
 }

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -23,6 +23,9 @@ use crate::{DeltaResult, Error};
 // description for that concept.
 pub(crate) type TransformSpec = Vec<FieldTransformSpec>;
 
+/// Per-file Add-action values used to reconstruct stable row id/commit version.
+///
+/// A value is absent when the Add action doesn't have the corresponding field.
 #[derive(Debug, Default)]
 pub(crate) struct FileRowTrackingMetadata {
     pub(crate) base_row_id: Option<i64>,

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -165,9 +165,12 @@ pub(crate) fn get_transform_expr(
             GenerateRowCommitVersion { field_name } => {
                 let default_row_commit_version = row_tracking_metadata
                     .default_row_commit_version
-                    .ok_or(Error::missing_data(
-                    "Missing defaultRowCommitVersion for Row Commit Version reconstruction",
-                ))?;
+                    .ok_or_else(|| {
+                    Error::missing_data(concat!(
+                        "Missing defaultRowCommitVersion for Row Commit Version ",
+                        "reconstruction",
+                    ))
+                })?;
                 let expr = Arc::new(Expression::coalesce([
                     Expression::column([field_name]),
                     lit(default_row_commit_version),

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -4,7 +4,9 @@ use super::scan_file::{CdfScanFile, CdfScanFileType};
 use super::{CHANGE_TYPE_COL_NAME, COMMIT_TIMESTAMP_COL_NAME, COMMIT_VERSION_COL_NAME};
 use crate::expressions::Scalar;
 use crate::scan::state_info::StateInfo;
-use crate::scan::transform_spec::{get_transform_expr, parse_partition_values};
+use crate::scan::transform_spec::{
+    get_transform_expr, parse_partition_values, FileRowTrackingMetadata,
+};
 use crate::schema::{schema_ref, SchemaRef, StructType};
 use crate::{DeltaResult, Error, ExpressionRef};
 
@@ -121,7 +123,7 @@ pub(crate) fn get_cdf_transform_expr(
         transform_spec,
         partition_values,
         physical_schema,
-        None, /* base_row_id */
+        FileRowTrackingMetadata::default(),
     )
     .map(Some)
 }

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -14,7 +14,7 @@ use crate::actions::deletion_vector::split_vector;
 use crate::scan::field_classifiers::CdfTransformFieldClassifier;
 use crate::scan::state_info::StateInfo;
 use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions};
-use crate::schema::SchemaRef;
+use crate::schema::{MetadataColumnSpec, SchemaRef};
 use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, PredicateRef};
 
@@ -123,6 +123,13 @@ impl TableChangesScanBuilder {
         let table_schema: SchemaRef = self.table_changes.schema().clone().into();
         // If no projection is supplied, default to the full CDF-extended schema (SELECT *).
         let logical_read_schema = self.schema.unwrap_or_else(|| table_schema.clone());
+        if logical_read_schema.contains_metadata_column(&MetadataColumnSpec::RowId)
+            || logical_read_schema.contains_metadata_column(&MetadataColumnSpec::RowCommitVersion)
+        {
+            return Err(Error::unsupported(
+                "Row ID and Row Commit Version metadata are unsupported in CDF scans",
+            ));
+        }
 
         // Create StateInfo using CDF field classifier
         // CDF doesn't support stats output
@@ -355,15 +362,18 @@ fn read_scan_file(
 mod tests {
     use std::sync::Arc;
 
+    use rstest::rstest;
+
     use crate::committer::FileSystemCommitter;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{col, lit};
     use crate::object_store::memory::InMemory;
     use crate::scan::transform_spec::FieldTransformSpec;
     use crate::scan::PhysicalPredicate;
-    use crate::schema::schema_ref;
+    use crate::schema::{schema_ref, MetadataColumnSpec};
     use crate::table_changes::{TableChanges, COMMIT_VERSION_COL_NAME};
     use crate::transaction::create_table::create_table;
+    use crate::unit_test_utils::assert_result_error_with_message;
     use crate::Predicate;
 
     #[test]
@@ -483,6 +493,32 @@ mod tests {
             PhysicalPredicate::Some(pred, pred_schema)
             if pred == &predicate && pred_schema.fields().len() == 1
         ));
+    }
+
+    #[rstest]
+    #[case::row_id(MetadataColumnSpec::RowId)]
+    #[case::row_commit_version(MetadataColumnSpec::RowCommitVersion)]
+    fn cdf_scan_rejects_row_tracking_metadata(#[case] metadata_spec: MetadataColumnSpec) {
+        let path = "./tests/data/table-with-cdf";
+        let engine = SyncEngine::new();
+        let url = delta_kernel::try_parse_uri(path).unwrap();
+        let table_changes = TableChanges::try_new(url, &engine, 0, Some(1)).unwrap();
+        let schema = Arc::new(
+            table_changes
+                .schema()
+                .add_metadata_column("row_tracking", metadata_spec)
+                .unwrap(),
+        );
+
+        let result = table_changes
+            .into_scan_builder()
+            .with_schema(schema)
+            .build();
+
+        assert_result_error_with_message(
+            result,
+            "Row ID and Row Commit Version metadata are unsupported in CDF scans",
+        );
     }
 
     // Regression for issue #2468 on the CDF path

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -912,9 +912,9 @@ async fn test_read_row_ids_basic() -> DeltaResult<()> {
 #[case::none("none")]
 #[case::name("name")]
 #[case::id("id")]
-/// When the row tracking metadata columns are before the partition columns in
-/// scan schema, the read result should preserve the order.
-fn generated_row_tracking_columns_preserve_order_before_partitions(
+  /// Row-tracking metadata columns directly adjacent to partition columns should preserve their
+  /// scan-schema order.
+fn generated_row_tracking_and_partition_columns_preserve_scan_schema_order(
     #[case] column_mapping_mode: &str,
 ) -> DeltaResult<()> {
     let table_schema = schema_ref! {
@@ -1089,6 +1089,11 @@ async fn test_read_row_commit_versions_use_add_action_defaults(
             .expect("row_commit_version column not found")
             .as_primitive::<Int64Type>();
         for row in 0..batch.num_rows() {
+            assert!(
+                !actual.contains_key(&numbers.value(row)),
+                "duplicate number {}",
+                numbers.value(row)
+            );
             actual.insert(numbers.value(row), row_commit_versions.value(row));
         }
     }
@@ -1397,6 +1402,7 @@ async fn test_read_row_tracking_values_after_checkpoint() -> DeltaResult<()> {
 
     let row_commit_version_batches =
         read_row_commit_version_scan(fresh_snapshot, mt_engine.clone())?;
+    assert!(!row_commit_version_batches.is_empty());
     for batch in row_commit_version_batches {
         let row_commit_versions = batch
             .column_by_name("row_commit_version")

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -1162,7 +1162,7 @@ async fn test_read_row_commit_versions_prefer_materialized_values(
     Ok(())
 }
 
- /// Collects `(number, value)` pairs, where `value` comes from `column_name`.
+/// Collects `(number, value)` pairs, where `value` comes from `column_name`.
 fn collect_number_to_column(batches: &[RecordBatch], column_name: &str) -> HashMap<i32, i64> {
     let mut map = HashMap::new();
     for batch in batches {
@@ -1181,6 +1181,7 @@ fn collect_number_to_column(batches: &[RecordBatch], column_name: &str) -> HashM
     map
 }
 
+/// A deletion vector must not change surviving rows' stable Row IDs or Row Commit Versions.
 #[rstest]
 #[case::middle(&[4, 5, 6])]
 #[case::first(&[0, 1, 2])]

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -912,8 +912,8 @@ async fn test_read_row_ids_basic() -> DeltaResult<()> {
 #[case::none("none")]
 #[case::name("name")]
 #[case::id("id")]
-  /// Row-tracking metadata columns directly adjacent to partition columns should preserve their
-  /// scan-schema order.
+/// Row-tracking metadata columns directly adjacent to partition columns should preserve their
+/// scan-schema order.
 fn generated_row_tracking_and_partition_columns_preserve_scan_schema_order(
     #[case] column_mapping_mode: &str,
 ) -> DeltaResult<()> {

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -3,14 +3,16 @@ use std::sync::Arc;
 
 use delta_kernel::actions::deletion_vector_writer::KernelDeletionVector;
 use delta_kernel::arrow::array::{Array, AsArray, Int32Array, Int64Array, StringArray};
-use delta_kernel::arrow::datatypes::{Int32Type, Int64Type, Schema as ArrowSchema};
+use delta_kernel::arrow::datatypes::{
+    DataType as ArrowDataType, Field, Int32Type, Int64Type, Schema as ArrowSchema,
+};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::to_json_bytes;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt};
-use delta_kernel::schema::{schema_ref, MetadataColumnSpec, SchemaRef};
+use delta_kernel::schema::{schema_ref, MetadataColumnSpec, SchemaRef, StructField};
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Error, Snapshot};
 use itertools::Itertools;
@@ -19,15 +21,19 @@ use serde_json::{Deserializer, Value};
 use tempfile::{tempdir, TempDir};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
+use test_utils::table_builder::{FeatureSet, LogState, TestTableBuilder};
 use test_utils::{
-    begin_transaction, collect_row_ids, create_default_engine_mt_executor, create_table,
-    engine_store_setup, load_and_begin_transaction, read_actions_from_commit, read_add_infos,
-    read_scan, test_read,
+    add_commit, assert_result_error_with_message, begin_transaction, collect_row_ids,
+    create_default_engine_mt_executor, create_table, create_table_and_load_snapshot,
+    engine_store_setup, get_materialized_row_tracking_column_names, load_and_begin_transaction,
+    read_actions_from_commit, read_add_infos, read_scan, record_batch_to_bytes, test_read,
+    test_table_setup,
 };
 use url::Url;
 
 use crate::common::write_utils::{
-    create_dv_update_transaction, get_scan_files, write_deletion_vector_to_store,
+    create_dv_update_transaction, get_scan_files, set_table_properties,
+    write_deletion_vector_to_store,
 };
 
 /// Helper function to create a simple table with row tracking enabled.
@@ -866,6 +872,19 @@ fn read_row_id_scan(
     read_scan(&scan, engine)
 }
 
+fn read_row_commit_version_scan(
+    snapshot: Arc<Snapshot>,
+    engine: Arc<dyn delta_kernel::Engine>,
+) -> DeltaResult<Vec<RecordBatch>> {
+    let scan_schema = Arc::new(
+        snapshot
+            .schema()
+            .add_metadata_column("row_commit_version", MetadataColumnSpec::RowCommitVersion)?,
+    );
+    let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
+    read_scan(&scan, engine)
+}
+
 /// Basic read: write one file with 3 rows, verify row IDs are sequential starting from 0.
 #[tokio::test]
 async fn test_read_row_ids_basic() -> DeltaResult<()> {
@@ -886,6 +905,254 @@ async fn test_read_row_ids_basic() -> DeltaResult<()> {
     row_ids.sort_unstable();
     assert_eq!(row_ids, vec![0, 1, 2], "Row IDs must be sequential from 0");
 
+    Ok(())
+}
+
+#[rstest]
+#[case::none("none")]
+#[case::name("name")]
+#[case::id("id")]
+/// When the row tracking metadata columns are before the partition columns in
+/// scan schema, the read result should preserve the order.
+fn generated_row_tracking_columns_preserve_order_before_partitions(
+    #[case] column_mapping_mode: &str,
+) -> DeltaResult<()> {
+    let table_schema = schema_ref! {
+        nullable "value": INTEGER,
+        nullable "part_a": STRING,
+        nullable "part_b": STRING,
+    };
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(1))
+        .with_features(
+            FeatureSet::new()
+                .column_mapping(column_mapping_mode)
+                .row_tracking(),
+        )
+        .with_schema(table_schema)
+        .with_partition_columns(["part_a", "part_b"])
+        .with_data(1, 3)
+        .build()?;
+
+    let engine: Arc<dyn delta_kernel::Engine> = Arc::new(table.engine());
+    let snapshot = Snapshot::builder_for(table.table_root()).build(engine.as_ref())?;
+    let snapshot_schema = snapshot.schema();
+    let scan_schema = schema_ref! {
+        (snapshot_schema.field("value").expect("value field not found").clone()),
+        (StructField::create_metadata_column("row_id", MetadataColumnSpec::RowId)),
+        (snapshot_schema.field("part_a").expect("part_a field not found").clone()),
+        (StructField::create_metadata_column(
+            "row_commit_version",
+            MetadataColumnSpec::RowCommitVersion,
+        )),
+        (snapshot_schema.field("part_b").expect("part_b field not found").clone()),
+    };
+    let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
+    let batches = read_scan(&scan, engine)?;
+
+    let expected_names = ["value", "row_id", "part_a", "row_commit_version", "part_b"];
+    let mut row_ids = Vec::new();
+    let mut row_commit_versions = Vec::new();
+    let mut part_a_values = Vec::new();
+    let mut part_b_values = Vec::new();
+    for batch in batches {
+        assert_eq!(
+            batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            expected_names,
+        );
+        row_ids.extend(
+            batch
+                .column_by_name("row_id")
+                .expect("row_id column not found")
+                .as_primitive::<Int64Type>()
+                .iter()
+                .map(|value| value.expect("row_id must not be null")),
+        );
+        row_commit_versions.extend(
+            batch
+                .column_by_name("row_commit_version")
+                .expect("row_commit_version column not found")
+                .as_primitive::<Int64Type>()
+                .iter()
+                .map(|value| value.expect("row_commit_version must not be null")),
+        );
+        part_a_values.extend(
+            batch
+                .column_by_name("part_a")
+                .expect("part_a column not found")
+                .as_string::<i32>()
+                .iter()
+                .map(|value| value.expect("part_a must not be null").to_string()),
+        );
+        part_b_values.extend(
+            batch
+                .column_by_name("part_b")
+                .expect("part_b column not found")
+                .as_string::<i32>()
+                .iter()
+                .map(|value| value.expect("part_b must not be null").to_string()),
+        );
+    }
+
+    assert_eq!(row_ids, [0, 1, 2]);
+    assert_eq!(row_commit_versions, [1, 1, 1]);
+    assert_eq!(part_a_values, ["part_1000"; 3]);
+    assert_eq!(part_b_values, ["part_1000"; 3]);
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RowTrackingTestCase {
+    Enabled,
+    Unsupported,
+    Supported,
+    Suspended,
+}
+
+impl RowTrackingTestCase {
+    fn create_table_properties(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            // Create-table rejects suspension, so suspend this case after writing.
+            Self::Enabled | Self::Suspended => &[("delta.enableRowTracking", "true")],
+            Self::Supported => &[("delta.feature.rowTracking", "supported")],
+            Self::Unsupported => &[],
+        }
+    }
+}
+
+#[rstest]
+#[case::enabled(RowTrackingTestCase::Enabled)]
+#[case::unsupported(RowTrackingTestCase::Unsupported)]
+#[case::supported(RowTrackingTestCase::Supported)]
+#[case::suspended(RowTrackingTestCase::Suspended)]
+#[tokio::test]
+async fn test_read_row_commit_versions_use_add_action_defaults(
+    #[case] test_case: RowTrackingTestCase,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = schema_ref! { nullable "number": INTEGER };
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| Error::generic("Failed to convert table path to URL"))?;
+    create_table_and_load_snapshot(
+        &table_path,
+        schema.clone(),
+        engine.as_ref(),
+        test_case.create_table_properties(),
+    )?;
+
+    let first_commit = generate_data(schema.clone(), [vec![int32_array(vec![10, 20])]])?;
+    write_data_to_table(&table_url, engine.clone(), first_commit)
+        .await?
+        .unwrap_committed();
+    let second_commit = generate_data(schema, [vec![int32_array(vec![30])]])?;
+    write_data_to_table(&table_url, engine.clone(), second_commit)
+        .await?
+        .unwrap_committed();
+
+    let snapshot = if test_case == RowTrackingTestCase::Suspended {
+        set_table_properties(
+            &table_path,
+            &table_url,
+            engine.as_ref(),
+            2, /* current_version */
+            &[
+                ("delta.enableRowTracking", "false"),
+                ("delta.rowTrackingSuspended", "true"),
+            ],
+        )?
+    } else {
+        Snapshot::builder_for(table_url).build(engine.as_ref())?
+    };
+    let batches = read_row_commit_version_scan(snapshot, engine);
+    if test_case != RowTrackingTestCase::Enabled {
+        assert_result_error_with_message(
+            batches,
+            "Row commit versions are not enabled on this table",
+        );
+        return Ok(());
+    }
+
+    let mut actual = HashMap::new();
+    for batch in batches? {
+        let numbers = batch
+            .column_by_name("number")
+            .expect("number column not found")
+            .as_primitive::<Int32Type>();
+        let row_commit_versions = batch
+            .column_by_name("row_commit_version")
+            .expect("row_commit_version column not found")
+            .as_primitive::<Int64Type>();
+        for row in 0..batch.num_rows() {
+            actual.insert(numbers.value(row), row_commit_versions.value(row));
+        }
+    }
+
+    assert_eq!(actual, HashMap::from([(10, 1), (20, 1), (30, 2)]));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_read_row_commit_versions_prefer_materialized_values(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_dir = tempdir()?;
+    let (_schema, table_url, engine, store) =
+        setup_number_table(&tmp_dir, "test_read_materialized_row_commit_versions").await?;
+    let materialized_column_name = get_materialized_row_tracking_column_names(&table_url, 0)?
+        .row_commit_version_column_name
+        .ok_or_else(|| Error::generic("Materialized Row Commit Version column name not found"))?;
+    let batch = RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("number", ArrowDataType::Int32, true),
+            Field::new(&materialized_column_name, ArrowDataType::Int64, true),
+        ])),
+        vec![
+            Arc::new(Int32Array::from(vec![10, 20])),
+            Arc::new(Int64Array::from(vec![Some(7), None])),
+        ],
+    )?;
+    let parquet_bytes = record_batch_to_bytes(&batch);
+    let parquet_size = parquet_bytes.len();
+    let data_path = "materialized-row-commit-versions.parquet";
+    let data_url = table_url.join(data_path)?;
+    store
+        .put(&Path::from_url_path(data_url.path())?, parquet_bytes.into())
+        .await?;
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        1,
+        format!(
+            r#"{{"domainMetadata":{{"domain":"delta.rowTracking","configuration":"{{\"rowIdHighWaterMark\":1}}","removed":false}}}}
+{{"add":{{"path":"{data_path}","partitionValues":{{}},"size":{},"modificationTime":0,"dataChange":true,"baseRowId":0,"defaultRowCommitVersion":1}}}}"#,
+            parquet_size
+        ),
+    )
+    .await?;
+
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let batches = read_row_commit_version_scan(snapshot, engine)?;
+    let mut actual = HashMap::new();
+    for batch in batches {
+        let numbers = batch
+            .column_by_name("number")
+            .expect("number column not found")
+            .as_primitive::<Int32Type>();
+        let row_commit_versions = batch
+            .column_by_name("row_commit_version")
+            .expect("row_commit_version column not found")
+            .as_primitive::<Int64Type>();
+        for row in 0..batch.num_rows() {
+            actual.insert(numbers.value(row), row_commit_versions.value(row));
+        }
+    }
+
+    assert_eq!(actual, HashMap::from([(10, 7), (20, 1)]));
     Ok(())
 }
 
@@ -1088,7 +1355,8 @@ async fn test_read_row_ids_multiple_commits() -> DeltaResult<()> {
     Ok(())
 }
 
-/// After checkpoint: row IDs survive a checkpoint and new writes continue from the high watermark.
+/// Row IDs and Row Commit Versions survive a checkpoint, and Row IDs from later writes continue
+/// from the high watermark.
 ///
 /// Uses a multi-threaded runtime and `TokioMultiThreadExecutor` for checkpoint because
 /// `checkpoint()` consumes a lazy iterator inside a `block_on()` future where each item read
@@ -1097,7 +1365,7 @@ async fn test_read_row_ids_multiple_commits() -> DeltaResult<()> {
 /// instead, which requires a multi-threaded runtime to delegate work to other workers.
 /// Writes use the standard `TokioBackgroundExecutor` engine, matching all other tests in this file.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_read_row_ids_after_checkpoint() -> DeltaResult<()> {
+async fn test_read_row_tracking_values_after_checkpoint() -> DeltaResult<()> {
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_dir = tempdir()?;
     let (schema, table_url, engine, _store) =
@@ -1117,7 +1385,7 @@ async fn test_read_row_ids_after_checkpoint() -> DeltaResult<()> {
 
     // Fresh snapshot loaded from the checkpoint must return the same row IDs.
     let fresh_snapshot = Snapshot::builder_for(table_url.clone()).build(mt_engine.as_ref())?;
-    let batches = read_row_id_scan(fresh_snapshot, mt_engine.clone())?;
+    let batches = read_row_id_scan(fresh_snapshot.clone(), mt_engine.clone())?;
 
     let mut ids_after_ckpt = collect_row_ids(&batches);
     ids_after_ckpt.sort_unstable();
@@ -1126,6 +1394,16 @@ async fn test_read_row_ids_after_checkpoint() -> DeltaResult<()> {
         vec![0, 1, 2],
         "Row IDs must be unchanged after loading from checkpoint"
     );
+
+    let row_commit_version_batches =
+        read_row_commit_version_scan(fresh_snapshot, mt_engine.clone())?;
+    for batch in row_commit_version_batches {
+        let row_commit_versions = batch
+            .column_by_name("row_commit_version")
+            .expect("row_commit_version column not found")
+            .as_primitive::<Int64Type>();
+        assert!(row_commit_versions.iter().all(|version| version == Some(1)));
+    }
 
     // Write 2 more rows -> must continue from watermark, no resets or duplicates.
     let data2 = generate_data(schema.clone(), [vec![int32_array(vec![4, 5])]])?;

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -858,31 +858,32 @@ async fn test_no_row_tracking_fields_without_feature() -> DeltaResult<()> {
     Ok(())
 }
 
-/// Build a scan with `MetadataColumnSpec::RowId` appended to the snapshot schema and execute it.
-fn read_row_id_scan(
+fn read_row_tracking_scan(
     snapshot: Arc<Snapshot>,
     engine: Arc<dyn delta_kernel::Engine>,
+    metadata_column: MetadataColumnSpec,
 ) -> DeltaResult<Vec<RecordBatch>> {
     let scan_schema = Arc::new(
         snapshot
             .schema()
-            .add_metadata_column("row_id", MetadataColumnSpec::RowId)?,
+            .add_metadata_column(metadata_column.text_value(), metadata_column)?,
     );
     let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
     read_scan(&scan, engine)
+}
+
+fn read_row_id_scan(
+    snapshot: Arc<Snapshot>,
+    engine: Arc<dyn delta_kernel::Engine>,
+) -> DeltaResult<Vec<RecordBatch>> {
+    read_row_tracking_scan(snapshot, engine, MetadataColumnSpec::RowId)
 }
 
 fn read_row_commit_version_scan(
     snapshot: Arc<Snapshot>,
     engine: Arc<dyn delta_kernel::Engine>,
 ) -> DeltaResult<Vec<RecordBatch>> {
-    let scan_schema = Arc::new(
-        snapshot
-            .schema()
-            .add_metadata_column("row_commit_version", MetadataColumnSpec::RowCommitVersion)?,
-    );
-    let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
-    read_scan(&scan, engine)
+    read_row_tracking_scan(snapshot, engine, MetadataColumnSpec::RowCommitVersion)
 }
 
 /// Basic read: write one file with 3 rows, verify row IDs are sequential starting from 0.
@@ -1161,27 +1162,25 @@ async fn test_read_row_commit_versions_prefer_materialized_values(
     Ok(())
 }
 
-/// Collect `(number, row_id)` pairs from a row-id scan, keyed by the `number` data column.
-fn collect_number_to_row_id(batches: &[RecordBatch]) -> HashMap<i32, i64> {
+ /// Collects `(number, value)` pairs, where `value` comes from `column_name`.
+fn collect_number_to_column(batches: &[RecordBatch], column_name: &str) -> HashMap<i32, i64> {
     let mut map = HashMap::new();
     for batch in batches {
         let numbers = batch
             .column_by_name("number")
             .expect("number column not found")
             .as_primitive::<Int32Type>();
-        let row_ids = batch
-            .column_by_name("row_id")
-            .expect("row_id column not found")
+        let values = batch
+            .column_by_name(column_name)
+            .unwrap_or_else(|| panic!("{column_name} column not found"))
             .as_primitive::<Int64Type>();
         for i in 0..batch.num_rows() {
-            map.insert(numbers.value(i), row_ids.value(i));
+            map.insert(numbers.value(i), values.value(i));
         }
     }
     map
 }
 
-/// Deletion vector: must not renumber the surviving rows' stable row IDs and not change any row
-/// tracking metadata.
 #[rstest]
 #[case::middle(&[4, 5, 6])]
 #[case::first(&[0, 1, 2])]
@@ -1189,14 +1188,16 @@ fn collect_number_to_row_id(batches: &[RecordBatch]) -> HashMap<i32, i64> {
 #[case::first_and_last(&[0, 1, 8, 9])]
 #[case::first_middle_last(&[0, 4, 5, 9])]
 #[tokio::test]
-async fn test_read_row_ids_stable_across_deletion_vector_update(
+async fn test_read_row_tracking_metadata_stable_across_deletion_vector_update(
     #[case] deleted_indexes: &[u64],
+    #[values(MetadataColumnSpec::RowId, MetadataColumnSpec::RowCommitVersion)]
+    metadata_column: MetadataColumnSpec,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_dir = tempdir()?;
     let (schema, table_url, engine, store) = setup_number_table_with_features(
         &tmp_dir,
-        "test_read_row_ids_stable_across_dv",
+        "test_read_row_tracking_metadata_stable_across_dv",
         &["deletionVectors"],
         &[],
     )
@@ -1211,16 +1212,25 @@ async fn test_read_row_ids_stable_across_deletion_vector_update(
         .await?
         .unwrap_committed();
 
-    // Snapshot the (value -> row_id) mapping before any deletion. value v sits at physical index
-    // (v - 100), and with baseRowId 0 that is also its row ID.
+    let column_name = metadata_column.text_value();
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let before = collect_number_to_row_id(&read_row_id_scan(snapshot.clone(), engine.clone())?);
+    let before = collect_number_to_column(
+        &read_row_tracking_scan(snapshot.clone(), engine.clone(), metadata_column)?,
+        column_name,
+    );
+    let expected_before = (100..110)
+        .map(|value| {
+            let metadata_value = if metadata_column == MetadataColumnSpec::RowId {
+                i64::from(value - 100)
+            } else {
+                1
+            };
+            (value, metadata_value)
+        })
+        .collect::<HashMap<_, _>>();
     assert_eq!(
-        before,
-        (100..110)
-            .map(|v| (v, (v - 100) as i64))
-            .collect::<HashMap<_, _>>(),
-        "row IDs must equal each row's physical index before deletion"
+        before, expected_before,
+        "{column_name} values must match before deletion"
     );
 
     // The original Add's row-tracking fields, to confirm they survive the DV update unchanged.
@@ -1250,17 +1260,22 @@ async fn test_read_row_ids_stable_across_deletion_vector_update(
     )?;
     txn.commit(engine.as_ref())?.unwrap_committed();
 
-    // Every survivor keeps the exact row ID it had before.
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let after = collect_number_to_row_id(&read_row_id_scan(snapshot, engine.clone())?);
+    let after = collect_number_to_column(
+        &read_row_tracking_scan(snapshot, engine.clone(), metadata_column)?,
+        column_name,
+    );
 
     let expected_survivors: HashMap<i32, i64> = (100..110)
-        .filter(|v| !deleted_indexes.contains(&((v - 100) as u64)))
-        .map(|v| (v, (v - 100) as i64))
+        .filter(|value| {
+            !deleted_indexes
+                .contains(&u64::try_from(value - 100).expect("test values must be at least 100"))
+        })
+        .map(|value| (value, expected_before[&value]))
         .collect();
     assert_eq!(
         after, expected_survivors,
-        "surviving rows must keep their original row IDs, not be renumbered"
+        "surviving rows must keep their original {column_name} values"
     );
 
     // The DV update must preserve the original row-tracking fields on the rewritten Add.

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -2000,7 +2000,7 @@ async fn test_unsupported_metadata_columns() -> Result<(), Box<dyn std::error::E
         (
             "row_commit_version",
             MetadataColumnSpec::RowCommitVersion,
-            "Row commit versions not supported",
+            "Row commit versions are not enabled on this table",
         ),
     ];
 


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3224/files) to review incremental changes.
- [**stack/read-stable-ver**](https://github.com/delta-io/delta-kernel-rs/pull/3224) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3224/files)] ← _this PR_
  - [stack/builder-ctx](https://github.com/delta-io/delta-kernel-rs/pull/3226) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3226/files/e3bae86f5b2610d6360b157472923a2e139808ba..9a6702491fdf4f4af81cc1a0da4381fe608c5034)]
    - [stack/rc-metadata-write](https://github.com/delta-io/delta-kernel-rs/pull/3229) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3229/files/9a6702491fdf4f4af81cc1a0da4381fe608c5034..16daf0af62ad16e1f0a482b945a3fd09dfbef965)]

---------
## What changes are proposed in this pull request?
Support reading [stable row commit version](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#row-commit-versions) by generating the column in physical-to-logical transform


## How was this change tested?
integration tests on different row tracking tables
unit tests for the added functional units