### PR TITLE
feat!: add row tracking metadata cols into writecontext

### DIFF
--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -71,10 +71,10 @@ file listing without re-scanning the table.
 `BoundWriteContext`) -> commit
 
 Kernel captures table-wide configuration in a transportable `WriteState`. Each writer binds
-partition values to create a `BoundWriteContext` containing validated partition values, schemas,
-statistics columns, and the recommended write directory. The transaction registers the resulting
-files, enforces protocol compliance, assembles commit actions, and delegates the atomic commit to
-a `Committer`.
+partition values and any logical materialized row-tracking columns to create a `BoundWriteContext`
+containing validated partition values, data schemas, statistics columns, and the recommended write
+directory. The transaction registers the resulting files, enforces protocol compliance, assembles
+commit actions, and delegates the atomic commit to a `Committer`.
 
 **Data-write steps:**
 1. Create `Transaction` from a snapshot with a `Committer` (e.g. `FileSystemCommitter`)

--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -67,7 +67,7 @@ file listing without re-scanning the table.
 
 ## Write Path
 
-`Snapshot` -> `Transaction` -> (`WriteState` -> `WriteContextBuilder` ->
+`Snapshot` -> `Transaction` -> (`WriteState` -> `BoundWriteContextBuilder` ->
 `BoundWriteContext`) -> commit
 
 Kernel captures table-wide configuration in a transportable `WriteState`. Each writer binds

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -380,7 +380,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
     ) -> DeltaResult<Box<dyn EngineData>> {
         let transform = write_context.logical_to_physical();
         let input_schema = Schema::try_from_arrow(data.record_batch().schema())?;
-        let output_schema = write_context.physical_schema();
+        let output_schema = write_context.physical_data_schema();
         let logical_to_physical_expr = self.evaluation_handler().new_expression_evaluator(
             input_schema.into(),
             transform.clone(),

--- a/default-engine/src/parquet.rs
+++ b/default-engine/src/parquet.rs
@@ -260,7 +260,7 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
                 &write_context.write_dir(),
                 data,
                 write_context.stats_columns(),
-                write_context.physical_schema().as_ref(),
+                write_context.physical_data_schema().as_ref(),
             )
             .await?;
         super::build_add_file_metadata(file_metadata, write_context)

--- a/docs/user-guide/src/writing/append.md
+++ b/docs/user-guide/src/writing/append.md
@@ -139,7 +139,8 @@ let write_context = write_state
     .build()?;
 ```
 
-Kernel maps the provided logical column to the corresponding physical materialized column configured on the table.
+Kernel maps each provided logical row-tracking metadata column to the corresponding physical
+column configured on the table. Row Tracking must be enabled when these options are provided.
 
 For partitioned tables, see
 [Writing to Partitioned Tables](./partitioned_writes.md).

--- a/docs/user-guide/src/writing/append.md
+++ b/docs/user-guide/src/writing/append.md
@@ -54,7 +54,12 @@ let write_context = write_state.write_context_builder().build()?;
 // 4. Write Parquet file(s)
 // Assumes the table schema is: name (STRING), age (INTEGER), city (STRING)
 let batch = RecordBatch::try_new(
-    Arc::new(write_context.logical_schema().as_ref().try_into_arrow()?),
+    Arc::new(
+        write_context
+            .logical_data_schema()
+            .as_ref()
+            .try_into_arrow()?,
+    ),
     vec![
         Arc::new(StringArray::from(vec!["Dave", "Eve", "Frank"])),
         Arc::new(Int32Array::from(vec![4, 5, 6])),
@@ -119,6 +124,23 @@ let write_context = write_state
     .build()?;
 ```
 
+If the connector input data contains materialized Row IDs or Row Commit Versions, provide their
+logical column names to the builder:
+
+```rust,ignore
+use delta_kernel::transaction::RowTrackingMetadataColumns;
+
+let write_context = write_state
+    .write_context_builder()
+    .with_row_tracking_columns(RowTrackingMetadataColumns {
+        row_id_col_name: Some("row_id"),
+        row_commit_version_col_name: Some("row_commit_version"),
+    })
+    .build()?;
+```
+
+Kernel maps the provided logical column to the corresponding physical materialized column configured on the table.
+
 For partitioned tables, see
 [Writing to Partitioned Tables](./partitioned_writes.md).
 
@@ -128,8 +150,8 @@ For partitioned tables, see
 |--------|---------|---------|
 | `table_root_dir()` | `&Url` | The table root URL |
 | `write_dir()` | `Url` | The URL for writing files |
-| `logical_schema()` | `&SchemaRef` | The schema your logical data should conform to |
-| `physical_schema()` | `&SchemaRef` | The schema for the on-disk physical data |
+| `logical_data_schema()` | `&SchemaRef` | The schema your connector input data must conform to when using this write context |
+| `physical_data_schema()` | `&SchemaRef` | The schema for the data written to Parquet |
 | `logical_to_physical()` | `ExpressionRef` | Expression that transforms logical data to physical |
 | `column_mapping_mode()` | `ColumnMappingMode` | The column mapping mode for this table |
 | `stats_columns()` | `&[ColumnName]` | Columns that should have statistics collected |
@@ -138,7 +160,7 @@ For partitioned tables, see
 ## Writing Parquet files
 
 Start with the logical `data: EngineData` you want to write. Its schema should conform to
-`write_context.logical_schema()`.
+`write_context.logical_data_schema()`.
 
 ### Using `DefaultEngine`
 
@@ -172,9 +194,9 @@ If you do not use `DefaultEngine`, write the files yourself. The expected flow i
 
 // 1. Transform logical data into physical data
 let evaluator = engine.evaluation_handler().new_expression_evaluator(
-    write_context.logical_schema().clone(),
+    write_context.logical_data_schema().clone(),
     write_context.logical_to_physical(),
-    write_context.physical_schema().clone().into(),
+    write_context.physical_data_schema().clone().into(),
 )?;
 let physical_data = evaluator.evaluate(data.as_ref())?;
 

--- a/docs/user-guide/src/writing/partitioned_writes.md
+++ b/docs/user-guide/src/writing/partitioned_writes.md
@@ -137,7 +137,8 @@ which you can collect into a `Vec<Option<String>>` group key for use in a `HashM
 
 ## Partition value validation
 
-`WriteContextBuilder::build` validates the provided values before creating the `BoundWriteContext`:
+`BoundWriteContextBuilder::build` validates the provided values before creating the
+`BoundWriteContext`:
 
 | Check | Example |
 |-------|---------|

--- a/docs/user-guide/src/writing/partitioned_writes.md
+++ b/docs/user-guide/src/writing/partitioned_writes.md
@@ -114,7 +114,7 @@ Key points:
 - **Case-insensitive keys**: `"YEAR"` matches schema column `"year"`. Kernel normalizes
   to the schema case.
 - **No partition columns in your logical data**: your data batches should follow the logical write
-  schema (`wc.logical_schema()`), which excludes partition columns.
+  schema (`wc.logical_data_schema()`), which excludes partition columns.
 - **Materialization is automatic**: some table features (such as
   `materializePartitionColumns` and `icebergCompatV3`) require partition values to also be
   written into the data files as regular columns. Kernel handles this through the

--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn get_write_schema(
     write_context: Handle<SharedWriteContext>,
 ) -> Handle<SharedSchema> {
     let write_context = unsafe { write_context.as_ref() };
-    write_context.logical_schema().clone().into()
+    write_context.logical_data_schema().clone().into()
 }
 
 /// Returns the physical write schema from a [`BoundWriteContext`] handle: the schema of the data
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn get_physical_write_schema(
     write_context: Handle<SharedWriteContext>,
 ) -> Handle<SharedSchema> {
     let write_context = unsafe { write_context.as_ref() };
-    write_context.physical_schema().clone().into()
+    write_context.physical_data_schema().clone().into()
 }
 
 /// Returns the logical-to-physical expression from a [`BoundWriteContext`] handle. Engines apply

--- a/kernel/src/transaction/bound_write_context.rs
+++ b/kernel/src/transaction/bound_write_context.rs
@@ -14,10 +14,10 @@ use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Error};
 
 /// A write context for a specific partition or an unpartitioned table. Created by a
-/// [`WriteContextBuilder`](super::WriteContextBuilder).
+/// [`BoundWriteContextBuilder`](super::BoundWriteContextBuilder).
 ///
-/// Note: clustered tables are unpartitioned and use [`WriteContextBuilder::build`] without calling
-/// [`with_partition_values`].
+/// Note: clustered tables are unpartitioned and use [`BoundWriteContextBuilder::build`] without
+/// calling [`with_partition_values`].
 ///
 /// Contains both table-wide state and per-partition state (serialized partition values with
 /// physical column names as keys). How you use a `BoundWriteContext` depends on your engine:
@@ -32,8 +32,8 @@ use crate::{DeltaResult, Error};
 ///
 /// [`Transaction::add_files`]: super::Transaction::add_files
 /// [`physical_partition_values`]: BoundWriteContext::physical_partition_values
-/// [`WriteContextBuilder::build`]: super::WriteContextBuilder::build
-/// [`with_partition_values`]: super::WriteContextBuilder::with_partition_values
+/// [`BoundWriteContextBuilder::build`]: super::BoundWriteContextBuilder::build
+/// [`with_partition_values`]: super::BoundWriteContextBuilder::with_partition_values
 #[derive(Debug)]
 pub struct BoundWriteContext {
     pub(super) write_state: Arc<WriteState>,

--- a/kernel/src/transaction/bound_write_context.rs
+++ b/kernel/src/transaction/bound_write_context.rs
@@ -37,6 +37,10 @@ use crate::{DeltaResult, Error};
 #[derive(Debug)]
 pub struct BoundWriteContext {
     pub(super) write_state: Arc<WriteState>,
+    /// Schema expected for to-be-written logical data.
+    pub(super) logical_data_schema: SchemaRef,
+    /// Schema expected in the written Parquet file.
+    pub(super) physical_data_schema: SchemaRef,
     /// Transforms logical data to physical data for writing. The logical data must not contain
     /// any partition columns. The expression injects the partition columns when needed.
     pub(super) logical_to_physical: ExpressionRef,
@@ -136,15 +140,19 @@ impl BoundWriteContext {
         url
     }
 
-    /// Returns the schema which connectors' logical data should conform to.
-    pub fn logical_schema(&self) -> &SchemaRef {
-        &self.write_state.logical_schema
+    /// Returns the schema expected for to-be-written logical data.
+    ///
+    /// This schema contains the Delta schema excluding partition columns, followed by any
+    /// connector-specified Row ID and Row Commit Version columns. If both are present, the Row ID
+    /// column precedes the Row Commit Version column. If the table requires materialized partition
+    /// columns, Kernel inserts them during the logical-to-physical transform.
+    pub fn logical_data_schema(&self) -> &SchemaRef {
+        &self.logical_data_schema
     }
 
-    /// Returns the physical schema (partition columns removed if applicable, column mapping
-    /// applied). Partition columns are kept when `materializePartitionColumns` is enabled.
-    pub fn physical_schema(&self) -> &SchemaRef {
-        &self.write_state.physical_schema
+    /// Returns the schema for data written to Parquet.
+    pub fn physical_data_schema(&self) -> &SchemaRef {
+        &self.physical_data_schema
     }
 
     /// Returns the expression that transforms logical data to physical data for writing.
@@ -289,8 +297,12 @@ mod tests {
         let write_state = Arc::new(WriteState {
             table_root: Url::parse("s3://bucket/table/").unwrap(),
             full_logical_schema: schema.clone(),
-            logical_schema: schema.clone(),
-            physical_schema: schema.clone(),
+            base_logical_data_schema: schema.clone(),
+            base_physical_data_schema: schema.clone(),
+            materialized_row_id_column_name: None,
+            materialized_row_commit_version_column_name: None,
+            row_tracking_enabled: false,
+            iceberg_compat_v3_enabled: false,
             column_mapping_mode: cm_mode,
             stats_columns: vec![],
             logical_partition_columns: partition_columns,
@@ -301,6 +313,8 @@ mod tests {
         });
         BoundWriteContext {
             write_state,
+            logical_data_schema: schema.clone(),
+            physical_data_schema: schema,
             logical_to_physical: Arc::new(lit(true)),
             physical_partition_values: partition_values,
         }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -82,7 +82,7 @@ mod write_validation;
 
 pub use bound_write_context::BoundWriteContext;
 use stats_verifier::StatsColumnVerifier;
-pub use write_state::{RowTrackingMetadataColumns, WriteContextBuilder, WriteState};
+pub use write_state::{BoundWriteContextBuilder, RowTrackingMetadataColumns, WriteState};
 
 /// Type alias for an iterator of [`EngineData`] results.
 pub(crate) type EngineDataResultIterator<'a> =
@@ -3131,6 +3131,7 @@ mod tests {
         )]
         row_tracking_state: RowTrackingState,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        // === Given every column-mapping mode and Row Tracking state ===
         let column_mapping_mode = match mode {
             ColumnMappingMode::None => "none",
             ColumnMappingMode::Name => "name",
@@ -3182,6 +3183,8 @@ mod tests {
             .ok_or_else(|| {
                 Error::internal_error("materialized Row Commit Version column name is missing")
             })?;
+
+        // === When the connector specifies its row-tracking input columns ===
         let write_context = write_state
             .write_context_builder()
             .with_row_tracking_columns(RowTrackingMetadataColumns {
@@ -3189,6 +3192,11 @@ mod tests {
                 row_commit_version_col_name: Some("connector_row_commit_version"),
             })
             .build();
+
+        // === Then ===
+        // Supplying materialized row-tracking columns requires Row Tracking to be enabled.
+        // Logical data schema, physical data schema, and logical_to_physical expression must be
+        // generated correctly.
         if row_tracking_state != RowTrackingState::Enabled {
             assert_result_error_with_message(
                 write_context,
@@ -3198,7 +3206,6 @@ mod tests {
             return Ok(());
         }
         let write_context = write_context?;
-
         assert_eq!(
             write_context.logical_data_schema(),
             &schema_ref! {

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -82,7 +82,7 @@ mod write_validation;
 
 pub use bound_write_context::BoundWriteContext;
 use stats_verifier::StatsColumnVerifier;
-pub use write_state::{WriteContextBuilder, WriteState};
+pub use write_state::{RowTrackingMetadataColumns, WriteContextBuilder, WriteState};
 
 /// Type alias for an iterator of [`EngineData`] results.
 pub(crate) type EngineDataResultIterator<'a> =
@@ -1702,15 +1702,17 @@ mod tests {
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::scan::log_replay::PATH_NAME;
+    use crate::scan::state_info::tests::RowTrackingState;
     use crate::schema::{schema, schema_ref, MapType};
     use crate::table_features::ColumnMappingMode;
     use crate::table_properties::APPEND_ONLY;
     use crate::transaction::create_table::create_table;
     use crate::transaction::data_layout::DataLayout;
     use crate::unit_test_utils::{
-        copy_test_table, create_valid_add_file_batch, install_thread_local_metrics_reporter,
-        load_test_table, string_array_to_engine_data, test_schema_flat, test_schema_nested,
-        test_schema_with_array, test_schema_with_map, CapturingReporter,
+        assert_result_error_with_message, copy_test_table, create_valid_add_file_batch,
+        install_thread_local_metrics_reporter, load_test_table, string_array_to_engine_data,
+        test_schema_flat, test_schema_nested, test_schema_with_array, test_schema_with_map,
+        CapturingReporter,
     };
     use crate::{DeltaResultIterator, EvaluationHandler, Snapshot};
 
@@ -2029,7 +2031,7 @@ mod tests {
         let initial_write_state = txn.write_state()?;
         let initial_write_context = initial_write_state.write_context_builder().build()?;
         assert!(!initial_write_context
-            .logical_schema()
+            .logical_data_schema()
             .contains("fresh_column"));
 
         let evolved_schema = schema_ref! {
@@ -2051,13 +2053,13 @@ mod tests {
         let updated_write_state = txn.write_state()?;
         let updated_write_context = updated_write_state.write_context_builder().build()?;
         assert!(updated_write_context
-            .logical_schema()
+            .logical_data_schema()
             .contains("fresh_column"));
         assert!(updated_write_context
-            .physical_schema()
+            .physical_data_schema()
             .contains("fresh_column"));
         assert!(!initial_write_context
-            .logical_schema()
+            .logical_data_schema()
             .contains("fresh_column"));
 
         Ok(())
@@ -2212,8 +2214,8 @@ mod tests {
                 Scalar::String("a".into()),
             )]))
             .build()?;
-        let logical_schema = write_context.logical_schema();
-        let physical_schema = write_context.physical_schema();
+        let logical_schema = write_context.logical_data_schema();
+        let physical_schema = write_context.physical_data_schema();
 
         // Both schemas exclude partition columns.
         assert!(
@@ -2267,7 +2269,7 @@ mod tests {
         batch: RecordBatch,
     ) -> Result<RecordBatch, Box<dyn std::error::Error>> {
         let input_schema = StructType::try_from_arrow(batch.schema())?;
-        let physical_schema = wc.physical_schema();
+        let physical_schema = wc.physical_data_schema();
         let l2p = wc.logical_to_physical();
 
         let handler = ArrowEvaluationHandler;
@@ -2398,7 +2400,7 @@ mod tests {
             .iter()
             .map(|f| f.name().as_str())
             .collect();
-        let physical_schema = wc.physical_schema();
+        let physical_schema = wc.physical_data_schema();
         let expected_names: Vec<&str> = physical_schema
             .fields()
             .map(|f| f.name().as_str())
@@ -2424,7 +2426,7 @@ mod tests {
             "./tests/data/partitioned_with_materialize_feature/",
             HashMap::from([("letter".to_string(), Scalar::String("a".into()))]),
         )?;
-        let physical_schema = write_context.physical_schema();
+        let physical_schema = write_context.physical_data_schema();
 
         assert!(
             physical_schema.contains("letter"),
@@ -3017,8 +3019,8 @@ mod tests {
         let write_state = txn.write_state().unwrap();
         let write_context = write_state.write_context_builder().build().unwrap();
         crate::unit_test_utils::validate_physical_schema_column_mapping(
-            write_context.logical_schema(),
-            write_context.physical_schema(),
+            write_context.logical_data_schema(),
+            write_context.physical_data_schema(),
             mode,
         );
         Ok(())
@@ -3066,8 +3068,8 @@ mod tests {
         let (_engine, txn) = crate::unit_test_utils::setup_column_mapping_txn(schema, mode)?;
         let write_state = txn.write_state().unwrap();
         let write_context = write_state.write_context_builder().build().unwrap();
-        let logical_schema = write_context.logical_schema();
-        let physical_schema = write_context.physical_schema();
+        let logical_schema = write_context.logical_data_schema();
+        let physical_schema = write_context.physical_data_schema();
         let logical_to_physical_expression = write_context.logical_to_physical();
 
         if mode != ColumnMappingMode::None {
@@ -3112,6 +3114,114 @@ mod tests {
     #[case::none_mode(ColumnMappingMode::None)]
     fn test_logical_to_physical_transform(#[case] mode: ColumnMappingMode) -> DeltaResult<()> {
         validate_logical_to_physical_transform(mode)
+    }
+
+    #[rstest]
+    fn test_logical_to_physical_transform_and_row_tracking_state(
+        #[values(
+            ColumnMappingMode::None,
+            ColumnMappingMode::Name,
+            ColumnMappingMode::Id
+        )]
+        mode: ColumnMappingMode,
+        #[values(
+            RowTrackingState::Enabled,
+            RowTrackingState::SupportedNotEnabled,
+            RowTrackingState::Suspended
+        )]
+        row_tracking_state: RowTrackingState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let column_mapping_mode = match mode {
+            ColumnMappingMode::None => "none",
+            ColumnMappingMode::Name => "name",
+            ColumnMappingMode::Id => "id",
+        };
+        let engine: Arc<dyn Engine> =
+            Arc::new(SyncEngine::new_with_store(Arc::new(InMemory::new())));
+        let mut txn = create_table(
+            "memory:///row_tracking_logical_to_physical",
+            schema_ref! { nullable "value": INTEGER },
+            "test",
+        )
+        .with_table_properties([
+            ("delta.columnMapping.mode", column_mapping_mode),
+            ("delta.feature.rowTracking", "supported"),
+        ])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        let mut metadata = txn.effective_table_config.metadata().clone();
+        for (key, value) in row_tracking_state.properties() {
+            metadata = metadata.with_configuration_entry(key, value);
+        }
+        let logical_schema = txn.effective_table_config.logical_schema();
+        let table_config = TableConfiguration::try_new_with_schema(
+            &txn.effective_table_config,
+            metadata,
+            logical_schema,
+        )?;
+        txn.replace_effective_table_config(table_config);
+        let write_state = txn.write_state()?;
+        let base_logical_field = write_state
+            .base_logical_data_schema
+            .fields()
+            .next()
+            .ok_or_else(|| Error::internal_error("base logical data field is missing"))?
+            .clone();
+        let base_physical_field = write_state
+            .base_physical_data_schema
+            .fields()
+            .next()
+            .ok_or_else(|| Error::internal_error("base physical data field is missing"))?
+            .clone();
+        let physical_row_id_name = write_state
+            .materialized_row_id_column_name
+            .clone()
+            .ok_or_else(|| Error::internal_error("materialized Row ID column name is missing"))?;
+        let physical_row_commit_version_name = write_state
+            .materialized_row_commit_version_column_name
+            .clone()
+            .ok_or_else(|| {
+                Error::internal_error("materialized Row Commit Version column name is missing")
+            })?;
+        let write_context = write_state
+            .write_context_builder()
+            .with_row_tracking_columns(RowTrackingMetadataColumns {
+                row_id_col_name: Some("connector_row_id"),
+                row_commit_version_col_name: Some("connector_row_commit_version"),
+            })
+            .build();
+        if row_tracking_state != RowTrackingState::Enabled {
+            assert_result_error_with_message(
+                write_context,
+                "Kernel does not allow writing materialized Row IDs or Row Commit Versions when \
+                 Row Tracking is not enabled",
+            );
+            return Ok(());
+        }
+        let write_context = write_context?;
+
+        assert_eq!(
+            write_context.logical_data_schema(),
+            &schema_ref! {
+                (base_logical_field),
+                nullable "connector_row_id": LONG,
+                nullable "connector_row_commit_version": LONG,
+            }
+        );
+        assert_eq!(
+            write_context.physical_data_schema(),
+            &schema_ref! {
+                (base_physical_field),
+                nullable (physical_row_id_name): LONG,
+                nullable (physical_row_commit_version_name): LONG,
+            }
+        );
+        assert_eq!(
+            write_context.logical_to_physical(),
+            Arc::new(Expression::struct_patch(
+                ExpressionStructPatchBuilder::new()
+            )?)
+        );
+        Ok(())
     }
 
     // =========================================================================

--- a/kernel/src/transaction/write_state.rs
+++ b/kernel/src/transaction/write_state.rs
@@ -10,9 +10,9 @@ use crate::expressions::{lit, ColumnName, ExpressionStructPatchBuilder, Scalar};
 use crate::partition::serialization::serialize_partition_value;
 use crate::partition::validation::validate_partition_values;
 use crate::schema::void_utils::add_void_stripping;
-use crate::schema::SchemaRef;
+use crate::schema::{SchemaRef, StructField, StructType};
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::ColumnMappingMode;
+use crate::table_features::{ColumnMappingMode, TableFeature};
 use crate::utils::require;
 use crate::{DataType, DeltaResult, Error, Expression};
 
@@ -32,16 +32,24 @@ pub struct WriteState {
     /// Partition binding needs this schema to validate values, preserve metadata-defined field
     /// order, and translate logical partition names to their physical names.
     pub(super) full_logical_schema: SchemaRef,
-    /// Logical schema accepted from the writer, with partition columns removed.
+    /// Base logical data schema: delta schema with partition columns removed.
     ///
     /// Connectors write one partition at a time, so partition values are bound separately rather
     /// than appearing in each input data batch.
-    pub(super) logical_schema: SchemaRef,
-    /// Physical schema expected in the written Parquet file.
+    pub(super) base_logical_data_schema: SchemaRef,
+    /// Base physical schema expected in the written Parquet file.
     ///
-    /// This differs from both logical schemas when column mapping, void stripping, or partition
-    /// materialization changes the data passed to the Parquet writer.
-    pub(super) physical_schema: SchemaRef,
+    /// This differs from the logical schemas when column mapping, void stripping, partition
+    /// materialization, or row tracking changes the data passed to the Parquet writer.
+    pub(super) base_physical_data_schema: SchemaRef,
+    /// Physical name of the materialized Row ID column, when configured on the table.
+    pub(super) materialized_row_id_column_name: Option<String>,
+    /// Physical name of the materialized Row Commit Version column, when configured on the table.
+    pub(super) materialized_row_commit_version_column_name: Option<String>,
+    /// Whether Row Tracking is enabled and not suspended on the table.
+    pub(super) row_tracking_enabled: bool,
+    /// Whether IcebergCompatV3 is enabled on the table.
+    pub(super) iceberg_compat_v3_enabled: bool,
     pub(super) column_mapping_mode: ColumnMappingMode,
     pub(super) stats_columns: Vec<ColumnName>,
     /// Logical partition column names in metadata-defined order.
@@ -57,11 +65,29 @@ pub struct WriteState {
     pub(super) random_prefix_length: NonZero<usize>,
 }
 
+/// Names of materialized row-tracking id/commit-version columns supplied by a connector.
+///
+/// See [Row Tracking] in the Delta protocol for details about materialized Row ID and Row Commit
+/// Version columns.
+///
+/// [Row Tracking]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#row-tracking
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RowTrackingMetadataColumns<'a> {
+    /// Name of the column containing materialized Row IDs, if present in the to-be-written logical
+    /// data.
+    pub row_id_col_name: Option<&'a str>,
+    /// Name of the column containing materialized Row Commit Versions, if present in the
+    /// to-be-written logical data.
+    pub row_commit_version_col_name: Option<&'a str>,
+}
+
 /// Builds a [`BoundWriteContext`].
 #[derive(Debug)]
 pub struct WriteContextBuilder {
     write_state: Arc<WriteState>,
     partition_values: Option<HashMap<String, Scalar>>,
+    logical_row_id_col_name: Option<String>,
+    logical_row_commit_version_col_name: Option<String>,
 }
 
 impl WriteContextBuilder {
@@ -78,10 +104,34 @@ impl WriteContextBuilder {
         self
     }
 
+    /// Specifies which columns contain materialized Row IDs and Row Commit Versions in the
+    /// to-be-written logical data.
+    pub fn with_row_tracking_columns(
+        mut self,
+        row_tracking_columns: RowTrackingMetadataColumns<'_>,
+    ) -> Self {
+        self.logical_row_id_col_name = row_tracking_columns.row_id_col_name.map(str::to_string);
+        self.logical_row_commit_version_col_name = row_tracking_columns
+            .row_commit_version_col_name
+            .map(str::to_string);
+        self
+    }
+
     /// Builds the write context.
     ///
-    /// Returns an error if partition values are present for an unpartitioned table, absent for a
-    /// partitioned table, or invalid.
+    /// Returns an error if:
+    ///
+    /// - Partition values are present for an unpartitioned table, absent for a partitioned table,
+    ///   or invalid.
+    /// - The connector specifies a column containing materialized Row IDs or Row Commit Versions
+    ///   when Row Tracking is not enabled.
+    /// - The connector specifies a column containing materialized Row IDs or Row Commit Versions
+    ///   for an IcebergCompatV3 table, which Kernel currently does not support writing
+    ///   (TODO(#2492)).
+    /// - The connector specifies a row-tracking metadata column, but its materialized column name
+    ///   is not in the table properties.
+    /// - The connector specifies a row-tracking metadata column that conflicts with another logical
+    ///   field.
     pub fn build(self) -> DeltaResult<BoundWriteContext> {
         let is_partitioned = !self.write_state.logical_partition_columns.is_empty();
         require!(
@@ -94,6 +144,23 @@ impl WriteContextBuilder {
             !is_partitioned || self.partition_values.is_some(),
             Error::invalid_partition_values("table is partitioned; partition values are required")
         );
+        let has_row_tracking_columns = self.logical_row_id_col_name.is_some()
+            || self.logical_row_commit_version_col_name.is_some();
+        require!(
+            !has_row_tracking_columns || self.write_state.row_tracking_enabled,
+            Error::unsupported(
+                "Kernel does not allow writing materialized Row IDs or Row Commit Versions when \
+                 Row Tracking is not enabled"
+            )
+        );
+        require!(
+            !has_row_tracking_columns || !self.write_state.iceberg_compat_v3_enabled,
+            Error::unsupported(
+                "Kernel does not support writing materialized Row IDs or Row Commit Versions to \
+                 IcebergCompatV3 tables"
+            )
+        );
+
         let normalized = self
             .partition_values
             .map(|partition_values| {
@@ -128,6 +195,69 @@ impl WriteContextBuilder {
                 serialized.insert(physical_name, value);
             }
         }
+        let mut physical_row_tracking_columns = Vec::with_capacity(2);
+        if let Some(logical_name) = self.logical_row_id_col_name {
+            let physical_name = self
+                .write_state
+                .materialized_row_id_column_name
+                .clone()
+                .ok_or_else(|| {
+                    Error::generic(
+                        "No delta.rowTracking.materializedRowIdColumnName key found in metadata \
+                         configuration",
+                    )
+                })?;
+            physical_row_tracking_columns.push((logical_name, physical_name));
+        }
+        if let Some(logical_name) = self.logical_row_commit_version_col_name {
+            let physical_name = self
+                .write_state
+                .materialized_row_commit_version_column_name
+                .clone()
+                .ok_or_else(|| {
+                    Error::generic(
+                        "No delta.rowTracking.materializedRowCommitVersionColumnName key found in \
+                         metadata configuration",
+                    )
+                })?;
+            physical_row_tracking_columns.push((logical_name, physical_name));
+        }
+        let (logical_data_schema, physical_data_schema) =
+            if physical_row_tracking_columns.is_empty() {
+                (
+                    self.write_state.base_logical_data_schema.clone(),
+                    self.write_state.base_physical_data_schema.clone(),
+                )
+            } else {
+                let logical_fields = self
+                    .write_state
+                    .base_logical_data_schema
+                    .fields()
+                    .cloned()
+                    .chain(
+                        physical_row_tracking_columns
+                            .iter()
+                            .map(|(logical_name, _)| {
+                                StructField::nullable(logical_name, DataType::LONG)
+                            }),
+                    );
+                let physical_fields = self
+                    .write_state
+                    .base_physical_data_schema
+                    .fields()
+                    .cloned()
+                    .chain(
+                        physical_row_tracking_columns
+                            .iter()
+                            .map(|(_, physical_name)| {
+                                StructField::nullable(physical_name, DataType::LONG)
+                            }),
+                    );
+                (
+                    Arc::new(StructType::try_new(logical_fields)?),
+                    Arc::new(StructType::try_new(physical_fields)?),
+                )
+            };
         let logical_to_physical = Arc::new(
             self.write_state
                 .generate_logical_to_physical(normalized.as_ref())?,
@@ -135,6 +265,8 @@ impl WriteContextBuilder {
 
         Ok(BoundWriteContext {
             write_state: self.write_state,
+            logical_data_schema,
+            physical_data_schema,
             logical_to_physical,
             physical_partition_values: serialized,
         })
@@ -162,6 +294,8 @@ impl WriteState {
         WriteContextBuilder {
             write_state: Arc::clone(self),
             partition_values: None,
+            logical_row_id_col_name: None,
+            logical_row_commit_version_col_name: None,
         }
     }
 
@@ -202,8 +336,15 @@ impl WriteState {
         Self {
             table_root: table_config.table_root().clone(),
             full_logical_schema: table_config.logical_schema(),
-            logical_schema: table_config.logical_schema_without_partition_columns(),
-            physical_schema: table_config.physical_write_schema(),
+            base_logical_data_schema: table_config.logical_schema_without_partition_columns(),
+            base_physical_data_schema: table_config.physical_write_schema(),
+            materialized_row_id_column_name: props.materialized_row_id_column_name.clone(),
+            materialized_row_commit_version_column_name: props
+                .materialized_row_commit_version_column_name
+                .clone(),
+            row_tracking_enabled: table_config.is_feature_enabled(&TableFeature::RowTracking),
+            iceberg_compat_v3_enabled: table_config
+                .is_feature_enabled(&TableFeature::IcebergCompatV3),
             column_mapping_mode: table_config.column_mapping_mode(),
             stats_columns,
             logical_partition_columns: table_config.logical_partition_columns().to_vec(),
@@ -335,7 +476,18 @@ mod tests {
         let encoded = original.encode().unwrap();
         let decoded = WriteState::decode(&encoded).unwrap();
         assert_eq!(decoded.full_logical_schema, original.full_logical_schema);
-        assert_eq!(decoded.logical_schema, original.logical_schema);
+        assert_eq!(
+            decoded.base_logical_data_schema,
+            original.base_logical_data_schema
+        );
+        assert_eq!(
+            decoded.materialized_row_id_column_name,
+            original.materialized_row_id_column_name
+        );
+        assert_eq!(
+            decoded.materialized_row_commit_version_column_name,
+            original.materialized_row_commit_version_column_name
+        );
 
         let values = || HashMap::from([("year".to_string(), Scalar::Integer(2024))]);
         let original_context = original
@@ -356,12 +508,12 @@ mod tests {
             original_context.table_root_dir()
         );
         assert_eq!(
-            decoded_context.logical_schema(),
-            original_context.logical_schema()
+            decoded_context.logical_data_schema(),
+            original_context.logical_data_schema()
         );
         assert_eq!(
-            decoded_context.physical_schema(),
-            original_context.physical_schema()
+            decoded_context.physical_data_schema(),
+            original_context.physical_data_schema()
         );
         assert_eq!(
             decoded_context.stats_columns(),
@@ -400,6 +552,155 @@ mod tests {
         } else {
             assert_eq!(write_dir, "/table/year=2024/");
         }
+    }
+
+    #[rstest]
+    #[case::both(RowTrackingMetadataColumns {
+        row_id_col_name: Some("connector_row_id"),
+        row_commit_version_col_name: Some("connector_row_commit_version"),
+    })]
+    #[case::row_id_only(RowTrackingMetadataColumns {
+        row_id_col_name: Some("connector_row_id"),
+        row_commit_version_col_name: None,
+    })]
+    #[case::row_commit_version_only(RowTrackingMetadataColumns {
+        row_id_col_name: None,
+        row_commit_version_col_name: Some("connector_row_commit_version"),
+    })]
+    fn build_write_context_with_row_tracking_columns(
+        #[case] row_tracking_columns: RowTrackingMetadataColumns<'_>,
+        #[values(
+            ColumnMappingMode::None,
+            ColumnMappingMode::Name,
+            ColumnMappingMode::Id
+        )]
+        column_mapping_mode: ColumnMappingMode,
+    ) -> DeltaResult<()> {
+        let mut write_state = partitioned_write_state(
+            column_mapping_mode,
+            false, /* materialize_partition_columns */
+            false, /* randomize_file_prefixes */
+            2,     /* random_prefix_length */
+        );
+        let state = Arc::get_mut(&mut write_state).unwrap();
+        state.materialized_row_id_column_name = Some("_metadata_row_id".into());
+        state.materialized_row_commit_version_column_name =
+            Some("_metadata_row_commit_version".into());
+        state.row_tracking_enabled = true;
+
+        let write_state = WriteState::decode(&write_state.encode()?)?;
+        let base_logical_field = write_state
+            .base_logical_data_schema
+            .fields()
+            .next()
+            .unwrap()
+            .clone();
+        let base_physical_field = write_state
+            .base_physical_data_schema
+            .fields()
+            .next()
+            .unwrap()
+            .clone();
+        let write_context = write_state
+            .write_context_builder()
+            .with_partition_values(HashMap::from([("year".to_string(), Scalar::Integer(2024))]))
+            .with_row_tracking_columns(row_tracking_columns)
+            .build()?;
+
+        let mut expected_logical_fields = vec![base_logical_field];
+        let mut expected_physical_fields = vec![base_physical_field];
+        if let Some(row_id_name) = row_tracking_columns.row_id_col_name {
+            expected_logical_fields.push(StructField::nullable(row_id_name, DataType::LONG));
+            expected_physical_fields
+                .push(StructField::nullable("_metadata_row_id", DataType::LONG));
+        }
+        if let Some(row_commit_version_name) = row_tracking_columns.row_commit_version_col_name {
+            expected_logical_fields.push(StructField::nullable(
+                row_commit_version_name,
+                DataType::LONG,
+            ));
+            expected_physical_fields.push(StructField::nullable(
+                "_metadata_row_commit_version",
+                DataType::LONG,
+            ));
+        }
+
+        assert_eq!(
+            write_context.logical_data_schema(),
+            &Arc::new(StructType::try_new(expected_logical_fields)?)
+        );
+        assert_eq!(
+            write_context.physical_data_schema(),
+            &Arc::new(StructType::try_new(expected_physical_fields)?)
+        );
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::row_id(
+        RowTrackingMetadataColumns {
+            row_id_col_name: Some("connector_row_id"),
+            row_commit_version_col_name: None,
+        },
+        "delta.rowTracking.materializedRowIdColumnName",
+    )]
+    #[case::row_commit_version(
+        RowTrackingMetadataColumns {
+            row_id_col_name: None,
+            row_commit_version_col_name: Some("connector_row_commit_version"),
+        },
+        "delta.rowTracking.materializedRowCommitVersionColumnName",
+    )]
+    fn write_context_rejects_row_tracking_column_without_physical_name(
+        #[case] row_tracking_columns: RowTrackingMetadataColumns<'_>,
+        #[case] expected_error: &str,
+    ) {
+        let mut write_state = partitioned_write_state(
+            ColumnMappingMode::None,
+            false, /* materialize_partition_columns */
+            false, /* randomize_file_prefixes */
+            2,     /* random_prefix_length */
+        );
+        Arc::get_mut(&mut write_state).unwrap().row_tracking_enabled = true;
+
+        let error = write_state
+            .write_context_builder()
+            .with_partition_values(HashMap::from([("year".to_string(), Scalar::Integer(2024))]))
+            .with_row_tracking_columns(row_tracking_columns)
+            .build()
+            .unwrap_err();
+        assert!(error.to_string().contains(expected_error));
+    }
+
+    #[rstest]
+    #[case::existing_data_column("VaLuE", "connector_row_commit_version")]
+    #[case::id_version_same_name("tracking", "TRACKING")]
+    fn write_context_rejects_duplicate_logical_row_tracking_names(
+        #[case] row_id_name: &str,
+        #[case] row_commit_version_name: &str,
+    ) {
+        let mut write_state = partitioned_write_state(
+            ColumnMappingMode::None,
+            false, /* materialize_partition_columns */
+            false, /* randomize_file_prefixes */
+            2,     /* random_prefix_length */
+        );
+        let state = Arc::get_mut(&mut write_state).unwrap();
+        state.materialized_row_id_column_name = Some("_metadata_row_id".into());
+        state.materialized_row_commit_version_column_name =
+            Some("_metadata_row_commit_version".into());
+        state.row_tracking_enabled = true;
+
+        let error = write_state
+            .write_context_builder()
+            .with_partition_values(HashMap::from([("year".to_string(), Scalar::Integer(2024))]))
+            .with_row_tracking_columns(RowTrackingMetadataColumns {
+                row_id_col_name: Some(row_id_name),
+                row_commit_version_col_name: Some(row_commit_version_name),
+            })
+            .build()
+            .unwrap_err();
+        assert!(error.to_string().to_ascii_lowercase().contains("duplicate"));
     }
 
     #[test]

--- a/kernel/src/transaction/write_state.rs
+++ b/kernel/src/transaction/write_state.rs
@@ -13,6 +13,9 @@ use crate::schema::void_utils::add_void_stripping;
 use crate::schema::{SchemaRef, StructField, StructType};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{ColumnMappingMode, TableFeature};
+use crate::table_properties::{
+    MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME, MATERIALIZED_ROW_ID_COLUMN_NAME,
+};
 use crate::utils::require;
 use crate::{DataType, DeltaResult, Error, Expression};
 
@@ -32,15 +35,16 @@ pub struct WriteState {
     /// Partition binding needs this schema to validate values, preserve metadata-defined field
     /// order, and translate logical partition names to their physical names.
     pub(super) full_logical_schema: SchemaRef,
-    /// Base logical data schema: delta schema with partition columns removed.
+    /// Base logical data schema: the Delta schema excluding partition columns.
     ///
-    /// Connectors write one partition at a time, so partition values are bound separately rather
-    /// than appearing in each input data batch.
+    /// [`BoundWriteContextBuilder`] appends any connector-specified Row ID and Row Commit Version
+    /// columns to construct the final [`BoundWriteContext::logical_data_schema`].
     pub(super) base_logical_data_schema: SchemaRef,
-    /// Base physical schema expected in the written Parquet file.
+    /// Base physical data schema used by [`BoundWriteContextBuilder`] to construct the final
+    /// [`BoundWriteContext::physical_data_schema`].
     ///
-    /// This differs from the logical schemas when column mapping, void stripping, partition
-    /// materialization, or row tracking changes the data passed to the Parquet writer.
+    /// The builder appends the table's physical materialized Row ID and Row Commit Version columns
+    /// when the connector supplies their logical counterparts.
     pub(super) base_physical_data_schema: SchemaRef,
     /// Physical name of the materialized Row ID column, when configured on the table.
     pub(super) materialized_row_id_column_name: Option<String>,
@@ -73,24 +77,24 @@ pub struct WriteState {
 /// [Row Tracking]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#row-tracking
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RowTrackingMetadataColumns<'a> {
-    /// Name of the column containing materialized Row IDs, if present in the to-be-written logical
+    /// Logical name of the column containing materialized Row IDs, if present in the to-be-written
     /// data.
     pub row_id_col_name: Option<&'a str>,
-    /// Name of the column containing materialized Row Commit Versions, if present in the
-    /// to-be-written logical data.
+    /// Logical name of the column containing materialized Row Commit Versions, if present in the
+    /// to-be-written data.
     pub row_commit_version_col_name: Option<&'a str>,
 }
 
 /// Builds a [`BoundWriteContext`].
 #[derive(Debug)]
-pub struct WriteContextBuilder {
+pub struct BoundWriteContextBuilder {
     write_state: Arc<WriteState>,
     partition_values: Option<HashMap<String, Scalar>>,
     logical_row_id_col_name: Option<String>,
     logical_row_commit_version_col_name: Option<String>,
 }
 
-impl WriteContextBuilder {
+impl BoundWriteContextBuilder {
     /// Binds one typed value for each logical partition column.
     ///
     /// Values are validated and serialized according to the Delta protocol when
@@ -160,6 +164,8 @@ impl WriteContextBuilder {
                  IcebergCompatV3 tables"
             )
         );
+        let logical_data_schema = self.build_logical_data_schema()?;
+        let physical_data_schema = self.build_physical_data_schema()?;
 
         let normalized = self
             .partition_values
@@ -195,69 +201,6 @@ impl WriteContextBuilder {
                 serialized.insert(physical_name, value);
             }
         }
-        let mut physical_row_tracking_columns = Vec::with_capacity(2);
-        if let Some(logical_name) = self.logical_row_id_col_name {
-            let physical_name = self
-                .write_state
-                .materialized_row_id_column_name
-                .clone()
-                .ok_or_else(|| {
-                    Error::generic(
-                        "No delta.rowTracking.materializedRowIdColumnName key found in metadata \
-                         configuration",
-                    )
-                })?;
-            physical_row_tracking_columns.push((logical_name, physical_name));
-        }
-        if let Some(logical_name) = self.logical_row_commit_version_col_name {
-            let physical_name = self
-                .write_state
-                .materialized_row_commit_version_column_name
-                .clone()
-                .ok_or_else(|| {
-                    Error::generic(
-                        "No delta.rowTracking.materializedRowCommitVersionColumnName key found in \
-                         metadata configuration",
-                    )
-                })?;
-            physical_row_tracking_columns.push((logical_name, physical_name));
-        }
-        let (logical_data_schema, physical_data_schema) =
-            if physical_row_tracking_columns.is_empty() {
-                (
-                    self.write_state.base_logical_data_schema.clone(),
-                    self.write_state.base_physical_data_schema.clone(),
-                )
-            } else {
-                let logical_fields = self
-                    .write_state
-                    .base_logical_data_schema
-                    .fields()
-                    .cloned()
-                    .chain(
-                        physical_row_tracking_columns
-                            .iter()
-                            .map(|(logical_name, _)| {
-                                StructField::nullable(logical_name, DataType::LONG)
-                            }),
-                    );
-                let physical_fields = self
-                    .write_state
-                    .base_physical_data_schema
-                    .fields()
-                    .cloned()
-                    .chain(
-                        physical_row_tracking_columns
-                            .iter()
-                            .map(|(_, physical_name)| {
-                                StructField::nullable(physical_name, DataType::LONG)
-                            }),
-                    );
-                (
-                    Arc::new(StructType::try_new(logical_fields)?),
-                    Arc::new(StructType::try_new(physical_fields)?),
-                )
-            };
         let logical_to_physical = Arc::new(
             self.write_state
                 .generate_logical_to_physical(normalized.as_ref())?,
@@ -270,6 +213,71 @@ impl WriteContextBuilder {
             logical_to_physical,
             physical_partition_values: serialized,
         })
+    }
+
+    fn build_logical_data_schema(&self) -> DeltaResult<SchemaRef> {
+        if self.logical_row_id_col_name.is_none()
+            && self.logical_row_commit_version_col_name.is_none()
+        {
+            return Ok(self.write_state.base_logical_data_schema.clone());
+        }
+        let mut fields: Vec<_> = self
+            .write_state
+            .base_logical_data_schema
+            .fields()
+            .cloned()
+            .collect();
+        if let Some(logical_name) = self.logical_row_id_col_name.as_deref() {
+            fields.push(StructField::nullable(logical_name, DataType::LONG));
+        }
+        if let Some(logical_name) = self.logical_row_commit_version_col_name.as_deref() {
+            fields.push(StructField::nullable(logical_name, DataType::LONG));
+        }
+        Ok(Arc::new(StructType::try_new(fields)?))
+    }
+
+    fn build_physical_data_schema(&self) -> DeltaResult<SchemaRef> {
+        if self.logical_row_id_col_name.is_none()
+            && self.logical_row_commit_version_col_name.is_none()
+        {
+            return Ok(self.write_state.base_physical_data_schema.clone());
+        }
+        let mut fields: Vec<_> = self
+            .write_state
+            .base_physical_data_schema
+            .fields()
+            .cloned()
+            .collect();
+        fields.extend(Self::build_physical_row_tracking_field(
+            self.logical_row_id_col_name.as_deref(),
+            self.write_state.materialized_row_id_column_name.as_deref(),
+            MATERIALIZED_ROW_ID_COLUMN_NAME,
+        )?);
+        fields.extend(Self::build_physical_row_tracking_field(
+            self.logical_row_commit_version_col_name.as_deref(),
+            self.write_state
+                .materialized_row_commit_version_column_name
+                .as_deref(),
+            MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
+        )?);
+        Ok(Arc::new(StructType::try_new(fields)?))
+    }
+
+    fn build_physical_row_tracking_field(
+        logical_name: Option<&str>,
+        physical_name: Option<&str>,
+        configuration_key: &str,
+    ) -> DeltaResult<Option<StructField>> {
+        if logical_name.is_none() {
+            return Ok(None);
+        }
+        let physical_name = physical_name.ok_or_else(|| {
+            Error::invalid_protocol(format!(
+                "The table has Row Tracking enabled, but {configuration_key} is missing from its \
+                 metadata configuration"
+            ))
+        })?;
+        Ok(Some(StructField::nullable(physical_name, DataType::LONG)))
     }
 }
 
@@ -288,10 +296,10 @@ struct DecodedWriteStateWire {
 impl WriteState {
     /// Creates a builder for a write context.
     ///
-    /// For an unpartitioned table, call [`WriteContextBuilder::build`] directly. For a partitioned
-    /// table, call [`WriteContextBuilder::with_partition_values`] first.
-    pub fn write_context_builder(self: &Arc<Self>) -> WriteContextBuilder {
-        WriteContextBuilder {
+    /// For an unpartitioned table, call [`BoundWriteContextBuilder::build`] directly. For a
+    /// partitioned table, call [`BoundWriteContextBuilder::with_partition_values`] first.
+    pub fn write_context_builder(self: &Arc<Self>) -> BoundWriteContextBuilder {
+        BoundWriteContextBuilder {
             write_state: Arc::clone(self),
             partition_values: None,
             logical_row_id_col_name: None,
@@ -413,6 +421,7 @@ mod tests {
         materialize_partition_columns: bool,
         randomize_file_prefixes: bool,
         random_prefix_length: usize,
+        row_tracking_enabled: bool,
     ) -> Arc<WriteState> {
         let mut properties = HashMap::new();
         if column_mapping_mode != ColumnMappingMode::None {
@@ -452,27 +461,43 @@ mod tests {
         let state = Arc::get_mut(&mut write_state).unwrap();
         state.randomize_file_prefixes = randomize_file_prefixes;
         state.random_prefix_length = NonZero::new(random_prefix_length).unwrap();
+        state.row_tracking_enabled = row_tracking_enabled;
         write_state
     }
 
     #[rstest]
-    #[case::default(ColumnMappingMode::None, false, false, 2, false)]
-    #[case::column_mapping(ColumnMappingMode::Name, false, false, 7, true)]
-    #[case::materialized_partition(ColumnMappingMode::None, true, false, 2, false)]
-    #[case::randomized_prefix(ColumnMappingMode::None, false, true, 7, true)]
+    #[case::default(ColumnMappingMode::None, false, false, 2, false, false, false)]
+    #[case::column_mapping(ColumnMappingMode::Name, false, false, 7, false, false, true)]
+    #[case::materialized_partition(ColumnMappingMode::None, true, false, 2, false, false, false)]
+    #[case::randomized_prefix(ColumnMappingMode::None, false, true, 7, false, false, true)]
+    #[case::row_tracking(ColumnMappingMode::None, false, false, 2, true, false, false)]
+    #[case::row_tracking_and_iceberg_compat_v3(
+        ColumnMappingMode::Name,
+        false,
+        false,
+        2,
+        true,
+        true,
+        true
+    )]
     fn write_state_json_round_trip_preserves_worker_behavior(
         #[case] column_mapping_mode: ColumnMappingMode,
         #[case] materialize_partition_columns: bool,
         #[case] randomize_file_prefixes: bool,
         #[case] random_prefix_length: usize,
+        #[case] row_tracking_enabled: bool,
+        #[case] iceberg_compat_v3_enabled: bool,
         #[case] expect_random_prefix: bool,
     ) {
-        let original = partitioned_write_state(
+        let mut original = partitioned_write_state(
             column_mapping_mode,
             materialize_partition_columns,
             randomize_file_prefixes,
             random_prefix_length,
+            row_tracking_enabled,
         );
+        let state = Arc::get_mut(&mut original).unwrap();
+        state.iceberg_compat_v3_enabled = iceberg_compat_v3_enabled;
         let encoded = original.encode().unwrap();
         let decoded = WriteState::decode(&encoded).unwrap();
         assert_eq!(decoded.full_logical_schema, original.full_logical_schema);
@@ -487,6 +512,11 @@ mod tests {
         assert_eq!(
             decoded.materialized_row_commit_version_column_name,
             original.materialized_row_commit_version_column_name
+        );
+        assert_eq!(decoded.row_tracking_enabled, original.row_tracking_enabled);
+        assert_eq!(
+            decoded.iceberg_compat_v3_enabled,
+            original.iceberg_compat_v3_enabled
         );
 
         let values = || HashMap::from([("year".to_string(), Scalar::Integer(2024))]);
@@ -581,12 +611,12 @@ mod tests {
             false, /* materialize_partition_columns */
             false, /* randomize_file_prefixes */
             2,     /* random_prefix_length */
+            true,  /* row_tracking_enabled */
         );
         let state = Arc::get_mut(&mut write_state).unwrap();
         state.materialized_row_id_column_name = Some("_metadata_row_id".into());
         state.materialized_row_commit_version_column_name =
             Some("_metadata_row_commit_version".into());
-        state.row_tracking_enabled = true;
 
         let write_state = WriteState::decode(&write_state.encode()?)?;
         let base_logical_field = write_state
@@ -655,13 +685,13 @@ mod tests {
         #[case] row_tracking_columns: RowTrackingMetadataColumns<'_>,
         #[case] expected_error: &str,
     ) {
-        let mut write_state = partitioned_write_state(
+        let write_state = partitioned_write_state(
             ColumnMappingMode::None,
             false, /* materialize_partition_columns */
             false, /* randomize_file_prefixes */
             2,     /* random_prefix_length */
+            true,  /* row_tracking_enabled */
         );
-        Arc::get_mut(&mut write_state).unwrap().row_tracking_enabled = true;
 
         let error = write_state
             .write_context_builder()
@@ -684,12 +714,12 @@ mod tests {
             false, /* materialize_partition_columns */
             false, /* randomize_file_prefixes */
             2,     /* random_prefix_length */
+            true,  /* row_tracking_enabled */
         );
         let state = Arc::get_mut(&mut write_state).unwrap();
         state.materialized_row_id_column_name = Some("_metadata_row_id".into());
         state.materialized_row_commit_version_column_name =
             Some("_metadata_row_commit_version".into());
-        state.row_tracking_enabled = true;
 
         let error = write_state
             .write_context_builder()
@@ -711,7 +741,13 @@ mod tests {
 
     #[test]
     fn write_state_encoding_uses_current_format_version() {
-        let state = partitioned_write_state(ColumnMappingMode::None, false, false, 2);
+        let state = partitioned_write_state(
+            ColumnMappingMode::None,
+            false, /* materialize_partition_columns */
+            false, /* randomize_file_prefixes */
+            2,     /* random_prefix_length */
+            false, /* row_tracking_enabled */
+        );
         let encoded: serde_json::Value = serde_json::from_slice(&state.encode().unwrap()).unwrap();
         assert_eq!(encoded["version"], 1);
         assert!(encoded.get("write_state").is_some());
@@ -719,7 +755,13 @@ mod tests {
 
     #[test]
     fn write_state_decode_rejects_unsupported_format_version() {
-        let state = partitioned_write_state(ColumnMappingMode::None, false, false, 2);
+        let state = partitioned_write_state(
+            ColumnMappingMode::None,
+            false, /* materialize_partition_columns */
+            false, /* randomize_file_prefixes */
+            2,     /* random_prefix_length */
+            false, /* row_tracking_enabled */
+        );
         let mut encoded: serde_json::Value =
             serde_json::from_slice(&state.encode().unwrap()).unwrap();
         encoded["version"] = 2.into();

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -101,8 +101,12 @@ async fn append_only_enforces_data_change_for_file_actions(
         .unwrap_post_commit_snapshot();
     let mut txn = begin_transaction(snapshot, engine.as_ref())?.with_data_change(true);
     let write_context = txn.write_state()?.write_context_builder().build()?;
-    let arrow_schema: Arc<ArrowSchema> =
-        Arc::new(write_context.physical_schema().as_ref().try_into_arrow()?);
+    let arrow_schema: Arc<ArrowSchema> = Arc::new(
+        write_context
+            .physical_data_schema()
+            .as_ref()
+            .try_into_arrow()?,
+    );
     for value in [1, 2, 3] {
         let data = ArrowEngineData::new(RecordBatch::try_new(
             arrow_schema.clone(),

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -1,11 +1,19 @@
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::Int32Array;
+use delta_kernel::arrow::array::{AsArray, Int32Array};
+use delta_kernel::arrow::compute::concat_batches;
+use delta_kernel::arrow::datatypes::{Int32Type, Int64Type};
+use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::schema::schema_ref;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::schema::{schema_ref, MetadataColumnSpec};
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
-use delta_kernel::Snapshot;
-use test_utils::test_table_setup_mt;
+use delta_kernel::transaction::RowTrackingMetadataColumns;
+use delta_kernel::{DeltaResult, Engine, Snapshot};
+use test_utils::{
+    assert_result_error_with_message, insert_data, into_record_batch, read_scan, test_table_setup,
+    test_table_setup_mt,
+};
 use url::Url;
 
 use crate::common::write_utils::set_table_properties;
@@ -101,4 +109,203 @@ async fn test_row_tracking_remove_gate(
         txn.commit(engine.as_ref())?.unwrap_committed();
     }
     Ok(())
+}
+
+#[rstest::rstest]
+#[case::supported(
+    &[
+        ("delta.enableRowTracking", "true"),
+        ("delta.columnMapping.mode", "name"),
+        ("delta.feature.icebergCompatV3", "supported"),
+    ],
+    None,
+)]
+#[case::enabled(
+    &[("delta.enableIcebergCompatV3", "true")],
+    Some(
+        "Kernel does not support writing materialized Row IDs or Row Commit Versions to \
+         IcebergCompatV3 tables",
+    ),
+)]
+fn write_context_row_tracking_columns_respect_iceberg_compat_v3(
+    #[case] table_properties: &[(&str, &str)],
+    #[case] expected_error: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = kernel_create_table(
+        table_path.as_str(),
+        schema_ref! { nullable "number": INTEGER },
+        "Test/1.0",
+    )
+    .with_table_properties(table_properties.iter().copied())
+    .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+    .commit(engine.as_ref())?
+    .unwrap_post_commit_snapshot();
+    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    let result = txn
+        .write_state()?
+        .write_context_builder()
+        .with_row_tracking_columns(RowTrackingMetadataColumns {
+            row_id_col_name: Some("row_id"),
+            row_commit_version_col_name: Some("row_commit_version"),
+        })
+        .build();
+
+    if let Some(expected_error) = expected_error {
+        assert_result_error_with_message(result, expected_error);
+    } else {
+        result?;
+    }
+    Ok(())
+}
+
+#[rstest::rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn write_context_maps_row_tracking_metadata_to_physical(
+    #[values("none", "name", "id")] column_mapping_mode: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // === Create table and insert data ===
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let schema = schema_ref! { nullable "number": INTEGER };
+    let snapshot = kernel_create_table(table_path.as_str(), schema, "Test/1.0")
+        .with_table_properties([
+            ("delta.columnMapping.mode", column_mapping_mode),
+            ("delta.enableRowTracking", "true"),
+        ])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+    let snapshot = insert_data(
+        snapshot,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![10, 20]))],
+    )
+    .await?
+    .unwrap_post_commit_snapshot();
+    let source_snapshot = insert_data(
+        snapshot,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![30, 40, 50]))],
+    )
+    .await?
+    .unwrap_post_commit_snapshot();
+
+    // === Read data with row tracking ===
+    let read_with_row_tracking = |snapshot: Arc<Snapshot>| -> DeltaResult<Vec<RecordBatch>> {
+        let scan_schema = Arc::new(
+            snapshot
+                .schema()
+                .add_metadata_column("row_id", MetadataColumnSpec::RowId)?
+                .add_metadata_column("row_commit_version", MetadataColumnSpec::RowCommitVersion)?,
+        );
+        let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
+        read_scan(&scan, engine.clone())
+    };
+    let source_batches = read_with_row_tracking(source_snapshot.clone())?;
+
+    // === Merge the batches ===
+    let merged_batch = concat_batches(&source_batches[0].schema(), &source_batches)?;
+
+    // === Assert merged logical data ===
+    let expected_rows = vec![(10, 0, 1), (20, 1, 1), (30, 2, 2), (40, 3, 2), (50, 4, 2)];
+    assert_eq!(
+        collect_rows(
+            std::slice::from_ref(&merged_batch),
+            "number",
+            "row_id",
+            "row_commit_version",
+        ),
+        expected_rows
+    );
+
+    // === Build the write context ===
+    let txn = source_snapshot
+        .clone()
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    let write_context = txn
+        .write_state()?
+        .write_context_builder()
+        .with_row_tracking_columns(RowTrackingMetadataColumns {
+            row_id_col_name: Some("row_id"),
+            row_commit_version_col_name: Some("row_commit_version"),
+        })
+        .build()?;
+
+    // === Evaluate logical-to-physical ===
+    let evaluator = engine.evaluation_handler().new_expression_evaluator(
+        write_context.logical_data_schema().clone(),
+        write_context.logical_to_physical(),
+        write_context.physical_data_schema().clone().into(),
+    )?;
+    let physical_batch =
+        into_record_batch(evaluator.evaluate(&ArrowEngineData::new(merged_batch))?);
+
+    // === Assert physical schema and data ===
+    let physical_row_id_name = source_snapshot
+        .table_properties()
+        .materialized_row_id_column_name
+        .as_deref()
+        .expect("row-tracking table must have a materialized Row ID column name");
+    let physical_row_commit_version_name = source_snapshot
+        .table_properties()
+        .materialized_row_commit_version_column_name
+        .as_deref()
+        .expect("row-tracking table must have a materialized Row Commit Version column name");
+    let expected_physical_names: Vec<_> = write_context
+        .physical_data_schema()
+        .fields()
+        .map(|field| field.name.as_str())
+        .collect();
+    let physical_arrow_schema = physical_batch.schema();
+    let actual_physical_names: Vec<_> = physical_arrow_schema
+        .fields()
+        .iter()
+        .map(|field| field.name().as_str())
+        .collect();
+    assert_eq!(actual_physical_names, expected_physical_names);
+    assert_eq!(
+        expected_physical_names[1..],
+        [physical_row_id_name, physical_row_commit_version_name]
+    );
+    let physical_rows = collect_rows(
+        std::slice::from_ref(&physical_batch),
+        expected_physical_names[0],
+        physical_row_id_name,
+        physical_row_commit_version_name,
+    );
+    assert_eq!(physical_rows, expected_rows);
+
+    Ok(())
+}
+
+fn collect_rows(
+    batches: &[RecordBatch],
+    number_name: &str,
+    row_id_name: &str,
+    version_name: &str,
+) -> Vec<(i32, i64, i64)> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let numbers = batch
+            .column_by_name(number_name)
+            .unwrap()
+            .as_primitive::<Int32Type>();
+        let row_ids = batch
+            .column_by_name(row_id_name)
+            .unwrap()
+            .as_primitive::<Int64Type>();
+        let row_commit_versions = batch
+            .column_by_name(version_name)
+            .unwrap()
+            .as_primitive::<Int64Type>();
+        rows.extend((0..batch.num_rows()).map(|row| {
+            (
+                numbers.value(row),
+                row_ids.value(row),
+                row_commit_versions.value(row),
+            )
+        }));
+    }
+    rows.sort_unstable();
+    rows
 }

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -563,7 +563,7 @@ async fn test_not_null_data_column_rejects_null_in_batch(
 
     // Use the connector-facing physical schema (not the logical one); the logical schema
     // would hide bugs in the logical->physical mapping that engines hit in production.
-    let physical = write_context.physical_schema();
+    let physical = write_context.physical_data_schema();
     let physical_field = physical
         .field("c")
         .expect("physical schema must contain column 'c'");
@@ -775,7 +775,7 @@ async fn write_context_excludes_void_from_physical_schema() -> Result<(), Box<dy
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
 
     let wc = txn.write_state()?.write_context_builder().build()?;
-    let physical = wc.physical_schema();
+    let physical = wc.physical_data_schema();
 
     // Physical schema should NOT contain void column
     assert_eq!(physical.fields().count(), 2);
@@ -845,7 +845,7 @@ async fn write_context_excludes_nested_void_from_physical_schema(
 
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
     let wc = txn.write_state()?.write_context_builder().build()?;
-    let physical = wc.physical_schema();
+    let physical = wc.physical_data_schema();
 
     // Physical schema struct should NOT contain the void field
     let s_field = physical.field("s").expect("s should exist in physical");
@@ -893,7 +893,7 @@ async fn write_transform_drops_nested_void_fields() -> Result<(), Box<dyn std::e
     );
 
     // Physical schema should also not contain void
-    let physical = wc.physical_schema();
+    let physical = wc.physical_data_schema();
     let s_field = physical.field("s").expect("s should exist in physical");
     if let DataType::Struct(inner) = s_field.data_type() {
         assert_eq!(inner.fields().count(), 1);


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3229/files) to review incremental changes.
- [stack/read-stable-ver](https://github.com/delta-io/delta-kernel-rs/pull/3224) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3224/files)] [MERGED]
  - [stack/builder-ctx](https://github.com/delta-io/delta-kernel-rs/pull/3226) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3226/files)] [MERGED]
    - [**stack/rc-metadata-write**](https://github.com/delta-io/delta-kernel-rs/pull/3229) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3229/files)] ← _this PR_
      - [stack/ack-rc-preserve](https://github.com/delta-io/delta-kernel-rs/pull/3252) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3252/files/7ca320dff1fc4e630e45b64971a26a1f4a2f8e49..c162d1dd346426c08ecd60e80f390a8d8fbaeb08)]
        - stack/emit-preserve-flag

---------
## What changes are proposed in this pull request?

add row tracking metadata cols into writecontext

## How was this change tested?
integration test reads row tracking metadata and validates the logical-to-physical transform result
unit tests for individual changes