### PR TITLE
[PROTOTYPE] feat!: restrict declarative plan expressions

### DIFF
--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -20,6 +20,9 @@ use delta_kernel::expressions::{
     ExpressionStructPatch, MapToStructExpression, ParseJsonExpression, UnaryExpressionOp,
     VariadicExpression, VariadicExpressionOp,
 };
+use delta_kernel::plans::ir::expression::{
+    PlanExpression, PlanExpressionKind, PlanExpressionRef, PlanStructPatch,
+};
 use delta_kernel::schema::{
     DataType as KernelDataType, PrimitiveType, SchemaRef as KernelSchemaRef, StructField,
     StructType,
@@ -86,6 +89,202 @@ pub fn to_df_expr(
             "cannot convert Unknown expression {name:?}"
         ))),
     }
+}
+
+/// Converts a resolved plan expression into its DataFusion equivalent.
+///
+/// Unlike [`to_df_expr`], this function does not infer result types or thread an expected type
+/// through the tree. Kernel has already resolved every child and rejected expressions outside the
+/// mandatory plan dialect before constructing the plan.
+///
+/// # Errors
+///
+/// Returns an error when a scalar has no Arrow representation or DataFusion cannot construct the
+/// equivalent expression. Structural inconsistencies indicate an invalid resolved plan.
+pub(crate) fn to_df_plan_expr(
+    expr: &PlanExpression,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
+    match expr.kind() {
+        PlanExpressionKind::Literal(scalar) => Ok(lit(to_df_scalar(scalar)?)),
+        PlanExpressionKind::Column(column) => column_to_df_expr(column.name(), input_schema),
+        PlanExpressionKind::Predicate(predicate) => {
+            crate::predicate::to_df_plan_predicate_expr(predicate, input_schema)
+        }
+        PlanExpressionKind::Struct {
+            fields,
+            nullability,
+        } => {
+            let target = plan_struct_type(expr, "Struct")?;
+            Ok(plan_struct_columns_from_fields(fields, nullability, input_schema, target)?.pack())
+        }
+        PlanExpressionKind::StructPatch(patch) => {
+            let target = plan_struct_type(expr, "StructPatch")?;
+            Ok(plan_struct_columns_from_patch(patch, input_schema, target)?.pack())
+        }
+        PlanExpressionKind::Coalesce(expressions) => {
+            let args = expressions
+                .iter()
+                .map(|expression| to_df_plan_expr(expression, input_schema))
+                .collect::<DeltaResult<Vec<_>>>()?;
+            Ok(coalesce(args))
+        }
+        PlanExpressionKind::ParseJson {
+            json,
+            output_schema,
+        } => {
+            let json = to_df_plan_expr(json, input_schema)?;
+            let udf = ScalarUDF::new_from_impl(ParseJsonUdf::try_new(Arc::clone(output_schema))?);
+            Ok(udf.call(vec![json]))
+        }
+        PlanExpressionKind::MapToStruct { map, output_schema } => {
+            let map = to_df_plan_expr(map, input_schema)?;
+            map_to_struct_from_parts(map, output_schema)
+        }
+    }
+}
+
+/// Flattens a resolved top-level struct projection into named DataFusion columns.
+///
+/// # Errors
+///
+/// Returns an error if `expr` is not a struct constructor or struct patch, or a child cannot be
+/// converted to DataFusion.
+pub(crate) fn to_df_plan_struct_columns(
+    expr: &PlanExpression,
+    input_schema: &StructType,
+) -> DeltaResult<StructColumns> {
+    match expr.kind() {
+        PlanExpressionKind::Struct {
+            fields,
+            nullability,
+        } => plan_struct_columns_from_fields(
+            fields,
+            nullability,
+            input_schema,
+            plan_struct_type(expr, "Struct")?,
+        ),
+        PlanExpressionKind::StructPatch(patch) => plan_struct_columns_from_patch(
+            patch,
+            input_schema,
+            plan_struct_type(expr, "StructPatch")?,
+        ),
+        _ => Err(Error::internal_error(
+            "resolved Project expression is not a Struct or StructPatch",
+        )),
+    }
+}
+
+fn plan_struct_type<'a>(expr: &'a PlanExpression, arm: &str) -> DeltaResult<&'a StructType> {
+    let KernelDataType::Struct(schema) = expr.data_type() else {
+        return Err(Error::internal_error(format!(
+            "resolved {arm} expression does not have a struct type"
+        )));
+    };
+    Ok(schema)
+}
+
+fn plan_struct_columns_from_fields(
+    fields: &[PlanExpressionRef],
+    nullability: Option<&PlanExpression>,
+    input_schema: &StructType,
+    target: &StructType,
+) -> DeltaResult<StructColumns> {
+    if fields.len() != target.num_fields() {
+        return Err(Error::internal_error(
+            "resolved Struct field count does not match its output schema",
+        ));
+    }
+    let pairs = fields
+        .iter()
+        .zip(target.fields())
+        .map(|(child, field)| {
+            Ok((
+                field.name().to_string(),
+                to_df_plan_expr(child, input_schema)?,
+            ))
+        })
+        .collect::<DeltaResult<Vec<_>>>()?;
+    let null_guard = nullability
+        .map(|guard| to_df_plan_expr(guard, input_schema))
+        .transpose()?;
+    Ok(StructColumns { pairs, null_guard })
+}
+
+fn plan_struct_columns_from_patch(
+    patch: &PlanStructPatch,
+    input_schema: &StructType,
+    target: &StructType,
+) -> DeltaResult<StructColumns> {
+    let (source_struct, source_expr) = match patch.input_path() {
+        Some(path) => {
+            let KernelDataType::Struct(nested) = input_schema.field_at(path)?.data_type() else {
+                return Err(Error::internal_error(
+                    "resolved StructPatch input is not a struct",
+                ));
+            };
+            (
+                nested.as_ref(),
+                Some(column_to_df_expr(path, input_schema)?),
+            )
+        }
+        None => (input_schema, None),
+    };
+    let null_guard = source_expr.as_ref().map(|base| base.clone().is_not_null());
+    let mut output_fields = target.fields();
+    let mut pairs = Vec::with_capacity(target.num_fields());
+
+    let append_resolved = |pairs: &mut Vec<(String, DFExpr)>,
+                           output_fields: &mut dyn Iterator<Item = &StructField>,
+                           expression: &PlanExpression|
+     -> DeltaResult<()> {
+        let field = output_fields.next().ok_or_else(|| {
+            Error::internal_error("resolved StructPatch produces too many fields")
+        })?;
+        pairs.push((
+            field.name().to_string(),
+            to_df_plan_expr(expression, input_schema)?,
+        ));
+        Ok(())
+    };
+    let append_existing = |pairs: &mut Vec<(String, DFExpr)>,
+                           output_fields: &mut dyn Iterator<Item = &StructField>,
+                           name: &str|
+     -> DeltaResult<()> {
+        let field = output_fields.next().ok_or_else(|| {
+            Error::internal_error("resolved StructPatch produces too many fields")
+        })?;
+        let value = match &source_expr {
+            Some(base) => get_field(base.clone(), name.to_string()),
+            None => DFExpr::Column(DFColumn::new_unqualified(name)),
+        };
+        pairs.push((field.name().to_string(), value));
+        Ok(())
+    };
+
+    for expression in patch.prepended_fields() {
+        append_resolved(&mut pairs, &mut output_fields, expression)?;
+    }
+    for input_field in source_struct.fields() {
+        let field_patch = patch.field_patches().get(input_field.name());
+        if field_patch.is_none_or(|field_patch| field_patch.keeps_input()) {
+            append_existing(&mut pairs, &mut output_fields, input_field.name())?;
+        }
+        if let Some(field_patch) = field_patch {
+            for expression in field_patch.insertions() {
+                append_resolved(&mut pairs, &mut output_fields, expression)?;
+            }
+        }
+    }
+    for expression in patch.appended_fields() {
+        append_resolved(&mut pairs, &mut output_fields, expression)?;
+    }
+    if output_fields.next().is_some() {
+        return Err(Error::internal_error(
+            "resolved StructPatch produces fewer fields than its output schema",
+        ));
+    }
+    Ok(StructColumns { pairs, null_guard })
 }
 
 /// Lowers [`KernelExpression::Struct`] or [`KernelExpression::StructPatch`] into named child
@@ -417,6 +616,10 @@ fn map_to_struct_to_df_expr(
     let target = require_struct_output(output_type, "MapToStruct")?;
     let map = to_df_expr(&map_to_struct.map_expr, input_schema, None)?;
 
+    map_to_struct_from_parts(map, target)
+}
+
+fn map_to_struct_from_parts(map: DFExpr, target: &StructType) -> DeltaResult<DFExpr> {
     let mut args = Vec::with_capacity(target.num_fields() * 2);
     for field in target.fields() {
         let KernelDataType::Primitive(prim) = field.data_type() else {

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -24,14 +24,14 @@ use datafusion::logical_expr::{
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
 use delta_kernel::expressions::{ColumnName as KernelColumnName, Scalar as KernelScalar};
 use delta_kernel::plans::ir::nodes::{
-    Agg as KernelAgg, Aggregate as KernelAggregate, Filter as KernelFilter,
-    Operator as KernelOperator, Project as KernelProject, SemiJoin as KernelSemiJoin,
-    UnionAll as KernelUnionAll, Values as KernelValues,
+    Agg as KernelAgg, Aggregate as KernelAggregate, DataSkippingSite as KernelDataSkippingSite,
+    Filter as KernelFilter, Operator as KernelOperator, Project as KernelProject,
+    SemiJoin as KernelSemiJoin, UnionAll as KernelUnionAll, Values as KernelValues,
 };
 use delta_kernel::schema::{StructField, StructType};
 
-use crate::expression::to_df_struct_columns;
-use crate::predicate::to_df_predicate_expr;
+use crate::expression::to_df_plan_struct_columns;
+use crate::predicate::to_df_plan_predicate_expr;
 use crate::scalar::to_df_scalar;
 use crate::utils::column_to_df_expr;
 
@@ -69,6 +69,12 @@ pub(crate) fn lower_operator(
             };
             lower_filter(filter, input)
         }
+        KernelOperator::DataSkipping(site) => {
+            let [input] = inputs else {
+                return Err(input_count_error(1));
+            };
+            lower_data_skipping(site, input)
+        }
         KernelOperator::Aggregate(aggregate) => {
             let [input] = inputs else {
                 return Err(input_count_error(1));
@@ -89,6 +95,25 @@ pub(crate) fn lower_operator(
     }
 }
 
+/// Applies Kernel's portable data-skipping predicate, or leaves the input unchanged when Kernel
+/// could not derive one. A native optimizer may instead install a conservative filter based on
+/// [`KernelDataSkippingSite::source_predicate`].
+fn lower_data_skipping(
+    site: &KernelDataSkippingSite,
+    input: &Arc<DFLogicalPlan>,
+) -> Result<DFLogicalPlan, DataFusionError> {
+    let Some(predicate) = site.kernel_keep_predicate() else {
+        return Ok(input.as_ref().clone());
+    };
+    let input_schema: StructType = input.schema().as_arrow().try_into_kernel()?;
+    let predicate = to_df_plan_predicate_expr(predicate, &input_schema)
+        .map_err(|error| DataFusionError::External(Box::new(error)))?;
+    Ok(DFLogicalPlan::Filter(DFFilter::try_new(
+        predicate,
+        Arc::clone(input),
+    )?))
+}
+
 /// Lowers a [`Project`](KernelProject) to a single DataFusion projection.
 ///
 /// A kernel Project holds a struct expression and its declared output schema, while DataFusion
@@ -104,14 +129,14 @@ fn lower_project(
     input: &Arc<DFLogicalPlan>,
 ) -> Result<DFLogicalPlan, DataFusionError> {
     let input_schema: StructType = input.schema().as_arrow().try_into_kernel()?;
-    let arrow_schema: ArrowSchema = project.schema.as_ref().try_into_arrow()?;
+    let arrow_schema: ArrowSchema = project.schema().as_ref().try_into_arrow()?;
     let df_schema = Arc::new(DFSchema::try_from(arrow_schema)?);
-    let columns = to_df_struct_columns(&project.expr, &input_schema, project.schema.as_ref())
+    let columns = to_df_plan_struct_columns(project.expression(), &input_schema)
         .map_err(|error| DataFusionError::External(Box::new(error)))?
         .into_guarded_columns();
     let exprs: Result<Vec<DFExpr>, DataFusionError> = columns
         .into_iter()
-        .zip(project.schema.fields())
+        .zip(project.schema().fields())
         .map(|((name, expr), field)| {
             let target = field.data_type().try_into_arrow()?;
             let expr = expr.cast_to(&target, input.schema())?.alias(name);
@@ -332,7 +357,7 @@ fn lower_filter(
     input: &Arc<DFLogicalPlan>,
 ) -> Result<DFLogicalPlan, DataFusionError> {
     let input_schema: StructType = input.schema().as_arrow().try_into_kernel()?;
-    let predicate = to_df_predicate_expr(&filter.predicate, &input_schema)
+    let predicate = to_df_plan_predicate_expr(filter.predicate(), &input_schema)
         .map_err(|error| DataFusionError::External(Box::new(error)))?;
     let filter = DFFilter::try_new(predicate, Arc::clone(input))?;
     Ok(DFLogicalPlan::Filter(filter))
@@ -398,6 +423,7 @@ mod tests {
         ExpressionStructPatchBuilder, JunctionPredicateOp as KernelJunctionPredicateOp,
         MapData as KernelMapData, Predicate as KernelPredicate, StructData as KernelStructData,
     };
+    use delta_kernel::plans::ir::nodes::{DataSkippingStats, DataSkippingTarget};
     use delta_kernel::schema::{
         schema, ArrayType, DataType, MapType, SchemaRef, StructField, StructType,
     };
@@ -659,9 +685,8 @@ mod tests {
     #[test]
     fn filter_wraps_its_input_and_inherits_schema() {
         let input = input_with_schema(test_schema());
-        let filter = KernelFilter {
-            predicate: KernelPredicate::is_null(col!("a")).into(),
-        };
+        let filter =
+            KernelFilter::try_new(&test_schema(), KernelPredicate::is_null(col!("a"))).unwrap();
         let lowered = lower_operator(
             &KernelOperator::Filter(filter),
             std::slice::from_ref(&input),
@@ -675,14 +700,68 @@ mod tests {
         assert_eq!(lowered.schema(), input.schema());
     }
 
+    fn data_skipping_input_schema() -> StructType {
+        schema! {
+            nullable "stats": {
+                nullable "maxValues": { nullable "a": LONG },
+            },
+            not_null "is_add": BOOLEAN,
+        }
+    }
+
+    fn data_skipping_site(
+        keep: Option<KernelPredicate>,
+    ) -> delta_kernel::plans::ir::nodes::DataSkippingSite {
+        let input_schema = data_skipping_input_schema();
+        let stats = DataSkippingStats::try_new(
+            &input_schema,
+            Arc::new(schema! { nullable "a": LONG }),
+            Some(column_name!("stats")),
+            None,
+        )
+        .unwrap();
+        KernelDataSkippingSite::try_new(
+            &input_schema,
+            KernelPredicate::gt(col!("a"), kernel_lit(10i64)),
+            stats,
+            DataSkippingTarget::AddsOnly,
+            keep.map(Arc::new),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn data_skipping_without_portable_predicate_is_identity() {
+        let input = input_with_schema(data_skipping_input_schema());
+        let lowered = lower_operator(
+            &KernelOperator::DataSkipping(data_skipping_site(None)),
+            std::slice::from_ref(&input),
+        )
+        .unwrap();
+
+        assert_eq!(&lowered, input.as_ref());
+    }
+
+    #[test]
+    fn data_skipping_with_portable_predicate_lowers_to_filter() {
+        let input = input_with_schema(data_skipping_input_schema());
+        let keep = KernelPredicate::gt(col!("stats.maxValues.a"), kernel_lit(10i64));
+        let lowered = lower_operator(
+            &KernelOperator::DataSkipping(data_skipping_site(Some(keep))),
+            std::slice::from_ref(&input),
+        )
+        .unwrap();
+
+        assert!(matches!(lowered, DFLogicalPlan::Filter(_)));
+    }
+
     async fn execute_filter(
         rows: Vec<Vec<KernelScalar>>,
         predicate: KernelPredicate,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
         let input = Arc::new(lower_values_node(test_schema(), rows)?);
-        let filter = KernelFilter {
-            predicate: predicate.into(),
-        };
+        let filter = KernelFilter::try_new(&test_schema(), predicate)
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         execute(lower_operator(
             &KernelOperator::Filter(filter),
             std::slice::from_ref(&input),
@@ -816,9 +895,9 @@ mod tests {
     fn filter_rejects_wrong_input_count(#[case] actual: usize) {
         let input = input_with_schema(test_schema());
         let inputs = vec![input; actual];
-        let op = KernelOperator::Filter(KernelFilter {
-            predicate: KernelPredicate::is_null(col!("a")).into(),
-        });
+        let op = KernelOperator::Filter(
+            KernelFilter::try_new(&test_schema(), KernelPredicate::is_null(col!("a"))).unwrap(),
+        );
         let err = lower_operator(&op, &inputs).unwrap_err();
         assert!(
             err.to_string()
@@ -840,11 +919,11 @@ mod tests {
         schema: impl Into<SchemaRef>,
         parent: &Arc<DFLogicalPlan>,
     ) -> Result<DFLogicalPlan, DataFusionError> {
+        let input_schema: StructType = parent.schema().as_arrow().try_into_kernel()?;
+        let project = KernelProject::try_new(&input_schema, expr, schema)
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         lower_operator(
-            &KernelOperator::Project(KernelProject {
-                expr: expr.into(),
-                schema: schema.into(),
-            }),
+            &KernelOperator::Project(project),
             std::slice::from_ref(parent),
         )
     }
@@ -931,8 +1010,8 @@ mod tests {
             .drop("small")
             .drop("nested")
             .append(
-                StructField::nullable("sum", DataType::LONG),
-                col!("a") + KernelExpr::coalesce([col!("b"), kernel_lit(99i64)]),
+                StructField::nullable("selected", DataType::LONG),
+                KernelExpr::coalesce([col!("a"), col!("b")]),
             )
             .build()
             .unwrap()
@@ -941,7 +1020,10 @@ mod tests {
     fn nested_struct_patch_project() -> (SchemaRef, ExpressionRef) {
         let input = project_input_schema();
         ProjectionStructPatchBuilder::new_nested(&input, ["nested"])
-            .replace_expr("value", col!("nested.value") + kernel_lit(1i32))
+            .replace_expr(
+                "value",
+                KernelExpr::coalesce([col!("nested.value"), kernel_lit(0i32)]),
+            )
             .build()
             .unwrap()
     }
@@ -952,12 +1034,12 @@ mod tests {
     fn project_rejects_wrong_parent_count(#[case] actual: usize) {
         let parent = input_with_schema(test_schema());
         let parents = vec![parent; actual];
-        let op = KernelOperator::Project(KernelProject {
-            expr: KernelExpr::struct_from([col!("a")]).into(),
-            schema: Arc::new(
-                StructType::try_new([StructField::nullable("a", DataType::LONG)]).unwrap(),
-            ),
-        });
+        let output =
+            Arc::new(StructType::try_new([StructField::nullable("a", DataType::LONG)]).unwrap());
+        let op = KernelOperator::Project(
+            KernelProject::try_new(&test_schema(), KernelExpr::struct_from([col!("a")]), output)
+                .unwrap(),
+        );
         let err = lower_operator(&op, &parents).unwrap_err();
         assert!(
             err.to_string().contains(&format!(
@@ -1017,11 +1099,15 @@ mod tests {
         let output =
             StructType::try_new([StructField::nullable("projected", DataType::LONG)]).unwrap();
         let projected = Arc::new(
-            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap(),
+            lower_project_expr(
+                KernelExpr::struct_from([col!("a")]),
+                output.clone(),
+                &parent,
+            )
+            .unwrap(),
         );
-        let filter = KernelFilter {
-            predicate: KernelPredicate::is_null(col!("projected")).into(),
-        };
+        let filter =
+            KernelFilter::try_new(&output, KernelPredicate::is_null(col!("projected"))).unwrap();
         let filtered = lower_operator(
             &KernelOperator::Filter(filter),
             std::slice::from_ref(&projected),
@@ -1091,7 +1177,7 @@ mod tests {
     )]
     #[case::malformed_patch(
         KernelExpr::struct_patch(ExpressionStructPatchBuilder::new()).unwrap(),
-        "produced more fields"
+        "produces too many fields"
     )]
     fn zero_field_project_rejects_invalid_expression(
         #[case] expr: KernelExpr,
@@ -1103,7 +1189,7 @@ mod tests {
     }
 
     #[test]
-    fn project_rejects_uncastable_output_type() {
+    fn project_rejects_output_type_mismatch_before_datafusion() {
         let parent = input_with_schema(test_schema());
         let output =
             StructType::try_new([StructField::nullable("a", DataType::unshredded_variant())])
@@ -1111,11 +1197,8 @@ mod tests {
         let err =
             lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap_err();
         let message = err.to_string();
-        assert!(matches!(&err, DataFusionError::Plan(_)), "{message}");
-        assert!(
-            message.contains("Cannot automatically convert"),
-            "{message}"
-        );
+        assert!(matches!(&err, DataFusionError::External(_)), "{message}");
+        assert!(message.contains("expected variant"), "{message}");
     }
 
     #[rstest]
@@ -1147,24 +1230,18 @@ mod tests {
             ),
         ]).unwrap()
     )]
-    fn project_casts_output_to_declared_type(
+    fn project_rejects_implicit_casts_at_plan_boundary(
         #[case] input: StructType,
         #[case] expr: KernelExpr,
         #[case] output: StructType,
     ) {
-        let expected: ArrowSchema = (&output).try_into_arrow().unwrap();
-        let expected_types: Vec<ArrowDataType> = expected
-            .fields()
-            .iter()
-            .map(|field| field.data_type().clone())
-            .collect();
         let parent = input_with_schema(input);
-        let lowered = lower_project_expr(expr, output, &parent).unwrap();
-        assert_eq!(output_types(&lowered), expected_types);
+        let error = lower_project_expr(expr, output, &parent).unwrap_err();
+        assert!(error.to_string().contains("expected"), "{error}");
     }
 
     #[rstest]
-    #[case::literal_column_and_cast(
+    #[case::literal_and_column(
         struct_project([
             (StructField::nullable("selected", DataType::LONG), col!("a")),
             (StructField::nullable("literal", DataType::STRING), kernel_lit("constant")),
@@ -1172,66 +1249,31 @@ mod tests {
                 StructField::nullable("null_value", DataType::LONG),
                 null_lit(DataType::LONG),
             ),
-            (StructField::nullable("widened", DataType::LONG), col!("small")),
+            (StructField::nullable("small", DataType::INTEGER), col!("small")),
         ]),
         &[
-            "+----------+----------+------------+---------+",
-            "| selected | literal  | null_value | widened |",
-            "+----------+----------+------------+---------+",
-            "| 10       | constant |            | 1       |",
-            "| 20       | constant |            | 2       |",
-            "|          | constant |            | 3       |",
-            "+----------+----------+------------+---------+",
+            "+----------+----------+------------+-------+",
+            "| selected | literal  | null_value | small |",
+            "+----------+----------+------------+-------+",
+            "| 10       | constant |            | 1     |",
+            "| 20       | constant |            | 2     |",
+            "|          | constant |            | 3     |",
+            "+----------+----------+------------+-------+",
         ]
     )]
-    #[case::arithmetic(
-        struct_project([
-            (StructField::nullable("sum", DataType::LONG), col!("a") + col!("b")),
-            (
-                StructField::nullable("difference", DataType::LONG),
-                col!("a") - col!("b"),
-            ),
-            (
-                StructField::nullable("product", DataType::LONG),
-                col!("a") * col!("b"),
-            ),
-            (
-                StructField::nullable("quotient", DataType::LONG),
-                col!("a") / col!("b"),
-            ),
-        ]),
+    #[case::coalesce(
+        struct_project([(
+            StructField::nullable("coalesced", DataType::LONG),
+            KernelExpr::coalesce([col!("b"), col!("a"), kernel_lit(99i64)]),
+        )]),
         &[
-            "+-----+------------+---------+----------+",
-            "| sum | difference | product | quotient |",
-            "+-----+------------+---------+----------+",
-            "| 12  | 8          | 20      | 5        |",
-            "|     |            |         |          |",
-            "|     |            |         |          |",
-            "+-----+------------+---------+----------+",
-        ]
-    )]
-    #[case::variadic(
-        struct_project([
-            (
-                StructField::nullable("coalesced", DataType::LONG),
-                KernelExpr::coalesce([col!("b"), col!("a"), kernel_lit(99i64)]),
-            ),
-            (
-                StructField::nullable(
-                    "array",
-                    ArrayType::new(DataType::LONG, true),
-                ),
-                KernelExpr::array([col!("a"), col!("b"), kernel_lit(5i64)]),
-            ),
-        ]),
-        &[
-            "+-----------+------------+",
-            "| coalesced | array      |",
-            "+-----------+------------+",
-            "| 2         | [10, 2, 5] |",
-            "| 20        | [20, , 5]  |",
-            "| 4         | [, 4, 5]   |",
-            "+-----------+------------+",
+            "+-----------+",
+            "| coalesced |",
+            "+-----------+",
+            "| 2         |",
+            "| 20        |",
+            "| 4         |",
+            "+-----------+",
         ]
     )]
     #[case::predicate(
@@ -1271,7 +1313,7 @@ mod tests {
             StructField::nullable(
                 "record",
                 StructType::try_new([
-                    StructField::nullable("value", DataType::LONG),
+                    StructField::nullable("value", DataType::INTEGER),
                     StructField::nullable("label", DataType::STRING),
                 ]).unwrap(),
             ),
@@ -1288,30 +1330,6 @@ mod tests {
             "| {value: 8, label: seen} |",
             "|                         |",
             "+-------------------------+",
-        ]
-    )]
-    #[case::array_of_structs(
-        struct_project([(
-            StructField::nullable(
-                "records",
-                ArrayType::new(
-                    StructType::try_new([StructField::nullable("value", DataType::LONG)]).unwrap(),
-                    true,
-                ),
-            ),
-            KernelExpr::array([
-                KernelExpr::struct_from([col!("a")]),
-                KernelExpr::struct_from([col!("b")]),
-            ]),
-        )]),
-        &[
-            "+---------------------------+",
-            "| records                   |",
-            "+---------------------------+",
-            "| [{value: 10}, {value: 2}] |",
-            "| [{value: 20}, {value: }]  |",
-            "| [{value: }, {value: 4}]   |",
-            "+---------------------------+",
         ]
     )]
     #[case::top_level_nullability(
@@ -1383,13 +1401,13 @@ mod tests {
     #[case::struct_patch(
         struct_patch_project(),
         &[
-            "+----+----+-----+",
-            "| a  | b  | sum |",
-            "+----+----+-----+",
-            "| 10 | 2  | 12  |",
-            "| 20 | 99 | 119 |",
-            "|    | 4  |     |",
-            "+----+----+-----+",
+            "+----+----+----------+",
+            "| a  | b  | selected |",
+            "+----+----+----------+",
+            "| 10 | 2  | 10       |",
+            "| 20 | 99 | 20       |",
+            "|    | 4  | 4        |",
+            "+----+----+----------+",
         ]
     )]
     #[case::nested_struct_patch(
@@ -1398,8 +1416,8 @@ mod tests {
             "+-------+",
             "| value |",
             "+-------+",
+            "| 7     |",
             "| 8     |",
-            "| 9     |",
             "|       |",
             "+-------+",
         ]
@@ -1415,22 +1433,16 @@ mod tests {
         assert_batches_eq!(expected, &batches);
     }
 
-    #[tokio::test]
-    async fn project_rejects_invalid_cast_value_during_execution() {
+    #[test]
+    fn project_rejects_implicit_cast_before_execution() {
         let input = StructType::try_new([StructField::nullable("a", DataType::STRING)]).unwrap();
         let parent = Arc::new(
             lower_values_node(input, vec![vec![KernelScalar::String("abc".into())]]).unwrap(),
         );
         let output = StructType::try_new([StructField::nullable("a", DataType::INTEGER)]).unwrap();
-        let lowered =
-            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap();
-
-        let err = execute(lowered).await.unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("Cannot cast string 'abc' to value of Int32 type"),
-            "{err}"
-        );
+        let error =
+            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap_err();
+        assert!(error.to_string().contains("expected integer"), "{error}");
     }
 
     #[test]
@@ -1496,12 +1508,21 @@ mod tests {
         let expected: ArrowSchema = (&schema).try_into_arrow().unwrap();
         let expected_type = expected.field(0).data_type().clone();
         let parent = input_with_schema(schema.clone());
-        let lowered =
-            lower_project_expr(KernelExpr::struct_from([col!("a")]), schema, &parent).unwrap();
+        let project = KernelProject::try_new(
+            &schema,
+            KernelExpr::struct_from([col!("a")]),
+            schema.clone(),
+        )
+        .unwrap();
+        let lowered = lower_operator(
+            &KernelOperator::Project(project),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
         assert_eq!(output_types(&lowered), [expected_type]);
     }
 
-    /// Errors from converting a Project's child expression propagate to the caller.
+    /// Unsupported broad expressions are rejected while constructing the Project.
     #[test]
     fn project_propagates_expression_conversion_error() {
         let parent = input_with_schema(test_schema());
@@ -1511,7 +1532,7 @@ mod tests {
         let message = err.to_string();
         assert!(matches!(&err, DataFusionError::External(_)), "{message}");
         assert!(
-            message.contains(r#"cannot convert Unknown expression "engine_expr""#),
+            message.contains("Unknown is not part of the mandatory plan expression dialect"),
             "{message}"
         );
     }

--- a/datafusion-executor/src/plan.rs
+++ b/datafusion-executor/src/plan.rs
@@ -27,9 +27,9 @@ pub(crate) fn to_df_plan(plan: &KernelPlan) -> Result<DFLogicalPlan, DataFusionE
     // A node is identified by its index, and `nodes` is topologically ordered: every input index is
     // strictly less than the node's own, so a single forward pass leaves each node's inputs already
     // lowered by the time it is reached.
-    let mut lowered: Vec<Arc<DFLogicalPlan>> = Vec::with_capacity(plan.nodes.len());
-    for (node_index, node) in plan.nodes.iter().enumerate() {
-        let op = &node.op;
+    let mut lowered: Vec<Arc<DFLogicalPlan>> = Vec::with_capacity(plan.nodes().len());
+    for (node_index, node) in plan.nodes().iter().enumerate() {
+        let op = node.operator();
         let available = lowered.len();
         let invalid_input = |input_index| {
             DataFusionError::Plan(format!(
@@ -38,7 +38,7 @@ pub(crate) fn to_df_plan(plan: &KernelPlan) -> Result<DFLogicalPlan, DataFusionE
             ))
         };
         let inputs: Vec<_> = node
-            .inputs
+            .inputs()
             .iter()
             .map(|&input_index| {
                 let Some(input) = lowered.get(input_index) else {
@@ -70,13 +70,8 @@ mod tests {
     use delta_kernel::expressions::{
         col, Expression as KernelExpr, Predicate as KernelPredicate, Scalar as KernelScalar,
     };
-    use delta_kernel::plans::ir::nodes::{
-        Filter as KernelFilter, Project as KernelProject, Values as KernelValues,
-    };
-    use delta_kernel::plans::ir::plan::PlanNode as KernelPlanNode;
     use delta_kernel::schema::{schema, DataType, StructField, StructType};
     use delta_kernel::PlanBuilder;
-    use rstest::rstest;
 
     use super::*;
 
@@ -85,11 +80,6 @@ mod tests {
     /// A single-field `long` schema named `a`.
     fn test_schema() -> StructType {
         schema! { nullable "a": LONG }
-    }
-
-    /// A `Values` node over [`test_schema`] holding `rows` one-column rows.
-    fn values_node(rows: Vec<Vec<KernelScalar>>) -> KernelPlanNode {
-        KernelPlanNode::new(KernelValues::new(test_schema(), rows), vec![])
     }
 
     async fn execute(plan: &KernelPlan) -> Result<Vec<RecordBatch>, DataFusionError> {
@@ -101,44 +91,6 @@ mod tests {
     }
 
     // === Tests ===
-
-    #[test]
-    fn empty_plan_is_rejected() {
-        let err = to_df_plan(&KernelPlan { nodes: vec![] }).unwrap_err();
-        assert!(err.to_string().contains("no nodes"), "{err}");
-    }
-
-    #[tokio::test]
-    async fn terminal_node_is_the_plans_output() {
-        // Two independent sources; the last node is the terminal one, so its rows are the output.
-        let plan = KernelPlan {
-            nodes: vec![
-                values_node(vec![vec![1i64.into()]]),
-                values_node(vec![vec![2i64.into()], vec![3i64.into()]]),
-            ],
-        };
-        let batches = execute(&plan).await.unwrap();
-        assert_batches_eq!(
-            &["+---+", "| a |", "+---+", "| 2 |", "| 3 |", "+---+"],
-            &batches
-        );
-    }
-
-    #[rstest]
-    #[case::self_reference(0)]
-    #[case::forward_reference(1)]
-    #[case::far_out_of_range(42)]
-    fn invalid_input_reference_is_rejected(#[case] input_index: usize) {
-        let node = KernelPlanNode::new(KernelValues::new(test_schema(), vec![]), vec![input_index]);
-        let err = to_df_plan(&KernelPlan { nodes: vec![node] }).unwrap_err();
-        let message = err.to_string();
-        assert!(message.contains("node 0 (values)"), "{message}");
-        assert!(
-            message.contains(&format!("references input {input_index}")),
-            "{message}"
-        );
-        assert!(message.contains("0 prior node(s)"), "{message}");
-    }
 
     #[tokio::test]
     async fn filter_plan_executes() {
@@ -160,20 +112,17 @@ mod tests {
         let project_schema = Arc::new(
             StructType::try_new([StructField::nullable("projected", DataType::LONG)]).unwrap(),
         );
-        let project = KernelProject {
-            expr: KernelExpr::struct_from([col!("a")]).into(),
-            schema: project_schema,
-        };
-        let filter = KernelFilter {
-            predicate: KernelPredicate::is_not_null(col!("projected")).into(),
-        };
-        let plan = KernelPlan {
-            nodes: vec![
-                values_node(vec![vec![1i64.into()]]),
-                KernelPlanNode::new(project, vec![0]),
-                KernelPlanNode::new(filter, vec![1]),
-            ],
-        };
+        let plan = PlanBuilder::values(Arc::new(test_schema()), vec![vec![KernelScalar::Long(1)]])
+            .unwrap()
+            .project(
+                KernelExpr::struct_from([col!("a")]),
+                Arc::clone(&project_schema),
+            )
+            .unwrap()
+            .filter(KernelPredicate::is_not_null(col!("projected")))
+            .unwrap()
+            .build()
+            .unwrap();
 
         let batches = execute(&plan).await.unwrap();
         assert_batches_eq!(

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -13,10 +13,11 @@ use delta_kernel::expressions::{
     Scalar as KernelScalar, UnaryPredicate as KernelUnaryPredicate,
     UnaryPredicateOp as KernelUnaryPredicateOp,
 };
+use delta_kernel::plans::ir::expression::{PlanComparison, PlanPredicate, PlanPredicateKind};
 use delta_kernel::schema::{DataType, StructType};
 use delta_kernel::{DeltaResult, Error};
 
-use crate::expression::to_df_expr;
+use crate::expression::{to_df_expr, to_df_plan_expr};
 use crate::scalar::to_df_scalar;
 
 /// Converts a kernel [`Predicate`](KernelPredicate) into a boolean-valued DataFusion
@@ -48,6 +49,68 @@ pub fn to_df_predicate_expr(
         KernelPredicate::Unknown(name) => Err(Error::unsupported(format!(
             "cannot convert Unknown predicate {name:?}"
         ))),
+    }
+}
+
+/// Converts a resolved plan predicate into its DataFusion equivalent.
+///
+/// Kernel has already proved operand types, Boolean inputs, and membership in the mandatory plan
+/// dialect. This lowering therefore performs no source-language inference or fallback.
+///
+/// # Errors
+///
+/// Returns an error when a resolved child cannot be represented by DataFusion. An empty junction
+/// indicates an invalid resolved plan.
+pub(crate) fn to_df_plan_predicate_expr(
+    predicate: &PlanPredicate,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
+    match predicate.kind() {
+        PlanPredicateKind::Boolean(expression) => to_df_plan_expr(expression, input_schema),
+        PlanPredicateKind::Not(inner) => Ok(DFExpr::Not(Box::new(to_df_plan_predicate_expr(
+            inner,
+            input_schema,
+        )?))),
+        PlanPredicateKind::IsNull {
+            expression,
+            inverted,
+        } => {
+            let expression = to_df_plan_expr(expression, input_schema)?;
+            if inverted {
+                Ok(DFExpr::IsNotNull(Box::new(expression)))
+            } else {
+                Ok(DFExpr::IsNull(Box::new(expression)))
+            }
+        }
+        PlanPredicateKind::Compare { op, left, right } => {
+            let op = match op {
+                PlanComparison::LessThan => Operator::Lt,
+                PlanComparison::GreaterThan => Operator::Gt,
+                PlanComparison::Equal => Operator::Eq,
+                PlanComparison::Distinct => Operator::IsDistinctFrom,
+            };
+            Ok(binary_expr(
+                to_df_plan_expr(left, input_schema)?,
+                op,
+                to_df_plan_expr(right, input_schema)?,
+            ))
+        }
+        PlanPredicateKind::And(predicates) => {
+            let expressions = predicates
+                .iter()
+                .map(|predicate| to_df_plan_predicate_expr(predicate, input_schema))
+                .collect::<DeltaResult<Vec<_>>>()?;
+            conjunction(expressions)
+                .ok_or_else(|| Error::internal_error("resolved plan AND predicate has no children"))
+        }
+        PlanPredicateKind::Or(predicates) => {
+            let expressions = predicates
+                .iter()
+                .map(|predicate| to_df_plan_predicate_expr(predicate, input_schema))
+                .collect::<DeltaResult<Vec<_>>>()?;
+            disjunction(expressions)
+                .ok_or_else(|| Error::internal_error("resolved plan OR predicate has no children"))
+        }
     }
 }
 

--- a/ffi/src/plans/executor.rs
+++ b/ffi/src/plans/executor.rs
@@ -58,7 +58,7 @@ unsafe impl Sync for FfiPlanExecutor {}
 
 impl PlanExecutor for FfiPlanExecutor {
     fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult> {
-        let plan_proto_bytes = op.to_proto_bytes();
+        let plan_proto_bytes = op.to_proto_bytes()?;
         let plan_proto_slice = kernel_bytes_slice!(plan_proto_bytes);
 
         let mut out = EngineExecResult::Uninit;

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -470,8 +470,9 @@ fn scan_declarative_metadata_plan_impl(
         .map(|plan| {
             delta_kernel::Operation::QueryPlan(plan)
                 .to_proto_bytes()
-                .into()
+                .map(Into::into)
         })
+        .transpose()?
         .into())
 }
 

--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -1,9 +1,10 @@
-// Proto mirror of `kernel/src/expressions/mod.rs` + `scalars.rs` (the Rust IR is the source
-// of truth for these shapes).
+// Expression wire types. The broad Expression/Predicate messages describe source syntax and
+// optional analysis input. Mandatory query-plan execution uses only the closed PlanExpression and
+// PlanPredicate messages below.
 //
-// Opaque{Expression,Predicate} and Unknown are escape hatches: kernel-rs can't serialise the
-// opaque trait objects, and Unknown is the "do not silently interpret" marker. They appear
-// here so the grammar is total, but engines MUST error on them, not produce NULL.
+// Opaque nodes carry a name rather than a Rust callback. An optional optimizer may use one only
+// when it recognizes the exact engine-owned operation; otherwise it must keep all candidate rows.
+// Unknown nodes are never executable.
 
 syntax = "proto3";
 
@@ -120,6 +121,97 @@ message ColumnName {
 }
 
 // ============================================================================
+// Resolved declarative-plan language
+// ============================================================================
+
+// These messages define every expression used for mandatory plan execution. They deliberately
+// exclude arithmetic, casts, arrays, IN, opaque callbacks, and unknown placeholders. A
+// DataSkippingNode may separately carry a broad Predicate as optional analysis input.
+
+enum PlanComparison {
+  PLAN_COMPARISON_UNSPECIFIED = 0;
+  PLAN_COMPARISON_LESS_THAN = 1;
+  PLAN_COMPARISON_GREATER_THAN = 2;
+  PLAN_COMPARISON_EQUAL = 3;
+  PLAN_COMPARISON_DISTINCT = 4;
+}
+
+message PlanStructExpression {
+  repeated PlanExpression fields = 1;
+  PlanExpression nullability = 2;
+}
+
+message PlanFieldPatch {
+  bool keep_input = 1;
+  repeated PlanExpression insertions = 2;
+  bool optional = 3;
+}
+
+message PlanStructPatch {
+  ColumnName input_path = 1;
+  map<string, PlanFieldPatch> field_patches = 2;
+  repeated PlanExpression prepended_fields = 3;
+  repeated PlanExpression appended_fields = 4;
+}
+
+message PlanCoalesce {
+  repeated PlanExpression expressions = 1;
+}
+
+message PlanParseJson {
+  PlanExpression json = 1;
+  delta.kernel.schema.StructType output_schema = 2;
+}
+
+message PlanMapToStruct {
+  PlanExpression map = 1;
+  delta.kernel.schema.StructType output_schema = 2;
+}
+
+message PlanIsNull {
+  PlanExpression expression = 1;
+  bool inverted = 2;
+}
+
+message PlanCompare {
+  PlanComparison op = 1;
+  PlanExpression left = 2;
+  PlanExpression right = 3;
+}
+
+message PlanJunction {
+  repeated PlanPredicate predicates = 1;
+}
+
+message PlanPredicate {
+  // Whether this predicate can evaluate to SQL unknown.
+  bool nullable = 1;
+  oneof kind {
+    PlanExpression boolean_expression = 2;
+    PlanPredicate not = 3;
+    PlanIsNull is_null = 4;
+    PlanCompare compare = 5;
+    PlanJunction and = 6;
+    PlanJunction or = 7;
+  }
+}
+
+message PlanExpression {
+  delta.kernel.schema.DataType data_type = 1;
+  bool nullable = 2;
+  oneof kind {
+    Scalar literal = 3;
+    ColumnName column = 4;
+    PlanPredicate predicate = 5;
+    PlanStructExpression struct_expr = 6;
+    PlanStructPatch struct_patch = 7;
+    PlanCoalesce coalesce = 8;
+    PlanParseJson parse_json = 9;
+    PlanMapToStruct map_to_struct = 10;
+  }
+}
+
+// ============================================================================
 // Composite expression bodies
 // ============================================================================
 
@@ -152,6 +244,11 @@ message ParseJsonExpression {
 
 message MapToStructExpression {
   Expression map_expr = 1;
+}
+
+message CastExpression {
+  Expression expr = 1;
+  delta.kernel.schema.DataType target = 2;
 }
 
 // `nullability_predicate` is optional: when set and it evaluates to false/null, the whole
@@ -239,5 +336,6 @@ message Expression {
     ParseJsonExpression parse_json = 11;
     MapToStructExpression map_to_struct = 12;
     string unknown = 13;
+    CastExpression cast = 14;
   }
 }

--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -1,4 +1,4 @@
-// Proto mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (the Rust IR is the source of truth).
+// Wire representation of the validated declarative-plan IR.
 //
 // A plan is a DAG of plan nodes: `Plan` is a flat list of `PlanNode`s, and each node wires
 // into the DAG by referencing other nodes' positions (indices into `Plan.nodes`) in its
@@ -55,12 +55,35 @@ message ValuesNode {
 // ============================================================================
 
 message ProjectNode {
-  delta.kernel.expressions.Expression expr = 1;
+  delta.kernel.expressions.PlanExpression expr = 1;
   delta.kernel.schema.StructType schema = 2;
 }
 
 message FilterNode {
-  delta.kernel.expressions.Predicate predicate = 1;
+  delta.kernel.expressions.PlanPredicate predicate = 1;
+}
+
+// Optional analysis input for conservative file pruning. Ignoring this node is identity.
+message DataSkippingStats {
+  delta.kernel.schema.StructType source_schema = 1;
+  delta.kernel.expressions.ColumnName stats_column = 2;
+  delta.kernel.expressions.ColumnName partition_values_column = 3;
+}
+
+message DataSkippingTarget {
+  oneof target {
+    bool adds_only = 1;
+    delta.kernel.expressions.ColumnName is_add = 2;
+  }
+}
+
+message DataSkippingNode {
+  // This broad predicate is analysis input, not an expression the executor must evaluate.
+  delta.kernel.expressions.Predicate source_predicate = 1;
+  DataSkippingStats stats = 2;
+  DataSkippingTarget target = 3;
+  // For mixed-action targets, this predicate includes the guard that retains non-Add rows.
+  delta.kernel.expressions.PlanPredicate kernel_keep_predicate = 4;
 }
 
 message UnionAllNode {}
@@ -150,6 +173,7 @@ message Operator {
     DynamicScanNode dynamic_scan = 7;
     AggregateNode aggregate = 8;
     SemiJoinNode semi_join = 9;
+    DataSkippingNode data_skipping = 10;
   }
 }
 

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -130,8 +130,8 @@ impl SyncPlanExecutor {
     /// Evaluates `query` by materializing each node's output in slice (topological) order, then
     /// streams the terminal (last) node's batches to the caller.
     fn execute_query(&self, query: Plan) -> DeltaResult<PlanResult> {
-        let mut outputs: Vec<Vec<RecordBatch>> = Vec::with_capacity(query.nodes.len());
-        for node in query.nodes {
+        let mut outputs: Vec<Vec<RecordBatch>> = Vec::with_capacity(query.nodes().len());
+        for node in query.into_nodes() {
             let output = self.eval_node(node, &outputs)?;
             outputs.push(output);
         }
@@ -151,7 +151,7 @@ impl SyncPlanExecutor {
         node: PlanNode,
         results: &[Vec<RecordBatch>],
     ) -> DeltaResult<Vec<RecordBatch>> {
-        let PlanNode { op, inputs } = node;
+        let (op, inputs) = node.into_parts();
         match op {
             Operator::ScanJson(ScanJson {
                 files,
@@ -168,7 +168,17 @@ impl SyncPlanExecutor {
                 inputs.iter().flat_map(|&i| results[i].iter().cloned()),
             )),
             Operator::Project(project) => eval_project(project, &results[inputs[0]]),
-            Operator::Filter(filter) => eval_filter(filter.predicate, &results[inputs[0]]),
+            Operator::Filter(filter) => eval_filter(
+                Arc::clone(filter.predicate().source_predicate()),
+                &results[inputs[0]],
+            ),
+            Operator::DataSkipping(site) => match site.kernel_keep_predicate() {
+                Some(predicate) => eval_filter(
+                    Arc::clone(predicate.source_predicate()),
+                    &results[inputs[0]],
+                ),
+                None => Ok(results[inputs[0]].clone()),
+            },
             Operator::DynamicScan(dynamic_scan) => {
                 self.eval_dynamic_scan(dynamic_scan, &results[inputs[0]])
             }
@@ -350,8 +360,8 @@ fn eval_project(project: Project, input: &[RecordBatch]) -> DeltaResult<Vec<Reco
     let input_schema = Arc::new(StructType::try_from_arrow(first_batch.schema().as_ref())?);
     let evaluator = ArrowEvaluationHandler.new_expression_evaluator(
         input_schema,
-        project.expr,
-        project.schema.as_ref().clone().into(),
+        Arc::clone(project.expression().source_expression()),
+        project.schema().as_ref().clone().into(),
     )?;
     input
         .iter()

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -31,8 +31,8 @@
 //! // ... while `build` keeps the plan runnable, replacing the absent relation with a single
 //! // empty `Values` node.
 //! let plan = scan.build()?;
-//! let [node] = plan.nodes.as_slice() else { panic!("expected one node") };
-//! assert!(matches!(&node.op, Operator::Values(values) if values.rows.is_empty()));
+//! let [node] = plan.nodes() else { panic!("expected one node") };
+//! assert!(matches!(node.operator(), Operator::Values(values) if values.rows.is_empty()));
 //! # Ok::<(), delta_kernel::Error>(())
 //! ```
 
@@ -42,8 +42,8 @@ use std::sync::Arc;
 use delta_kernel_derive::internal_api;
 
 use super::ir::nodes::{
-    Aggregate, AggregateBuilder, DynamicScan, FileType, Filter, Operator, Project, ScanFile,
-    ScanJson, ScanParquet, SemiJoin, UnionAll, Values,
+    Aggregate, AggregateBuilder, DataSkippingSite, DynamicScan, FileType, Filter, Operator,
+    Project, ScanFile, ScanJson, ScanParquet, SemiJoin, UnionAll, Values,
 };
 use super::ir::plan::{Plan, PlanNode};
 use crate::expressions::{ColumnName, ExpressionRef, PredicateRef, Scalar, StructData};
@@ -92,7 +92,7 @@ impl PlanBuilder {
     }
 
     /// The output schema of this relation -- carried whether present or absent.
-    fn schema(&self) -> &SchemaRef {
+    pub(crate) fn schema(&self) -> &SchemaRef {
         match &self.0 {
             PlanBuilderRoot::Present(node) => &node.schema,
             PlanBuilderRoot::Absent(schema) => schema,
@@ -224,7 +224,7 @@ impl PlanBuilder {
     /// }
     ///
     /// let plan = PlanBuilder::values_from([Row { id: 1 }, Row { id: 2 }]).build()?;
-    /// let Operator::Values(values) = &plan.nodes[0].op else { panic!("expected Values") };
+    /// let Operator::Values(values) = plan.nodes()[0].operator() else { panic!("expected Values") };
     /// assert_eq!(
     ///     values.rows,
     ///     vec![vec![Scalar::Integer(1)], vec![Scalar::Integer(2)]],
@@ -244,7 +244,8 @@ impl PlanBuilder {
 
     /// Keep rows where `predicate` holds. Output schema is unchanged. See [`Filter`].
     ///
-    /// Produces an error when `predicate` references a column absent from the input schema.
+    /// Produces an error when `predicate` references a column absent from the input schema, is not
+    /// Boolean, or contains an expression outside the mandatory plan dialect.
     ///
     /// # Example
     /// ```
@@ -259,17 +260,34 @@ impl PlanBuilder {
     /// # Ok::<(), delta_kernel::Error>(())
     /// ```
     pub fn filter(self, predicate: impl Into<PredicateRef>) -> DeltaResult<Self> {
-        let predicate = predicate.into();
-        check_columns_resolve(self.schema(), predicate.references(), "filter")?;
+        let filter = Filter::try_new(self.schema(), predicate)?;
         let schema = Arc::clone(self.schema());
-        Ok(self.unary_op_or_absent(schema, Filter { predicate }))
+        Ok(self.unary_op_or_absent(schema, filter))
+    }
+
+    /// Marks this relation as a safe site for optional conservative data skipping.
+    ///
+    /// The node is an identity operation when an executor declines the optimization. An executor
+    /// that applies the site must obey [`DataSkippingSite`]'s keep-all fallback and protected-row
+    /// contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the site's resolved metadata, target, or portable predicate does not
+    /// match this relation's schema.
+    pub fn data_skipping_site(self, site: DataSkippingSite) -> DeltaResult<Self> {
+        site.validate_input(self.schema())?;
+        let schema = Arc::clone(self.schema());
+        Ok(self.unary_op_or_absent(schema, site))
     }
 
     /// Project `self` through `expr` into rows of the caller-declared `schema`. `expr` must be a
     /// struct constructor / patch matching `schema`. See [`Project`].
     ///
-    /// Produces an error when `expr` references a column absent from the input schema. References
-    /// inside a `StructPatch` are validated by [`ProjectionStructPatchBuilder`] when the patch is
+    /// Produces an error when `expr` references a column absent from the input schema, contains a
+    /// node outside the mandatory plan dialect, or cannot produce the declared output type and
+    /// nullability. References inside a `StructPatch` are validated by
+    /// [`ProjectionStructPatchBuilder`] when the patch is
     ///
     /// [`ProjectionStructPatchBuilder`]: crate::struct_patch::ProjectionStructPatchBuilder
     ///
@@ -296,9 +314,8 @@ impl PlanBuilder {
         schema: impl Into<SchemaRef>,
     ) -> DeltaResult<Self> {
         let schema = schema.into();
-        let expr = expr.into();
-        check_columns_resolve(self.schema(), expr.references(), "project")?;
-        Ok(self.unary_op_or_absent(Arc::clone(&schema), Project { expr, schema }))
+        let project = Project::try_new(self.schema(), expr, Arc::clone(&schema))?;
+        Ok(self.unary_op_or_absent(schema, project))
     }
 
     /// Project `self` by editing its columns. `edit` receives a [`ProjectionStructPatchBuilder`]
@@ -426,8 +443,8 @@ impl PlanBuilder {
     ///
     /// Keys are columns (e.g. [`column_name!`](crate::expressions::column_name)), matched pairwise.
     ///
-    /// Produces an error when the probe and build key counts differ, or a probe/build key is absent
-    /// from its input schema.
+    /// Produces an error when the probe and build key counts differ, a key is absent, or paired
+    /// keys have different data types.
     ///
     /// # Example
     /// ```
@@ -481,6 +498,17 @@ impl PlanBuilder {
         }
         check_columns_resolve(self.schema(), &probe_keys, "join probe")?;
         check_columns_resolve(build.schema(), &build_keys, "join build")?;
+        for (probe_key, build_key) in probe_keys.iter().zip(&build_keys) {
+            let probe_field = self.schema().field_at(probe_key)?;
+            let build_field = build.schema().field_at(build_key)?;
+            if probe_field.data_type() != build_field.data_type() {
+                return Err(Error::generic(format!(
+                    "join keys `{probe_key}` and `{build_key}` have different types: {} and {}",
+                    probe_field.data_type(),
+                    build_field.data_type()
+                )));
+            }
+        }
         // An uninhabited probe always produces an uninhabited result; forward it unchanged.
         let PlanBuilderRoot::Present(probe) = self.0 else {
             return Ok(self);
@@ -545,29 +573,27 @@ impl PlanBuilder {
     /// Linearize the DAG reachable from `self` into a [`Plan`]. An absent relation builds to a
     /// single empty [`Values`] node carrying its schema, so the result is always a runnable plan.
     pub fn build(&self) -> DeltaResult<Plan> {
-        Ok(match &self.0 {
+        match &self.0 {
             PlanBuilderRoot::Present(root) => Self::build_plan(root),
-            PlanBuilderRoot::Absent(schema) => Plan {
-                nodes: vec![PlanNode::new(
-                    Values::new(Arc::clone(schema), vec![]),
-                    vec![],
-                )],
-            },
-        })
+            PlanBuilderRoot::Absent(schema) => Plan::try_new(vec![PlanNode::new(
+                Values::new(Arc::clone(schema), vec![]),
+                vec![],
+            )]),
+        }
     }
 
     /// Like [`Self::build`], but yields `None` for an absent relation instead of an empty plan.
     pub fn build_opt(&self) -> DeltaResult<Option<Plan>> {
-        Ok(match &self.0 {
-            PlanBuilderRoot::Present(root) => Some(Self::build_plan(root)),
-            PlanBuilderRoot::Absent(_) => None,
-        })
+        match &self.0 {
+            PlanBuilderRoot::Present(root) => Ok(Some(Self::build_plan(root)?)),
+            PlanBuilderRoot::Absent(_) => Ok(None),
+        }
     }
 
     /// Linearize the DAG rooted at `root` into a topologically sorted [`Plan`] with `root` as the
     /// last (terminal) node. A node's inputs always precede it, referenced by their index in
     /// [`Plan::nodes`]. Shared subgraphs are emitted once; multiple nodes can reference them.
-    fn build_plan(root: &BuilderNodeRef) -> Plan {
+    fn build_plan(root: &BuilderNodeRef) -> DeltaResult<Plan> {
         // Maps a node's Arc pointer to its index, deduping shared subgraphs. Pointers are stable
         // because `root` pins all reachable nodes for the lifetime of `build_plan`.
         fn emit(
@@ -588,7 +614,7 @@ impl PlanBuilder {
         }
         let mut nodes = Vec::new();
         emit(root, &mut nodes, &mut HashMap::new());
-        Plan { nodes }
+        Plan::try_new(nodes)
     }
 }
 
@@ -650,8 +676,8 @@ mod tests {
 
     use super::*;
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
-    use crate::expressions::{col, column_name, lit, Expression};
-    use crate::plans::ir::nodes::FileType;
+    use crate::expressions::{col, column_name, lit, BinaryExpressionOp, Expression, Predicate};
+    use crate::plans::ir::nodes::{DataSkippingStats, DataSkippingTarget, FileType};
     use crate::schema::{
         schema, schema_ref, DataType, MetadataColumnSpec, StructField, StructType,
     };
@@ -682,6 +708,12 @@ mod tests {
         }
     }
 
+    fn x_string_schema() -> SchemaRef {
+        schema_ref! {
+            nullable "x": STRING,
+        }
+    }
+
     /// A one-row (all-null) `Values` source over `schema` -- the common present-source fixture.
     /// (Empty rows would collapse to absent.)
     fn vals(schema: SchemaRef) -> PlanBuilder {
@@ -705,10 +737,10 @@ mod tests {
     /// inspection.
     fn assert_plan(builder: PlanBuilder, expected: &[(&[usize], &str)]) -> Plan {
         let plan = builder.build().unwrap();
-        assert_eq!(plan.nodes.len(), expected.len(), "node count");
-        for (i, (node, &(inputs, op))) in plan.nodes.iter().zip(expected).enumerate() {
-            assert_eq!(node.inputs.as_slice(), inputs, "node {i} inputs");
-            assert_eq!(node.op.to_string(), op, "node {i} op");
+        assert_eq!(plan.nodes().len(), expected.len(), "node count");
+        for (i, (node, &(inputs, op))) in plan.nodes().iter().zip(expected).enumerate() {
+            assert_eq!(node.inputs(), inputs, "node {i} inputs");
+            assert_eq!(node.operator().to_string(), op, "node {i} op");
         }
         plan
     }
@@ -749,7 +781,7 @@ mod tests {
         )?;
         assert_eq!(parquet.schema(), &part_schema());
         let plan = assert_plan(parquet, &[(&[], "scan_parquet")]);
-        let Operator::ScanParquet(node) = &plan.nodes[0].op else {
+        let Operator::ScanParquet(node) = plan.nodes()[0].operator() else {
             panic!("expected ScanParquet");
         };
         assert_eq!(node.file_constant_columns, part);
@@ -760,7 +792,7 @@ mod tests {
             part_schema(),
         )?;
         let plan = assert_plan(json, &[(&[], "scan_json")]);
-        let Operator::ScanJson(node) = &plan.nodes[0].op else {
+        let Operator::ScanJson(node) = plan.nodes()[0].operator() else {
             panic!("expected ScanJson");
         };
         assert_eq!(node.file_constant_columns, part);
@@ -772,6 +804,49 @@ mod tests {
     fn filter_preserves_schema() -> DeltaResult<()> {
         let filtered = vals(id_schema()).filter(col!("id").is_not_null())?;
         assert_eq!(filtered.schema(), &id_schema());
+        Ok(())
+    }
+
+    #[test]
+    fn data_skipping_can_carry_divide_without_adding_it_to_plan_expressions() -> DeltaResult<()> {
+        let source_schema = schema_ref! {
+            nullable "x": LONG,
+        };
+        let stats_schema = StructType::new_unchecked([StructField::nullable(
+            "maxValues",
+            StructType::new_unchecked([StructField::nullable("x", DataType::LONG)]),
+        )]);
+        let input_schema = schema_ref! {
+            nullable "stats": (stats_schema),
+            not_null "is_add": BOOLEAN,
+        };
+        let source_predicate = Predicate::gt(
+            Expression::binary(BinaryExpressionOp::Divide, col!("x"), lit(2i64)),
+            lit(50i64),
+        );
+        let input = scan(Arc::clone(&input_schema));
+        let stats = DataSkippingStats::try_new(
+            &input_schema,
+            source_schema,
+            Some(column_name!("stats")),
+            None,
+        )?;
+        let target = DataSkippingTarget::mixed_actions(&input_schema, column_name!("is_add"))?;
+        let site = DataSkippingSite::try_new(&input_schema, source_predicate, stats, target, None)?;
+
+        let plan = input.data_skipping_site(site)?.build()?;
+        let Operator::DataSkipping(site) = plan.nodes()[1].operator() else {
+            panic!("expected DataSkipping");
+        };
+        assert!(site.kernel_keep_predicate().is_none());
+        assert_eq!(
+            site.stats().source_schema(),
+            &schema_ref! { nullable "x": LONG }
+        );
+        assert_eq!(
+            site.target().is_add().map(|column| column.name()),
+            Some(&column_name!("is_add"))
+        );
         Ok(())
     }
 
@@ -889,9 +964,9 @@ mod tests {
     #[case::semi_join_absent_build(
         vals(id_schema()).semi_join(absent_src(), [column_name!("id")], [column_name!("id")]))]
     #[case::semi_join_absent_probe(
-        absent_src().semi_join(vals(x_schema()), [column_name!("id")], [column_name!("x")]))]
+        absent_src().semi_join(vals(x_string_schema()), [column_name!("id")], [column_name!("x")]))]
     #[case::anti_join_absent_probe(
-        absent_src().anti_join(vals(x_schema()), [column_name!("id")], [column_name!("x")]))]
+        absent_src().anti_join(vals(x_string_schema()), [column_name!("id")], [column_name!("x")]))]
     #[case::union_all_of_absent(PlanBuilder::union_all([absent_src(), absent_src()]))]
     fn collapses_to_absent(#[case] builder: DeltaResult<PlanBuilder>) -> DeltaResult<()> {
         assert!(builder?.build_opt()?.is_none()); // absent has no plan to run
@@ -905,7 +980,7 @@ mod tests {
         let absent = absent_src();
         assert_eq!(absent.schema(), &id_schema());
         let plan = assert_plan(absent, &[(&[], "values")]);
-        let Operator::Values(values) = &plan.nodes[0].op else {
+        let Operator::Values(values) = plan.nodes()[0].operator() else {
             panic!("expected Values");
         };
         assert!(values.rows.is_empty());
@@ -987,7 +1062,7 @@ mod tests {
             Aggregate::group_by(id_schema(), Vec::<ColumnName>::new()).max(column_name!("id")),
         )?;
         let plan = assert_plan(agg, &[(&[], "values"), (&[0], "aggregate")]);
-        let Operator::Values(values) = &plan.nodes[0].op else {
+        let Operator::Values(values) = plan.nodes()[0].operator() else {
             panic!("expected Values input");
         };
         assert!(values.rows.is_empty());
@@ -1004,7 +1079,7 @@ mod tests {
         assert_eq!(schema.fields().count(), 1);
         assert!(schema.field("part").is_some());
         let plan = assert_plan(agg, &[(&[], "values"), (&[0], "aggregate")]);
-        let Operator::Aggregate(node) = &plan.nodes[1].op else {
+        let Operator::Aggregate(node) = plan.nodes()[1].operator() else {
             panic!("expected Aggregate");
         };
         assert!(node.group_by.is_empty());
@@ -1062,13 +1137,21 @@ mod tests {
         Ok(())
     }
 
-    /// `project` records the caller's declared output schema verbatim.
+    /// `project` records the validated caller-declared output schema verbatim.
     #[test]
     fn project_records_declared_schema() -> DeltaResult<()> {
-        let out = x_schema();
+        let out = schema_ref! { nullable "renamed_id": STRING };
         let p = vals(id_schema()).project(Expression::struct_from([col!("id")]), out.clone())?;
         assert_eq!(p.schema(), &out);
-        assert_plan(p, &[(&[], "values"), (&[0], "project")]);
+        let plan = assert_plan(p, &[(&[], "values"), (&[0], "project")]);
+        let Operator::Project(project) = plan.nodes()[1].operator() else {
+            panic!("expected Project");
+        };
+        assert_eq!(project.schema(), &out);
+        assert_eq!(
+            project.expression().data_type(),
+            &DataType::from(out.as_ref().clone())
+        );
         Ok(())
     }
 
@@ -1079,7 +1162,7 @@ mod tests {
         #[values(false, true)] inverted: bool,
     ) -> DeltaResult<()> {
         let probe = vals(id_schema());
-        let build = vals(x_schema());
+        let build = vals(x_string_schema());
         let joined = if inverted {
             probe.anti_join(build, [column_name!("id")], [column_name!("x")])?
         } else {
@@ -1091,7 +1174,7 @@ mod tests {
             joined,
             &[(&[], "values"), (&[], "values"), (&[0, 1], "semi_join")],
         );
-        let Operator::SemiJoin(node) = &plan.nodes[2].op else {
+        let Operator::SemiJoin(node) = plan.nodes()[2].operator() else {
             panic!("expected SemiJoin");
         };
         assert_eq!(node.inverted, inverted);
@@ -1137,9 +1220,12 @@ mod tests {
         let input = dynamic_scan_input_schema();
         let out = dynamic_scan_output_schema();
         let node = dynamic_scan_node(&input, out.clone())?;
-        let dynamic_scan = vals(input).dynamic_scan(node)?;
+        let dynamic_scan = scan(input).dynamic_scan(node)?;
         assert_eq!(dynamic_scan.schema(), &out);
-        assert_plan(dynamic_scan, &[(&[], "values"), (&[0], "dynamic_scan")]);
+        assert_plan(
+            dynamic_scan,
+            &[(&[], "scan_parquet"), (&[0], "dynamic_scan")],
+        );
         Ok(())
     }
 
@@ -1287,10 +1373,24 @@ mod tests {
     #[case::values_row_width("schema has 1 field",
         || PlanBuilder::values(id_schema(), vec![vec!["a".into(), "b".into()]]))]
     // transforms referencing an absent column
-    #[case::filter_unknown_column("`nope` not found",
+    #[case::filter_unknown_column("field 'nope' not found",
         || vals(id_schema()).filter(col!("nope").is_not_null()))]
-    #[case::project_unknown_column("`nope` not found",
+    #[case::project_unknown_column("field 'nope' not found",
         || vals(id_schema()).project(Expression::struct_from([col!("nope")]), id_schema()))]
+    #[case::filter_non_boolean("expected boolean",
+        || vals(id_schema()).filter(Predicate::BooleanExpression(lit(1i64))))]
+    #[case::project_arithmetic("not part of the mandatory plan expression dialect", || {
+        let expr = Expression::struct_from([Expression::binary(
+            BinaryExpressionOp::Divide,
+            lit(4i64),
+            lit(2i64),
+        )]);
+        vals(x_schema()).project(expr, x_schema())
+    })]
+    #[case::project_type_mismatch("expected string",
+        || vals(id_schema()).project(Expression::struct_from([lit(1i64)]), id_schema()))]
+    #[case::project_non_struct("must be a Struct or StructPatch",
+        || vals(id_schema()).project(col!("id"), id_schema()))]
     #[case::project_patch_missing_field("does not exist",
         || vals(id_schema()).project_patch(|p| p.drop("nope")))]
     #[case::aggregate_unknown_value("not found in schema",
@@ -1308,6 +1408,8 @@ mod tests {
         || vals(id_schema()).anti_join(vals(x_schema()), [column_name!("id")], [column_name!("nope")]))]
     #[case::join_key_arity("must match",
         || vals(id_schema()).semi_join(vals(x_schema()), [column_name!("id")], [column_name!("x"), column_name!("x")]))]
+    #[case::join_key_type("different types",
+        || vals(id_schema()).semi_join(vals(x_schema()), [column_name!("id")], [column_name!("x")]))]
     // dynamic scan file constants
     #[case::dynamic_scan_missing_source("`version`", || build_dynamic_scan_with_schemas(
         dynamic_scan_input_missing("version"),

--- a/kernel/src/plans/ir/expression.rs
+++ b/kernel/src/plans/ir/expression.rs
@@ -1,0 +1,1170 @@
+//! Resolved expressions and predicates accepted by declarative plans.
+//!
+//! Public [`Expression`] values are a broad source language. Plan
+//! construction resolves that language against an input schema and rejects nodes outside the
+//! mandatory replay dialect before an executor receives the plan.
+//!
+//! Resolution makes runtime schema facts explicit. For example, given:
+//!
+//! ```text
+//! add: nullable struct {
+//!     path: non-null string
+//! }
+//! ```
+//!
+//! `add.path` resolves to `STRING, nullable`: the non-null leaf can still be null when its parent
+//! is null. Every executor sees that same result through [`PlanColumn`] instead of independently
+//! rediscovering it.
+//!
+//! The source language remains broader than this module. A caller predicate containing `x / 2`
+//! may be carried by an optional [`DataSkippingSite`](super::nodes::DataSkippingSite) for native
+//! range analysis, but `Divide` cannot appear in [`PlanExpressionKind`] and is never mandatory for
+//! replay.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::expressions::{
+    BinaryPredicateOp, ColumnName, Expression, ExpressionRef, ExpressionStructPatch,
+    JunctionPredicateOp, Predicate, PredicateRef, Scalar, UnaryPredicateOp, VariadicExpressionOp,
+};
+use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::{DeltaResult, Error};
+
+/// A shared reference to a resolved [`PlanExpression`].
+pub type PlanExpressionRef = Arc<PlanExpression>;
+
+/// A shared reference to a resolved [`PlanPredicate`].
+pub type PlanPredicateRef = Arc<PlanPredicate>;
+
+/// A column path resolved against the schema at a declarative-plan boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanColumn {
+    name: ColumnName,
+    data_type: DataType,
+    nullable: bool,
+}
+
+impl PlanColumn {
+    pub(crate) fn resolve(input_schema: &StructType, name: ColumnName) -> DeltaResult<Self> {
+        let (data_type, nullable) = resolve_column(input_schema, &name)?;
+        Ok(Self {
+            name,
+            data_type,
+            nullable,
+        })
+    }
+
+    /// Returns the resolved column path.
+    pub fn name(&self) -> &ColumnName {
+        &self.name
+    }
+
+    /// Returns the resolved column's leaf type.
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    /// Returns whether the leaf or any parent struct is nullable.
+    pub fn is_nullable(&self) -> bool {
+        self.nullable
+    }
+}
+
+/// An expression resolved and validated for execution inside a declarative plan.
+#[derive(Debug, Clone)]
+pub struct PlanExpression {
+    source: ExpressionRef,
+    node: PlanExpressionNode,
+    data_type: DataType,
+    nullable: bool,
+}
+
+/// A borrowed view of a resolved plan expression.
+#[derive(Debug, Clone, Copy)]
+pub enum PlanExpressionKind<'a> {
+    /// A typed literal.
+    Literal(&'a Scalar),
+    /// A column path proved to exist in the input schema.
+    Column(&'a PlanColumn),
+    /// A Boolean predicate used as an expression.
+    Predicate(&'a PlanPredicate),
+    /// A struct constructor whose children are paired with the output fields in order.
+    Struct {
+        /// Resolved expressions for the struct fields.
+        fields: &'a [PlanExpressionRef],
+        /// Optional Boolean expression controlling whether the struct value is null.
+        nullability: Option<&'a PlanExpression>,
+    },
+    /// A sparse struct projection resolved against its input and output schemas.
+    StructPatch(&'a PlanStructPatch),
+    /// A non-empty, same-type coalesce operation.
+    Coalesce(&'a [PlanExpressionRef]),
+    /// Permissive JSON parsing into the attached output schema.
+    ParseJson {
+        /// Resolved string input.
+        json: &'a PlanExpression,
+        /// Struct schema produced by parsing.
+        output_schema: &'a SchemaRef,
+    },
+    /// Conversion of a string map into the attached typed struct.
+    MapToStruct {
+        /// Resolved map input.
+        map: &'a PlanExpression,
+        /// Struct schema produced from map entries.
+        output_schema: &'a StructType,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum PlanExpressionNode {
+    Literal(Scalar),
+    Column(PlanColumn),
+    Predicate(PlanPredicateRef),
+    Struct {
+        fields: Vec<PlanExpressionRef>,
+        nullability: Option<PlanExpressionRef>,
+    },
+    StructPatch(PlanStructPatch),
+    Coalesce(Vec<PlanExpressionRef>),
+    ParseJson {
+        json: PlanExpressionRef,
+        output_schema: SchemaRef,
+    },
+    MapToStruct {
+        map: PlanExpressionRef,
+        output_schema: StructType,
+    },
+}
+
+impl PlanExpression {
+    /// Resolves `source` against `input_schema` for use in a declarative plan.
+    ///
+    /// When `expected_type` is present, the resolved output type must match it exactly. The method
+    /// rejects every source-language node outside the mandatory replay dialect.
+    pub fn resolve(
+        source: impl Into<ExpressionRef>,
+        input_schema: &StructType,
+        expected_type: Option<&DataType>,
+    ) -> DeltaResult<PlanExpressionRef> {
+        let source = source.into();
+        let (node, data_type, nullable) =
+            resolve_expression_node(&source, input_schema, expected_type)?;
+        require_expected_type(&data_type, expected_type, "expression")?;
+        Ok(Arc::new(Self {
+            source,
+            node,
+            data_type,
+            nullable,
+        }))
+    }
+
+    /// Returns an exhaustive borrowed view of this expression's resolved node.
+    pub fn kind(&self) -> PlanExpressionKind<'_> {
+        match &self.node {
+            PlanExpressionNode::Literal(value) => PlanExpressionKind::Literal(value),
+            PlanExpressionNode::Column(name) => PlanExpressionKind::Column(name),
+            PlanExpressionNode::Predicate(predicate) => {
+                PlanExpressionKind::Predicate(predicate.as_ref())
+            }
+            PlanExpressionNode::Struct {
+                fields,
+                nullability,
+            } => PlanExpressionKind::Struct {
+                fields,
+                nullability: nullability.as_deref(),
+            },
+            PlanExpressionNode::StructPatch(patch) => PlanExpressionKind::StructPatch(patch),
+            PlanExpressionNode::Coalesce(expressions) => PlanExpressionKind::Coalesce(expressions),
+            PlanExpressionNode::ParseJson {
+                json,
+                output_schema,
+            } => PlanExpressionKind::ParseJson {
+                json,
+                output_schema,
+            },
+            PlanExpressionNode::MapToStruct { map, output_schema } => {
+                PlanExpressionKind::MapToStruct { map, output_schema }
+            }
+        }
+    }
+
+    /// Returns this expression's resolved output type.
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    /// Returns whether this expression can produce a null value.
+    pub fn is_nullable(&self) -> bool {
+        self.nullable
+    }
+
+    /// Returns the validated source expression for delegation to an imperative evaluator.
+    ///
+    /// Plan executors should prefer [`Self::kind`]. Executors that delegate evaluation to an
+    /// [`EvaluationHandler`](crate::EvaluationHandler) can use this tree after Kernel validates it.
+    pub fn source_expression(&self) -> &ExpressionRef {
+        &self.source
+    }
+}
+
+/// A sparse struct projection whose computed children have been recursively resolved.
+#[derive(Debug, Clone)]
+pub struct PlanStructPatch {
+    input_path: Option<ColumnName>,
+    field_patches: HashMap<String, PlanFieldPatch>,
+    prepended_fields: Vec<PlanExpressionRef>,
+    appended_fields: Vec<PlanExpressionRef>,
+}
+
+impl PlanStructPatch {
+    /// Returns the nested input path, or `None` for a top-level patch.
+    pub fn input_path(&self) -> Option<&ColumnName> {
+        self.input_path.as_ref()
+    }
+
+    /// Returns the resolved patch associated with each source field name.
+    pub fn field_patches(&self) -> &HashMap<String, PlanFieldPatch> {
+        &self.field_patches
+    }
+
+    /// Returns fields inserted before all source fields.
+    pub fn prepended_fields(&self) -> &[PlanExpressionRef] {
+        &self.prepended_fields
+    }
+
+    /// Returns fields inserted after all source fields.
+    pub fn appended_fields(&self) -> &[PlanExpressionRef] {
+        &self.appended_fields
+    }
+}
+
+/// A resolved edit associated with one source struct field.
+#[derive(Debug, Clone)]
+pub struct PlanFieldPatch {
+    keep_input: bool,
+    insertions: Vec<PlanExpressionRef>,
+    optional: bool,
+}
+
+impl PlanFieldPatch {
+    /// Returns whether the source field is preserved before the insertions.
+    pub fn keeps_input(&self) -> bool {
+        self.keep_input
+    }
+
+    /// Returns computed fields inserted after the source field's output position.
+    pub fn insertions(&self) -> &[PlanExpressionRef] {
+        &self.insertions
+    }
+
+    /// Returns whether a missing source field causes this patch to be ignored.
+    pub fn is_optional(&self) -> bool {
+        self.optional
+    }
+}
+
+/// A Boolean predicate resolved and validated for execution inside a declarative plan.
+#[derive(Debug, Clone)]
+pub struct PlanPredicate {
+    source: PredicateRef,
+    node: PlanPredicateNode,
+    nullable: bool,
+}
+
+/// A borrowed view of a resolved plan predicate.
+#[derive(Debug, Clone, Copy)]
+pub enum PlanPredicateKind<'a> {
+    /// A resolved Boolean expression.
+    Boolean(&'a PlanExpression),
+    /// Boolean inversion.
+    Not(&'a PlanPredicate),
+    /// A null test, optionally inverted to `IS NOT NULL`.
+    IsNull {
+        /// Expression being tested.
+        expression: &'a PlanExpression,
+        /// Whether the result is inverted.
+        inverted: bool,
+    },
+    /// A comparison over exact-type operands.
+    Compare {
+        /// Comparison operation.
+        op: PlanComparison,
+        /// Left operand.
+        left: &'a PlanExpression,
+        /// Right operand.
+        right: &'a PlanExpression,
+    },
+    /// A non-empty SQL three-valued conjunction.
+    And(&'a [PlanPredicateRef]),
+    /// A non-empty SQL three-valued disjunction.
+    Or(&'a [PlanPredicateRef]),
+}
+
+#[derive(Debug, Clone)]
+enum PlanPredicateNode {
+    Boolean(PlanExpressionRef),
+    Not(PlanPredicateRef),
+    IsNull {
+        expression: PlanExpressionRef,
+        inverted: bool,
+    },
+    Compare {
+        op: PlanComparison,
+        left: PlanExpressionRef,
+        right: PlanExpressionRef,
+    },
+    And(Vec<PlanPredicateRef>),
+    Or(Vec<PlanPredicateRef>),
+}
+
+/// Comparisons in the mandatory declarative-plan dialect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanComparison {
+    /// SQL less-than using three-valued logic.
+    LessThan,
+    /// SQL greater-than using three-valued logic.
+    GreaterThan,
+    /// SQL equality using three-valued logic.
+    Equal,
+    /// SQL `IS DISTINCT FROM`, which always produces a non-null Boolean.
+    Distinct,
+}
+
+impl PlanPredicate {
+    /// Resolves `source` against `input_schema` for use in a declarative plan.
+    pub fn resolve(
+        source: impl Into<PredicateRef>,
+        input_schema: &StructType,
+    ) -> DeltaResult<PlanPredicateRef> {
+        let source = source.into();
+        let (node, nullable) = resolve_predicate_node(&source, input_schema, false)?;
+        Ok(Arc::new(Self {
+            source,
+            node,
+            nullable,
+        }))
+    }
+
+    /// Returns an exhaustive borrowed view of this predicate's resolved node.
+    pub fn kind(&self) -> PlanPredicateKind<'_> {
+        match &self.node {
+            PlanPredicateNode::Boolean(expression) => {
+                PlanPredicateKind::Boolean(expression.as_ref())
+            }
+            PlanPredicateNode::Not(predicate) => PlanPredicateKind::Not(predicate.as_ref()),
+            PlanPredicateNode::IsNull {
+                expression,
+                inverted,
+            } => PlanPredicateKind::IsNull {
+                expression,
+                inverted: *inverted,
+            },
+            PlanPredicateNode::Compare { op, left, right } => PlanPredicateKind::Compare {
+                op: *op,
+                left,
+                right,
+            },
+            PlanPredicateNode::And(predicates) => PlanPredicateKind::And(predicates),
+            PlanPredicateNode::Or(predicates) => PlanPredicateKind::Or(predicates),
+        }
+    }
+
+    /// Returns whether this predicate can evaluate to SQL unknown.
+    pub fn is_nullable(&self) -> bool {
+        self.nullable
+    }
+
+    /// Returns the validated source predicate for delegation to an imperative evaluator.
+    ///
+    /// Plan executors should prefer [`Self::kind`].
+    pub fn source_predicate(&self) -> &PredicateRef {
+        &self.source
+    }
+}
+
+fn resolve_expression_node(
+    source: &ExpressionRef,
+    input_schema: &StructType,
+    expected_type: Option<&DataType>,
+) -> DeltaResult<(PlanExpressionNode, DataType, bool)> {
+    match source.as_ref() {
+        Expression::Literal(value) => Ok((
+            PlanExpressionNode::Literal(value.clone()),
+            value.data_type(),
+            value.is_null(),
+        )),
+        Expression::Column(name) => {
+            let column = PlanColumn::resolve(input_schema, name.clone())?;
+            Ok((
+                PlanExpressionNode::Column(column.clone()),
+                column.data_type().clone(),
+                column.is_nullable(),
+            ))
+        }
+        Expression::Predicate(predicate) => {
+            let predicate = PlanPredicate::resolve(predicate.as_ref().clone(), input_schema)?;
+            let nullable = predicate.is_nullable();
+            Ok((
+                PlanExpressionNode::Predicate(predicate),
+                DataType::BOOLEAN,
+                nullable,
+            ))
+        }
+        Expression::Struct(fields, nullability) => {
+            let output_schema = require_struct_type(expected_type, "Struct")?;
+            if fields.len() != output_schema.num_fields() {
+                return Err(Error::generic(format!(
+                    "plan Struct has {} fields but its output schema has {}",
+                    fields.len(),
+                    output_schema.num_fields()
+                )));
+            }
+            let nullability = nullability
+                .as_ref()
+                .map(|expression| {
+                    PlanExpression::resolve(
+                        Arc::clone(expression),
+                        input_schema,
+                        Some(&DataType::BOOLEAN),
+                    )
+                })
+                .transpose()?;
+            let fields = fields
+                .iter()
+                .zip(output_schema.fields())
+                .map(|(expression, field)| {
+                    let expression = PlanExpression::resolve(
+                        Arc::clone(expression),
+                        input_schema,
+                        Some(field.data_type()),
+                    )?;
+                    require_field_assignment(
+                        &expression,
+                        field,
+                        nullability.as_deref(),
+                        input_schema,
+                    )?;
+                    Ok(expression)
+                })
+                .collect::<DeltaResult<Vec<_>>>()?;
+            let nullable = nullability.is_some();
+            Ok((
+                PlanExpressionNode::Struct {
+                    fields,
+                    nullability,
+                },
+                DataType::from(output_schema.clone()),
+                nullable,
+            ))
+        }
+        Expression::StructPatch(patch) => {
+            let output_schema = require_struct_type(expected_type, "StructPatch")?;
+            let (patch, nullable) = resolve_struct_patch(patch, input_schema, output_schema)?;
+            Ok((
+                PlanExpressionNode::StructPatch(patch),
+                DataType::from(output_schema.clone()),
+                nullable,
+            ))
+        }
+        Expression::Variadic(variadic) if variadic.op == VariadicExpressionOp::Coalesce => {
+            let first = variadic
+                .exprs
+                .first()
+                .ok_or_else(|| Error::generic("plan Coalesce requires at least one expression"))?;
+            let first = PlanExpression::resolve(first.clone(), input_schema, expected_type)?;
+            let data_type = first.data_type().clone();
+            let mut expressions = Vec::with_capacity(variadic.exprs.len());
+            expressions.push(first);
+            for expression in variadic.exprs.iter().skip(1) {
+                expressions.push(PlanExpression::resolve(
+                    expression.clone(),
+                    input_schema,
+                    Some(&data_type),
+                )?);
+            }
+            let nullable = expressions
+                .iter()
+                .all(|expression| expression.is_nullable());
+            Ok((
+                PlanExpressionNode::Coalesce(expressions),
+                data_type,
+                nullable,
+            ))
+        }
+        Expression::ParseJson(parse) => {
+            let json = PlanExpression::resolve(
+                parse.json_expr.as_ref().clone(),
+                input_schema,
+                Some(&DataType::STRING),
+            )?;
+            let data_type = DataType::from(parse.output_schema.as_ref().clone());
+            Ok((
+                PlanExpressionNode::ParseJson {
+                    json,
+                    output_schema: Arc::clone(&parse.output_schema),
+                },
+                data_type,
+                true,
+            ))
+        }
+        Expression::MapToStruct(map_to_struct) => {
+            let output_schema = require_struct_type(expected_type, "MapToStruct")?;
+            let map = PlanExpression::resolve(
+                map_to_struct.map_expr.as_ref().clone(),
+                input_schema,
+                None,
+            )?;
+            require_string_map(map.data_type())?;
+            for field in output_schema.fields() {
+                if !matches!(field.data_type(), DataType::Primitive(_)) {
+                    return Err(Error::generic(format!(
+                        "plan MapToStruct field `{}` must be primitive, got {}",
+                        field.name(),
+                        field.data_type()
+                    )));
+                }
+                if !field.is_nullable() {
+                    return Err(Error::generic(format!(
+                        "plan MapToStruct field `{}` must be nullable because a key may be missing",
+                        field.name()
+                    )));
+                }
+            }
+            let nullable = map.is_nullable();
+            Ok((
+                PlanExpressionNode::MapToStruct {
+                    map,
+                    output_schema: output_schema.clone(),
+                },
+                DataType::from(output_schema.clone()),
+                nullable,
+            ))
+        }
+        Expression::Unary(_) => Err(unsupported_plan_expression("Unary")),
+        Expression::Binary(_) => Err(unsupported_plan_expression("Binary arithmetic")),
+        Expression::Variadic(_) => Err(unsupported_plan_expression("Array")),
+        Expression::Opaque(_) => Err(unsupported_plan_expression("Opaque")),
+        Expression::Unknown(_) => Err(unsupported_plan_expression("Unknown")),
+        Expression::Cast(_) => Err(unsupported_plan_expression("Cast")),
+    }
+}
+
+fn resolve_predicate_node(
+    source: &PredicateRef,
+    input_schema: &StructType,
+    inverted: bool,
+) -> DeltaResult<(PlanPredicateNode, bool)> {
+    match source.as_ref() {
+        Predicate::BooleanExpression(expression) => {
+            let expression = PlanExpression::resolve(
+                expression.clone(),
+                input_schema,
+                Some(&DataType::BOOLEAN),
+            )?;
+            let nullable = expression.is_nullable();
+            let node = PlanPredicateNode::Boolean(expression);
+            if inverted {
+                Ok((
+                    PlanPredicateNode::Not(Arc::new(PlanPredicate {
+                        source: Arc::clone(source),
+                        node,
+                        nullable,
+                    })),
+                    nullable,
+                ))
+            } else {
+                Ok((node, nullable))
+            }
+        }
+        Predicate::Not(predicate) => resolve_predicate_node(
+            &Arc::new(predicate.as_ref().clone()),
+            input_schema,
+            !inverted,
+        ),
+        Predicate::Unary(unary) if unary.op == UnaryPredicateOp::IsNull => {
+            let expression =
+                PlanExpression::resolve(unary.expr.as_ref().clone(), input_schema, None)?;
+            Ok((
+                PlanPredicateNode::IsNull {
+                    expression,
+                    inverted,
+                },
+                false,
+            ))
+        }
+        Predicate::Binary(binary) => {
+            let op = match binary.op {
+                BinaryPredicateOp::LessThan => PlanComparison::LessThan,
+                BinaryPredicateOp::GreaterThan => PlanComparison::GreaterThan,
+                BinaryPredicateOp::Equal => PlanComparison::Equal,
+                BinaryPredicateOp::Distinct => PlanComparison::Distinct,
+                BinaryPredicateOp::In => {
+                    return Err(Error::unsupported(
+                        "IN is not part of the plan predicate dialect",
+                    ))
+                }
+            };
+            let left = PlanExpression::resolve(binary.left.as_ref().clone(), input_schema, None)?;
+            let right = PlanExpression::resolve(
+                binary.right.as_ref().clone(),
+                input_schema,
+                Some(left.data_type()),
+            )?;
+            require_comparable(left.data_type())?;
+            let nullable =
+                op != PlanComparison::Distinct && (left.is_nullable() || right.is_nullable());
+            let node = PlanPredicateNode::Compare { op, left, right };
+            if inverted {
+                Ok((
+                    PlanPredicateNode::Not(Arc::new(PlanPredicate {
+                        source: Arc::clone(source),
+                        node,
+                        nullable,
+                    })),
+                    nullable,
+                ))
+            } else {
+                Ok((node, nullable))
+            }
+        }
+        Predicate::Junction(junction) => {
+            if junction.preds.is_empty() {
+                return Err(Error::generic(
+                    "plan AND and OR predicates require at least one child",
+                ));
+            }
+            let predicates = junction
+                .preds
+                .iter()
+                .map(|predicate| {
+                    let source = Arc::new(predicate.clone());
+                    let (node, nullable) = resolve_predicate_node(&source, input_schema, inverted)?;
+                    Ok(Arc::new(PlanPredicate {
+                        source,
+                        node,
+                        nullable,
+                    }))
+                })
+                .collect::<DeltaResult<Vec<_>>>()?;
+            let nullable = predicates.iter().any(|predicate| predicate.is_nullable());
+            let op = if inverted {
+                junction.op.invert()
+            } else {
+                junction.op
+            };
+            let node = match op {
+                JunctionPredicateOp::And => PlanPredicateNode::And(predicates),
+                JunctionPredicateOp::Or => PlanPredicateNode::Or(predicates),
+            };
+            Ok((node, nullable))
+        }
+        Predicate::Opaque(_) => Err(Error::unsupported(
+            "Opaque is not part of the plan predicate dialect",
+        )),
+        Predicate::Unknown(_) => Err(Error::unsupported(
+            "Unknown is not part of the plan predicate dialect",
+        )),
+        Predicate::Unary(_) => Err(Error::internal_error("unknown unary predicate operation")),
+    }
+}
+
+fn resolve_column(input_schema: &StructType, name: &ColumnName) -> DeltaResult<(DataType, bool)> {
+    let mut nullable = false;
+    let mut data_type = None;
+    input_schema.visit_fields_of_path(name, |field| {
+        nullable |= field.is_nullable();
+        data_type = Some(field.data_type().clone());
+    })?;
+    let data_type = data_type.ok_or_else(|| Error::generic("plan column path cannot be empty"))?;
+    Ok((data_type, nullable))
+}
+
+fn resolve_struct_patch(
+    patch: &ExpressionStructPatch,
+    input_schema: &StructType,
+    output_schema: &StructType,
+) -> DeltaResult<(PlanStructPatch, bool)> {
+    let (source_schema, nullable) = match patch.input_path() {
+        Some(path) => {
+            let (data_type, nullable) = resolve_column(input_schema, path)?;
+            let DataType::Struct(source) = data_type else {
+                return Err(Error::generic(format!(
+                    "plan StructPatch input `{path}` is not a struct"
+                )));
+            };
+            (*source, nullable)
+        }
+        None => (input_schema.clone(), false),
+    };
+
+    let mut output_fields = output_schema.fields();
+    let prepended_fields = patch
+        .prepended_fields
+        .iter()
+        .map(|expression| resolve_patch_insertion(expression, input_schema, &mut output_fields))
+        .collect::<DeltaResult<Vec<_>>>()?;
+
+    let mut field_patches = HashMap::with_capacity(patch.field_patches.len());
+    let mut used_required = 0usize;
+    for input_field in source_schema.fields() {
+        let field_patch = patch.field_patches.get(input_field.name());
+        if field_patch.is_none_or(|field_patch| field_patch.keep_input) {
+            let output_field = output_fields
+                .next()
+                .ok_or_else(|| Error::generic("plan StructPatch produces too many fields"))?;
+            require_passthrough_field(input_field, output_field)?;
+        }
+        let Some(field_patch) = field_patch else {
+            continue;
+        };
+        let insertions = field_patch
+            .insertions
+            .iter()
+            .map(|expression| resolve_patch_insertion(expression, input_schema, &mut output_fields))
+            .collect::<DeltaResult<Vec<_>>>()?;
+        field_patches.insert(
+            input_field.name().clone(),
+            PlanFieldPatch {
+                keep_input: field_patch.keep_input,
+                insertions,
+                optional: field_patch.optional,
+            },
+        );
+        if !field_patch.optional {
+            used_required += 1;
+        }
+    }
+
+    let required = patch
+        .field_patches
+        .values()
+        .filter(|field_patch| !field_patch.optional)
+        .count();
+    if used_required != required {
+        return Err(Error::generic(
+            "plan StructPatch has a required patch for a missing input field",
+        ));
+    }
+    for (name, field_patch) in &patch.field_patches {
+        if field_patch.optional && !field_patches.contains_key(name) {
+            field_patches.insert(
+                name.clone(),
+                PlanFieldPatch {
+                    keep_input: field_patch.keep_input,
+                    insertions: Vec::new(),
+                    optional: true,
+                },
+            );
+        }
+    }
+
+    let appended_fields = patch
+        .appended_fields
+        .iter()
+        .map(|expression| resolve_patch_insertion(expression, input_schema, &mut output_fields))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    if output_fields.next().is_some() {
+        return Err(Error::generic(
+            "plan StructPatch produces fewer fields than its output schema",
+        ));
+    }
+
+    Ok((
+        PlanStructPatch {
+            input_path: patch.input_path.clone(),
+            field_patches,
+            prepended_fields,
+            appended_fields,
+        },
+        nullable,
+    ))
+}
+
+fn resolve_patch_insertion<'a>(
+    expression: &ExpressionRef,
+    input_schema: &StructType,
+    output_fields: &mut impl Iterator<Item = &'a StructField>,
+) -> DeltaResult<PlanExpressionRef> {
+    let field = output_fields
+        .next()
+        .ok_or_else(|| Error::generic("plan StructPatch produces too many fields"))?;
+    let expression = PlanExpression::resolve(
+        Arc::clone(expression),
+        input_schema,
+        Some(field.data_type()),
+    )?;
+    require_field_assignment(&expression, field, None, input_schema)?;
+    Ok(expression)
+}
+
+fn require_expected_type(
+    actual: &DataType,
+    expected: Option<&DataType>,
+    context: &str,
+) -> DeltaResult<()> {
+    if let Some(expected) = expected {
+        if actual != expected {
+            return Err(Error::generic(format!(
+                "plan {context} has type {actual}, expected {expected}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn require_struct_type<'a>(
+    expected: Option<&'a DataType>,
+    context: &str,
+) -> DeltaResult<&'a StructType> {
+    match expected {
+        Some(DataType::Struct(schema)) => Ok(schema),
+        Some(other) => Err(Error::generic(format!(
+            "plan {context} requires a struct output type, got {other}"
+        ))),
+        None => Err(Error::generic(format!(
+            "plan {context} requires an expected output type"
+        ))),
+    }
+}
+
+fn require_field_assignment(
+    expression: &PlanExpression,
+    field: &StructField,
+    struct_guard: Option<&PlanExpression>,
+    input_schema: &StructType,
+) -> DeltaResult<()> {
+    let guarded_non_null = struct_guard
+        .map(|guard| expression_is_non_null_when_guard_is_true(expression, guard, input_schema))
+        .transpose()?
+        .unwrap_or(false);
+    if !field.is_nullable() && expression.is_nullable() && !guarded_non_null {
+        return Err(Error::generic(format!(
+            "plan expression `{}` for non-nullable field `{}` may produce null",
+            expression.source_expression(),
+            field.name()
+        )));
+    }
+    Ok(())
+}
+
+/// Proves the narrow conditional-nullability pattern emitted by replay projections.
+///
+/// A nullable parent makes every descendant effectively nullable. A struct guard such as
+/// `add.deletionVector.storageType IS NOT NULL` proves that the nullable `add` and
+/// `deletionVector` ancestors exist, so non-null sibling leaves may safely populate non-null fields
+/// inside that guarded struct. Unrelated guards and nullable leaves remain rejected.
+fn expression_is_non_null_when_guard_is_true(
+    expression: &PlanExpression,
+    guard: &PlanExpression,
+    input_schema: &StructType,
+) -> DeltaResult<bool> {
+    if !expression.is_nullable() {
+        return Ok(true);
+    }
+    match guard.kind() {
+        PlanExpressionKind::Predicate(predicate) => {
+            predicate_proves_expression_non_null(predicate, expression, input_schema)
+        }
+        _ => expression_non_null_implies_target_non_null(guard, expression, input_schema),
+    }
+}
+
+fn expression_non_null_implies_target_non_null(
+    condition: &PlanExpression,
+    target: &PlanExpression,
+    input_schema: &StructType,
+) -> DeltaResult<bool> {
+    if condition.source_expression() == target.source_expression() {
+        return Ok(true);
+    }
+    if let PlanExpressionKind::Coalesce(expressions) = condition.kind() {
+        for expression in expressions {
+            if !expression_non_null_implies_target_non_null(expression, target, input_schema)? {
+                return Ok(false);
+            }
+        }
+        return Ok(true);
+    }
+
+    match target.kind() {
+        PlanExpressionKind::Column(column) => {
+            let PlanExpressionKind::Column(condition_column) = condition.kind() else {
+                return Ok(false);
+            };
+            Ok(nullable_column_prefixes(input_schema, column.name())?
+                .into_iter()
+                .all(|prefix| condition_column.name().path().starts_with(prefix.path())))
+        }
+        PlanExpressionKind::Coalesce(expressions) => {
+            for expression in expressions {
+                if expression_non_null_implies_target_non_null(condition, expression, input_schema)?
+                {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        PlanExpressionKind::MapToStruct { map, .. } => {
+            expression_non_null_implies_target_non_null(condition, map, input_schema)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn nullable_column_prefixes(
+    input_schema: &StructType,
+    column: &ColumnName,
+) -> DeltaResult<Vec<ColumnName>> {
+    let mut prefixes = Vec::new();
+    for end in 1..=column.path().len() {
+        let prefix = ColumnName::new(column.path()[..end].iter().cloned());
+        if input_schema.field_at(&prefix)?.is_nullable() {
+            prefixes.push(prefix);
+        }
+    }
+    Ok(prefixes)
+}
+
+fn predicate_proves_expression_non_null(
+    predicate: &PlanPredicate,
+    target: &PlanExpression,
+    input_schema: &StructType,
+) -> DeltaResult<bool> {
+    match predicate.kind() {
+        PlanPredicateKind::IsNull {
+            expression,
+            inverted: true,
+        }
+        | PlanPredicateKind::Boolean(expression) => {
+            expression_non_null_implies_target_non_null(expression, target, input_schema)
+        }
+        PlanPredicateKind::And(predicates) => {
+            for predicate in predicates {
+                if predicate_proves_expression_non_null(predicate, target, input_schema)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn require_passthrough_field(input: &StructField, output: &StructField) -> DeltaResult<()> {
+    if input.name() != output.name()
+        || input.data_type() != output.data_type()
+        || input.is_nullable() != output.is_nullable()
+    {
+        return Err(Error::generic(format!(
+            "plan StructPatch passthrough field `{}` does not exactly match output field `{}`",
+            input.name(),
+            output.name()
+        )));
+    }
+    Ok(())
+}
+
+fn require_string_map(data_type: &DataType) -> DeltaResult<()> {
+    let DataType::Map(map) = data_type else {
+        return Err(Error::generic(format!(
+            "plan MapToStruct input must be a map, got {data_type}"
+        )));
+    };
+    if map.key_type() != &DataType::STRING || map.value_type() != &DataType::STRING {
+        return Err(Error::generic(format!(
+            "plan MapToStruct input must be MAP<STRING, STRING>, got {data_type}"
+        )));
+    }
+    Ok(())
+}
+
+fn require_comparable(data_type: &DataType) -> DeltaResult<()> {
+    if matches!(data_type, DataType::Primitive(_)) {
+        Ok(())
+    } else {
+        Err(Error::unsupported(format!(
+            "plan comparisons require primitive operands, got {data_type}"
+        )))
+    }
+}
+
+fn unsupported_plan_expression(name: &str) -> Error {
+    Error::unsupported(format!(
+        "{name} is not part of the mandatory plan expression dialect"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expressions::{col, lit, null_lit, BinaryExpressionOp, Expression};
+    use crate::schema::{schema, schema_ref};
+
+    fn input_schema() -> StructType {
+        schema! {
+            not_null "id": LONG,
+            nullable "maybe": LONG,
+            nullable "parent": {
+                not_null "child": STRING,
+            },
+        }
+    }
+
+    #[test]
+    fn resolves_literal_type_and_nullability() {
+        let input = input_schema();
+        let value = PlanExpression::resolve(lit(1i64), &input, None).unwrap();
+        assert_eq!(value.data_type(), &DataType::LONG);
+        assert!(!value.is_nullable());
+
+        let null = PlanExpression::resolve(null_lit(DataType::LONG), &input, None).unwrap();
+        assert_eq!(null.data_type(), &DataType::LONG);
+        assert!(null.is_nullable());
+    }
+
+    #[test]
+    fn column_inherits_nullable_parent() {
+        let expression =
+            PlanExpression::resolve(col!("parent.child"), &input_schema(), None).unwrap();
+        assert_eq!(expression.data_type(), &DataType::STRING);
+        assert!(expression.is_nullable());
+    }
+
+    #[test]
+    fn rejects_non_boolean_filter_expression() {
+        let error =
+            PlanPredicate::resolve(Predicate::BooleanExpression(lit(1i64)), &input_schema())
+                .unwrap_err();
+        assert!(error.to_string().contains("expected boolean"));
+    }
+
+    #[test]
+    fn rejects_arithmetic_from_mandatory_dialect() {
+        let expression = Expression::binary(BinaryExpressionOp::Divide, col!("id"), lit(2i64));
+        let error = PlanExpression::resolve(expression, &input_schema(), None).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("not part of the mandatory plan expression dialect"));
+    }
+
+    #[test]
+    fn resolves_struct_children_from_output_schema() {
+        let output = schema_ref! {
+            not_null "id": LONG,
+            nullable "maybe": LONG,
+        };
+        let expression = Expression::struct_from([col!("id"), col!("maybe")]);
+        let resolved = PlanExpression::resolve(
+            expression,
+            &input_schema(),
+            Some(&DataType::from(output.as_ref().clone())),
+        )
+        .unwrap();
+        let PlanExpressionKind::Struct { fields, .. } = resolved.kind() else {
+            panic!("expected Struct");
+        };
+        assert_eq!(fields[0].data_type(), &DataType::LONG);
+        assert!(!fields[0].is_nullable());
+        assert!(fields[1].is_nullable());
+    }
+
+    #[test]
+    fn rejects_nullable_expression_for_non_nullable_field() {
+        let output = schema! { not_null "maybe": LONG };
+        let expression = Expression::struct_from([col!("maybe")]);
+        let error =
+            PlanExpression::resolve(expression, &input_schema(), Some(&DataType::from(output)))
+                .unwrap_err();
+        assert!(error.to_string().contains("may produce null"));
+    }
+
+    #[test]
+    fn struct_guard_proves_non_null_sibling_leaves() {
+        let input = schema! {
+            nullable "add": {
+                nullable "dv": {
+                    not_null "storage": STRING,
+                    not_null "path": STRING,
+                    nullable "offset": INTEGER,
+                },
+            },
+        };
+        let output = schema! {
+            nullable "dv": {
+                not_null "storage": STRING,
+                not_null "path": STRING,
+                nullable "offset": INTEGER,
+            },
+        };
+        let dv = Expression::struct_with_nullability_from(
+            [
+                col!("add.dv.storage"),
+                col!("add.dv.path"),
+                col!("add.dv.offset"),
+            ],
+            Expression::from_pred(col!("add.dv.storage").is_not_null()),
+        );
+        let expression = Expression::struct_from([dv]);
+
+        PlanExpression::resolve(expression, &input, Some(&DataType::from(output))).unwrap();
+    }
+
+    #[test]
+    fn unrelated_struct_guard_does_not_hide_nullable_assignment() {
+        let input = schema! {
+            nullable "value": STRING,
+            not_null "guard": BOOLEAN,
+        };
+        let output = schema! { nullable "record": { not_null "value": STRING } };
+        let record = Expression::struct_with_nullability_from([col!("value")], col!("guard"));
+        let expression = Expression::struct_from([record]);
+
+        let error =
+            PlanExpression::resolve(expression, &input, Some(&DataType::from(output))).unwrap_err();
+        assert!(error.to_string().contains("may produce null"));
+    }
+
+    #[test]
+    fn coalesced_guard_proves_corresponding_coalesced_sibling() {
+        let action = schema! {
+            nullable "dv": {
+                not_null "storage": STRING,
+                not_null "path": STRING,
+            },
+        };
+        let input = schema! {
+            nullable "add": (action.clone()),
+            nullable "remove": (action),
+        };
+        let output = schema! {
+            nullable "dv": {
+                not_null "storage": STRING,
+                not_null "path": STRING,
+            },
+        };
+        let storage = Expression::coalesce([col!("add.dv.storage"), col!("remove.dv.storage")]);
+        let path = Expression::coalesce([col!("add.dv.path"), col!("remove.dv.path")]);
+        let dv = Expression::struct_with_nullability_from(
+            [storage.clone(), path],
+            Expression::from_pred(storage.is_not_null()),
+        );
+
+        PlanExpression::resolve(
+            Expression::struct_from([dv]),
+            &input,
+            Some(&DataType::from(output)),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_junction() {
+        let predicate = Predicate::Junction(crate::expressions::JunctionPredicate {
+            op: JunctionPredicateOp::And,
+            preds: Vec::new(),
+        });
+        let error = PlanPredicate::resolve(predicate, &input_schema()).unwrap_err();
+        assert!(error.to_string().contains("at least one child"));
+    }
+}

--- a/kernel/src/plans/ir/mod.rs
+++ b/kernel/src/plans/ir/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! - [`operation`] -- top-level [`Operation`] dispatch (I/O vs query) consumed by
 //!   [`PlanExecutor`](super::PlanExecutor).
+//! - [`expression`] -- resolved expression and predicate nodes that may cross the plan boundary.
 //! - [`nodes`] -- the plan nodes: [`nodes::Operator`] and its payload structs.
 //! - [`plan`] -- plan topology: [`plan::Plan`] holds a sequence of [`plan::PlanNode`]s wired into a
 //!   DAG by their input node indices.
+pub mod expression;
 pub mod nodes;
 pub mod operation;
 pub mod plan;

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -12,7 +12,12 @@ use url::Url;
 
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::error::add_scalar_path_context;
-use crate::expressions::{ColumnName, ExpressionRef, PredicateRef, Scalar, StructData};
+use crate::expressions::{
+    ColumnName, Expression, ExpressionRef, Predicate, PredicateRef, Scalar, StructData,
+};
+use crate::plans::ir::expression::{
+    PlanColumn, PlanExpression, PlanExpressionRef, PlanPredicate, PlanPredicateRef,
+};
 use crate::schema::{DataType, SchemaRef, StructField, StructType, ToSchema};
 use crate::utils::CollectInto;
 use crate::{DeltaResult, Error, FileMeta};
@@ -38,6 +43,7 @@ pub enum Operator {
     // === Unary operators (1 input) ===========================================
     Project(Project),
     Filter(Filter),
+    DataSkipping(DataSkippingSite),
     DynamicScan(DynamicScan),
     Aggregate(Aggregate),
 
@@ -71,6 +77,12 @@ impl_from_payload_for_operator!(
     SemiJoin,
     UnionAll,
 );
+
+impl From<DataSkippingSite> for Operator {
+    fn from(payload: DataSkippingSite) -> Self {
+        Self::DataSkipping(payload)
+    }
+}
 
 /// One file to scan plus literal values broadcast to every row read from that file.
 ///
@@ -327,39 +339,354 @@ where
 ///
 /// # Example
 ///
-/// Input `{ id, first, last, add: { path, size, stats_parsed: { numRecords } } }` projected to
-/// `{ id, names, file_meta }`, showing passthrough, array construction, nested input access, and a
-/// struct output column:
+/// Input `{ id, name, add: { path, size, stats_parsed: { numRecords } } }` projected to
+/// `{ id, name, file_meta }`, showing passthrough, nested input access, and a struct output column:
 ///
 /// ```text
-/// Project {
-///     expr: Expression::struct_from([
+/// input.project(
+///     Expression::struct_from([
 ///         col!("id"),
-///         Expression::array([col!("first"), col!("last")]),
+///         col!("name"),
 ///         Expression::struct_from([
 ///             col!("add.path"),
 ///             col!("add.size"),
 ///             col!("add.stats_parsed.numRecords"),
 ///         ]),
 ///     ]),
-///     schema: {
+///     schema! {
 ///         id: int,
-///         names: array<string>,
+///         name: string,
 ///         file_meta: { path: string, size: long, num_records: long },
 ///     },
-/// }
+/// )?
 /// ```
 #[derive(Debug, Clone)]
 pub struct Project {
-    pub expr: ExpressionRef,
-    pub schema: SchemaRef,
+    expr: PlanExpressionRef,
+    schema: SchemaRef,
+}
+
+impl Project {
+    /// Resolves `expr` against `input_schema` and validates that it produces exactly `schema`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a column does not resolve, an expression is outside the mandatory
+    /// plan dialect, or its resolved type or nullability cannot be assigned to `schema`.
+    pub fn try_new(
+        input_schema: &StructType,
+        expr: impl Into<ExpressionRef>,
+        schema: impl Into<SchemaRef>,
+    ) -> DeltaResult<Self> {
+        let schema = schema.into();
+        let expr = expr.into();
+        if !matches!(
+            expr.as_ref(),
+            Expression::Struct(..) | Expression::StructPatch(_)
+        ) {
+            return Err(Error::generic(
+                "plan Project expression must be a Struct or StructPatch",
+            ));
+        }
+        let output_type = DataType::from(schema.as_ref().clone());
+        let expr = PlanExpression::resolve(expr, input_schema, Some(&output_type))?;
+        Ok(Self { expr, schema })
+    }
+
+    /// Returns the resolved struct expression that produces the output row.
+    pub fn expression(&self) -> &PlanExpressionRef {
+        &self.expr
+    }
+
+    /// Returns the exact output schema of this projection.
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
 }
 
 /// Keeps input rows where `predicate` evaluates true (SQL null semantics).
 /// Output schema is the input schema unchanged.
 #[derive(Debug, Clone)]
 pub struct Filter {
-    pub predicate: PredicateRef,
+    predicate: PlanPredicateRef,
+}
+
+impl Filter {
+    /// Resolves `predicate` against `input_schema` and proves that it is Boolean.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a column does not resolve, an expression is outside the mandatory
+    /// plan dialect, or the predicate is not Boolean.
+    pub fn try_new(
+        input_schema: &StructType,
+        predicate: impl Into<PredicateRef>,
+    ) -> DeltaResult<Self> {
+        Ok(Self {
+            predicate: PlanPredicate::resolve(predicate, input_schema)?,
+        })
+    }
+
+    /// Returns the resolved Boolean predicate evaluated by this filter.
+    pub fn predicate(&self) -> &PlanPredicateRef {
+        &self.predicate
+    }
+}
+
+/// Describes the metadata columns available for optional file pruning.
+///
+/// The columns point into the [`DataSkippingSite`]'s input rows. `stats_column`, when present, is
+/// a struct containing Delta statistics such as `numRecords`, `minValues`, `maxValues`, and
+/// `nullCount`. `partition_values_column`, when present, is a struct of exact typed partition
+/// values. `source_schema` describes the table columns referenced by the original row predicate.
+///
+/// The descriptor contains locations, not statistics values. Values continue to flow through the
+/// plan rows. In scan plans, the source predicate and schemas use physical column names. For a
+/// source column `x`, an engine can inspect `<stats_column>.maxValues.x` or the exact value at
+/// `<partition_values_column>.x` when those fields exist.
+#[derive(Debug, Clone)]
+pub struct DataSkippingStats {
+    source_schema: SchemaRef,
+    stats_column: Option<PlanColumn>,
+    partition_values_column: Option<PlanColumn>,
+}
+
+impl DataSkippingStats {
+    /// Resolves the available metadata columns against `input_schema`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if neither metadata source is present, a column does not resolve, or a
+    /// metadata column is not struct-valued.
+    pub fn try_new(
+        input_schema: &StructType,
+        source_schema: impl Into<SchemaRef>,
+        stats_column: Option<ColumnName>,
+        partition_values_column: Option<ColumnName>,
+    ) -> DeltaResult<Self> {
+        if stats_column.is_none() && partition_values_column.is_none() {
+            return Err(Error::generic(
+                "data-skipping stats require statistics or partition values",
+            ));
+        }
+        let resolve_struct = |name: Option<ColumnName>| -> DeltaResult<Option<PlanColumn>> {
+            name.map(|name| {
+                let column = PlanColumn::resolve(input_schema, name)?;
+                if !matches!(column.data_type(), DataType::Struct(_)) {
+                    return Err(Error::generic(format!(
+                        "data-skipping metadata column `{}` must be a struct, found {}",
+                        column.name(),
+                        column.data_type()
+                    )));
+                }
+                Ok(column)
+            })
+            .transpose()
+        };
+        Ok(Self {
+            source_schema: source_schema.into(),
+            stats_column: resolve_struct(stats_column)?,
+            partition_values_column: resolve_struct(partition_values_column)?,
+        })
+    }
+
+    /// Returns the schema of columns referenced by the source row predicate.
+    pub fn source_schema(&self) -> &SchemaRef {
+        &self.source_schema
+    }
+
+    /// Returns the resolved Delta statistics struct, when available.
+    pub fn stats_column(&self) -> Option<&PlanColumn> {
+        self.stats_column.as_ref()
+    }
+
+    /// Returns the resolved exact partition-values struct, when available.
+    pub fn partition_values_column(&self) -> Option<&PlanColumn> {
+        self.partition_values_column.as_ref()
+    }
+
+    fn validate_input(&self, input_schema: &StructType) -> DeltaResult<()> {
+        let stats_column = self
+            .stats_column
+            .as_ref()
+            .map(|column| column.name().clone());
+        let partition_values_column = self
+            .partition_values_column
+            .as_ref()
+            .map(|column| column.name().clone());
+        let resolved = Self::try_new(
+            input_schema,
+            Arc::clone(&self.source_schema),
+            stats_column,
+            partition_values_column,
+        )?;
+        if resolved.stats_column != self.stats_column
+            || resolved.partition_values_column != self.partition_values_column
+        {
+            return Err(Error::generic(
+                "data-skipping metadata columns were resolved against a different input schema",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Identifies which input rows an optional data-skipping filter may remove.
+#[derive(Debug, Clone)]
+pub enum DataSkippingTarget {
+    /// Every input row represents an Add action and may be considered for pruning.
+    AddsOnly,
+    /// Only rows where `is_add` is true may be pruned; all other rows must pass unchanged.
+    MixedActions {
+        /// A resolved, non-null Boolean discriminator for Add rows.
+        is_add: PlanColumn,
+    },
+}
+
+impl DataSkippingTarget {
+    /// Resolves a mixed-action Add discriminator against `input_schema`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless `is_add` is a non-null Boolean column.
+    pub fn mixed_actions(input_schema: &StructType, is_add: ColumnName) -> DeltaResult<Self> {
+        let is_add = PlanColumn::resolve(input_schema, is_add)?;
+        if is_add.data_type() != &DataType::BOOLEAN || is_add.is_nullable() {
+            return Err(Error::generic(format!(
+                "data-skipping Add discriminator `{}` must be a non-null boolean",
+                is_add.name()
+            )));
+        }
+        Ok(Self::MixedActions { is_add })
+    }
+
+    /// Returns the Add discriminator for a mixed-action input.
+    pub fn is_add(&self) -> Option<&PlanColumn> {
+        match self {
+            Self::AddsOnly => None,
+            Self::MixedActions { is_add } => Some(is_add),
+        }
+    }
+
+    fn validate_input(&self, input_schema: &StructType) -> DeltaResult<()> {
+        let Some(is_add) = self.is_add() else {
+            return Ok(());
+        };
+        let resolved = Self::mixed_actions(input_schema, is_add.name().clone())?;
+        let Self::MixedActions {
+            is_add: resolved_is_add,
+        } = resolved
+        else {
+            return Err(Error::internal_error(
+                "mixed data-skipping target resolved as AddsOnly",
+            ));
+        };
+        if &resolved_is_add != is_add {
+            return Err(Error::generic(
+                "data-skipping Add discriminator was resolved against a different input schema",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// An optional, conservative file-pruning opportunity at a Kernel-selected safe plan location.
+///
+/// Unlike [`Filter`], this node is semantically an identity operation: an executor may pass every
+/// input row through. `kernel_keep_predicate` is a ready-to-run portable optimization. An executor
+/// may instead analyze `source_predicate` with the described statistics and install a richer
+/// native keep filter. In either case, it may discard a row only when it proves that the file
+/// cannot match the source predicate.
+///
+/// For example, Kernel may provide `DISTINCT(maxValues.x > 100, false)` for `x > 100`. For
+/// `x / 2 > 50`, the portable predicate may be absent; an engine with sound range analysis may
+/// still derive a native filter, while every other engine passes the rows through.
+#[derive(Debug, Clone)]
+pub struct DataSkippingSite {
+    source_predicate: PredicateRef,
+    stats: DataSkippingStats,
+    target: DataSkippingTarget,
+    kernel_keep_predicate: Option<PlanPredicateRef>,
+}
+
+impl DataSkippingSite {
+    /// Creates an optional pruning site and resolves its portable keep predicate.
+    ///
+    /// `source_predicate` is evaluated by the connector's query engine over data rows. It is
+    /// carried here only as input to optional statistics analysis. For a mixed-action target, this
+    /// constructor guards Kernel's keep predicate so every non-Add row passes unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a source column is absent from the source schema, metadata or target
+    /// columns do not match `input_schema`, or the portable predicate is not in the mandatory plan
+    /// predicate dialect.
+    pub fn try_new(
+        input_schema: &StructType,
+        source_predicate: impl Into<PredicateRef>,
+        stats: DataSkippingStats,
+        target: DataSkippingTarget,
+        kernel_keep_predicate: Option<PredicateRef>,
+    ) -> DeltaResult<Self> {
+        let source_predicate = source_predicate.into();
+        for column in source_predicate.references() {
+            stats.source_schema.field_at(column)?;
+        }
+        stats.validate_input(input_schema)?;
+        target.validate_input(input_schema)?;
+
+        let kernel_keep_predicate = kernel_keep_predicate
+            .map(|predicate| {
+                let predicate = match target.is_add() {
+                    Some(is_add) => Arc::new(Predicate::or(
+                        Predicate::not(Predicate::from_expr(is_add.name().clone())),
+                        predicate.as_ref().clone(),
+                    )),
+                    None => predicate,
+                };
+                PlanPredicate::resolve(predicate, input_schema)
+            })
+            .transpose()?;
+
+        Ok(Self {
+            source_predicate,
+            stats,
+            target,
+            kernel_keep_predicate,
+        })
+    }
+
+    /// Returns the original row predicate used as input to optional native pruning analysis.
+    pub fn source_predicate(&self) -> &PredicateRef {
+        &self.source_predicate
+    }
+
+    /// Returns the available statistics and partition-value locations.
+    pub fn stats(&self) -> &DataSkippingStats {
+        &self.stats
+    }
+
+    /// Returns the rows that an installed pruning filter is allowed to remove.
+    pub fn target(&self) -> &DataSkippingTarget {
+        &self.target
+    }
+
+    /// Returns Kernel's portable, Remove-safe keep predicate, when one was derived.
+    pub fn kernel_keep_predicate(&self) -> Option<&PlanPredicateRef> {
+        self.kernel_keep_predicate.as_ref()
+    }
+
+    pub(crate) fn validate_input(&self, input_schema: &StructType) -> DeltaResult<()> {
+        for column in self.source_predicate.references() {
+            self.stats.source_schema.field_at(column)?;
+        }
+        self.stats.validate_input(input_schema)?;
+        self.target.validate_input(input_schema)?;
+        if let Some(predicate) = &self.kernel_keep_predicate {
+            PlanPredicate::resolve(Arc::clone(predicate.source_predicate()), input_schema)?;
+        }
+        Ok(())
+    }
 }
 
 /// File formats supported by [`DynamicScan`].
@@ -714,6 +1041,52 @@ impl Aggregate {
             group_by: grouping_keys.collect_into(),
             aggs: Vec::new(),
         }
+    }
+
+    /// Validates this aggregate's operands and output schema against its actual input schema.
+    pub(crate) fn validate_input(&self, input_schema: &StructType) -> DeltaResult<()> {
+        let expected_width = self.group_by.len() + self.aggs.len();
+        if self.schema.fields().len() != expected_width {
+            return Err(Error::generic(format!(
+                "aggregate output has {} field(s), expected {expected_width}",
+                self.schema.fields().len()
+            )));
+        }
+
+        for (index, key) in self.group_by.iter().enumerate() {
+            let expected = input_schema.field_at(key)?;
+            let actual = self.schema.field_at_index(index).ok_or_else(|| {
+                Error::internal_error("validated aggregate output field is missing")
+            })?;
+            if actual != expected {
+                return Err(Error::generic(format!(
+                    "aggregate group key `{key}` produces field `{expected}`, found `{actual}`"
+                )));
+            }
+        }
+
+        for (agg_index, agg) in self.aggs.iter().enumerate() {
+            if let Agg::Sum(value) = agg {
+                let field = input_schema.field_at(value)?;
+                if field.data_type() != &DataType::LONG {
+                    return Err(Error::generic(format!(
+                        "sum operand `{value}` must have type long, found {}",
+                        field.data_type()
+                    )));
+                }
+            }
+            let output_index = self.group_by.len() + agg_index;
+            let actual = self.schema.field_at_index(output_index).ok_or_else(|| {
+                Error::internal_error("validated aggregate output field is missing")
+            })?;
+            let expected = agg.output_field(input_schema, Some(actual.name().to_string()))?;
+            if actual != &expected {
+                return Err(Error::generic(format!(
+                    "aggregate output field {output_index} must be `{expected}`, found `{actual}`"
+                )));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/kernel/src/plans/ir/operation.rs
+++ b/kernel/src/plans/ir/operation.rs
@@ -7,7 +7,7 @@ use bytes::Bytes;
 use url::Url;
 
 use super::plan::Plan;
-use crate::{FileMeta, FileSlice};
+use crate::{DeltaResult, FileMeta, FileSlice};
 
 /// Represents a set of instructions that the
 /// [`PlanExecutor`](crate::plans::PlanExecutor) should perform.
@@ -25,9 +25,16 @@ pub enum Operation {
 
 impl Operation {
     /// Serializes this [`Operation`] into its proto wire representation.
-    pub fn to_proto_bytes(&self) -> Vec<u8> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a query plan is invalid or cannot be represented by the wire format.
+    pub fn to_proto_bytes(&self) -> DeltaResult<Vec<u8>> {
         use prost::Message as _;
-        crate::plans::proto::operation::Operation::from(self).encode_to_vec()
+        if let Self::QueryPlan(plan) = self {
+            plan.validate()?;
+        }
+        Ok(crate::plans::proto::operation::Operation::from(self).encode_to_vec())
     }
 }
 

--- a/kernel/src/plans/ir/plan.rs
+++ b/kernel/src/plans/ir/plan.rs
@@ -1,6 +1,12 @@
-//! Plan containers ([`Plan`], [`PlanNode`]).
+//! Validated plan containers ([`Plan`], [`PlanNode`]).
+
+use std::collections::HashSet;
+use std::sync::Arc;
 
 pub use super::nodes::Operator;
+use super::nodes::{Filter, Project, ScanFile, Values};
+use crate::schema::{SchemaRef, StructType};
+use crate::{DeltaResult, Error};
 
 // ============================================================================
 // Plan nodes
@@ -14,17 +20,32 @@ pub use super::nodes::Operator;
 /// emits the rows of all inputs regardless of input order.
 #[derive(Debug, Clone)]
 pub struct PlanNode {
-    pub op: Operator,
-    pub inputs: Vec<usize>,
+    op: Operator,
+    inputs: Vec<usize>,
 }
 
 impl PlanNode {
     /// A node applying `op` over the nodes at `inputs` (indices into [`Plan::nodes`]).
-    pub fn new(op: impl Into<Operator>, inputs: Vec<usize>) -> Self {
+    pub(crate) fn new(op: impl Into<Operator>, inputs: Vec<usize>) -> Self {
         Self {
             op: op.into(),
             inputs,
         }
+    }
+
+    /// Returns this node's relational operator.
+    pub fn operator(&self) -> &Operator {
+        &self.op
+    }
+
+    /// Returns the indices of this node's inputs, in operator-defined order.
+    pub fn inputs(&self) -> &[usize] {
+        &self.inputs
+    }
+
+    /// Consumes this node and returns its operator and input indices.
+    pub fn into_parts(self) -> (Operator, Vec<usize>) {
+        (self.op, self.inputs)
     }
 }
 
@@ -47,7 +68,7 @@ impl PlanNode {
 /// each node's inputs are guaranteed bound by the time the node is reached.
 ///
 /// A well-formed `Plan` has at least one node. The **terminal node** is always the last entry in
-/// `nodes`: no other node lists its index in `inputs`, and its rows are the value the engine
+/// [`Self::nodes`]: no other node lists its index in `inputs`, and its rows are the value the engine
 /// streams to the caller.
 ///
 /// The terminal node describes the rows produced by the plan. The calling API determines who
@@ -96,5 +117,346 @@ impl PlanNode {
 /// node to the caller.
 #[derive(Debug, Clone)]
 pub struct Plan {
-    pub nodes: Vec<PlanNode>,
+    nodes: Vec<PlanNode>,
+}
+
+impl Plan {
+    /// Constructs a plan after validating its topology, operator inputs, and propagated schemas.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty plan, a non-topological input reference, an invalid operator
+    /// arity, or an operator whose values or schema do not match its inputs.
+    pub(crate) fn try_new(nodes: Vec<PlanNode>) -> DeltaResult<Self> {
+        let plan = Self { nodes };
+        plan.validate()?;
+        Ok(plan)
+    }
+
+    /// Returns the plan nodes in topological order, with the terminal node last.
+    pub fn nodes(&self) -> &[PlanNode] {
+        &self.nodes
+    }
+
+    /// Consumes this plan and returns its nodes in topological order.
+    pub fn into_nodes(self) -> Vec<PlanNode> {
+        self.nodes
+    }
+
+    /// Revalidates this plan's topology, operator inputs, and propagated schemas.
+    ///
+    /// Plan construction performs the same validation. Serialization calls this method again as
+    /// defense in depth at the process boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty plan, a non-topological input reference, an invalid operator
+    /// arity, or an operator whose values or schema do not match its inputs.
+    pub fn validate(&self) -> DeltaResult<()> {
+        if self.nodes.is_empty() {
+            return Err(Error::generic("plan must contain at least one node"));
+        }
+
+        let mut schemas = Vec::with_capacity(self.nodes.len());
+        for (node_index, node) in self.nodes.iter().enumerate() {
+            u32::try_from(node_index)
+                .map_err(|_| Error::generic("plan has more nodes than the wire format supports"))?;
+            for &input in &node.inputs {
+                if input >= node_index {
+                    return Err(node_error(
+                        node_index,
+                        &node.op,
+                        format!(
+                            "input {input} must reference one of the {node_index} prior node(s)"
+                        ),
+                    ));
+                }
+                u32::try_from(input).map_err(|_| {
+                    node_error(
+                        node_index,
+                        &node.op,
+                        format!("input {input} cannot be represented by the wire format"),
+                    )
+                })?;
+            }
+
+            let input_schemas = node
+                .inputs
+                .iter()
+                .map(|&input| Arc::clone(&schemas[input]))
+                .collect::<Vec<_>>();
+            let output_schema = validate_operator(node_index, &node.op, &input_schemas)?;
+            schemas.push(output_schema);
+        }
+        Ok(())
+    }
+}
+
+fn validate_operator(
+    node_index: usize,
+    op: &Operator,
+    inputs: &[SchemaRef],
+) -> DeltaResult<SchemaRef> {
+    let result = (|| -> DeltaResult<SchemaRef> {
+        Ok(match op {
+            Operator::ScanParquet(scan) => {
+                require_arity(inputs, 0)?;
+                validate_scan(&scan.schema, &scan.file_constant_columns, &scan.files)?;
+                Arc::clone(&scan.schema)
+            }
+            Operator::ScanJson(scan) => {
+                require_arity(inputs, 0)?;
+                validate_scan(&scan.schema, &scan.file_constant_columns, &scan.files)?;
+                Arc::clone(&scan.schema)
+            }
+            Operator::Values(values) => {
+                require_arity(inputs, 0)?;
+                validate_values(values)?;
+                Arc::clone(&values.schema)
+            }
+            Operator::Project(project) => {
+                require_arity(inputs, 1)?;
+                Project::try_new(
+                    inputs[0].as_ref(),
+                    Arc::clone(project.expression().source_expression()),
+                    Arc::clone(project.schema()),
+                )?;
+                Arc::clone(project.schema())
+            }
+            Operator::Filter(filter) => {
+                require_arity(inputs, 1)?;
+                Filter::try_new(
+                    inputs[0].as_ref(),
+                    Arc::clone(filter.predicate().source_predicate()),
+                )?;
+                Arc::clone(&inputs[0])
+            }
+            Operator::DataSkipping(site) => {
+                require_arity(inputs, 1)?;
+                site.validate_input(inputs[0].as_ref())?;
+                Arc::clone(&inputs[0])
+            }
+            Operator::DynamicScan(scan) => {
+                require_arity(inputs, 1)?;
+                scan.validate_input(&inputs[0])?;
+                Arc::clone(&scan.schema)
+            }
+            Operator::Aggregate(aggregate) => {
+                require_arity(inputs, 1)?;
+                aggregate.validate_input(inputs[0].as_ref())?;
+                Arc::clone(&aggregate.schema)
+            }
+            Operator::SemiJoin(join) => {
+                require_arity(inputs, 2)?;
+                if join.probe_keys.len() != join.build_keys.len() {
+                    return Err(Error::generic(format!(
+                        "join has {} probe key(s) but {} build key(s)",
+                        join.probe_keys.len(),
+                        join.build_keys.len()
+                    )));
+                }
+                for (probe, build) in join.probe_keys.iter().zip(&join.build_keys) {
+                    let probe_field = inputs[0].field_at(probe)?;
+                    let build_field = inputs[1].field_at(build)?;
+                    if probe_field.data_type() != build_field.data_type() {
+                        return Err(Error::generic(format!(
+                            "join keys `{probe}` and `{build}` have different types: {} and {}",
+                            probe_field.data_type(),
+                            build_field.data_type()
+                        )));
+                    }
+                }
+                Arc::clone(&inputs[0])
+            }
+            Operator::UnionAll(_) => {
+                if inputs.len() < 2 {
+                    return Err(Error::generic("union_all requires at least two inputs"));
+                }
+                if let Some(index) = inputs.iter().position(|schema| schema != &inputs[0]) {
+                    return Err(Error::generic(format!(
+                        "union_all input {index} has a different schema from input 0"
+                    )));
+                }
+                Arc::clone(&inputs[0])
+            }
+        })
+    })();
+    result.map_err(|error| node_error(node_index, op, error.to_string()))
+}
+
+fn require_arity(inputs: &[SchemaRef], expected: usize) -> DeltaResult<()> {
+    if inputs.len() != expected {
+        return Err(Error::generic(format!(
+            "expected {expected} input(s), found {}",
+            inputs.len()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_scan(
+    schema: &StructType,
+    file_constant_columns: &[String],
+    files: &[ScanFile],
+) -> DeltaResult<()> {
+    let mut seen = HashSet::new();
+    let mut fields = Vec::with_capacity(file_constant_columns.len());
+    for name in file_constant_columns {
+        if !seen.insert(name) {
+            return Err(Error::generic(format!(
+                "file-constant column `{name}` is listed more than once"
+            )));
+        }
+        let field = schema.field(name).ok_or_else(|| {
+            Error::generic(format!(
+                "file-constant column `{name}` is absent from scan schema"
+            ))
+        })?;
+        if field.is_metadata_column() {
+            return Err(Error::generic(format!(
+                "file-constant column `{name}` is a metadata column"
+            )));
+        }
+        fields.push(field);
+    }
+
+    for (file_index, file) in files.iter().enumerate() {
+        if file.file_constants.len() != fields.len() {
+            return Err(Error::generic(format!(
+                "file {file_index} has {} constant value(s), expected {}",
+                file.file_constants.len(),
+                fields.len()
+            )));
+        }
+        for (value_index, (value, field)) in file.file_constants.iter().zip(&fields).enumerate() {
+            if value.data_type() != *field.data_type() {
+                return Err(Error::generic(format!(
+                    "file {file_index} constant {value_index} for `{}` has type {}, expected {}",
+                    field.name(),
+                    value.data_type(),
+                    field.data_type()
+                )));
+            }
+            if value.is_null() && !field.is_nullable() {
+                return Err(Error::generic(format!(
+                    "file {file_index} constant {value_index} for non-nullable column `{}` is null",
+                    field.name()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_values(values: &Values) -> DeltaResult<()> {
+    let fields = values.schema.fields().collect::<Vec<_>>();
+    for (row_index, row) in values.rows.iter().enumerate() {
+        if row.len() != fields.len() {
+            return Err(Error::generic(format!(
+                "values row {row_index} has {} value(s), expected {}",
+                row.len(),
+                fields.len()
+            )));
+        }
+        for (column_index, (value, field)) in row.iter().zip(&fields).enumerate() {
+            if value.data_type() != *field.data_type() {
+                return Err(Error::generic(format!(
+                    "values row {row_index} column {column_index} `{}` has type {}, expected {}",
+                    field.name(),
+                    value.data_type(),
+                    field.data_type()
+                )));
+            }
+            if value.is_null() && !field.is_nullable() {
+                return Err(Error::generic(format!(
+                    "values row {row_index} column {column_index} `{}` is null but not nullable",
+                    field.name()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn node_error(node_index: usize, op: &Operator, message: impl std::fmt::Display) -> Error {
+    Error::generic(format!("plan node {node_index} ({op}): {message}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use test_utils::assert_result_error_with_message;
+
+    use super::*;
+    use crate::expressions::{col, column_name, lit, Predicate, Scalar};
+    use crate::plans::ir::nodes::{Filter, SemiJoin, UnionAll};
+    use crate::schema::{DataType, StructField, StructType};
+
+    fn schema(name: &str, data_type: DataType) -> SchemaRef {
+        Arc::new(StructType::new_unchecked([StructField::nullable(
+            name, data_type,
+        )]))
+    }
+
+    fn values(schema: SchemaRef, value: Scalar) -> PlanNode {
+        PlanNode::new(Values::new(schema, vec![vec![value]]), vec![])
+    }
+
+    #[test]
+    fn empty_plan_is_rejected() {
+        assert_result_error_with_message(Plan::try_new(vec![]), "at least one node");
+    }
+
+    #[test]
+    fn forward_input_reference_is_rejected() {
+        let node = PlanNode::new(Values::new(schema("id", DataType::LONG), vec![]), vec![0]);
+        assert_result_error_with_message(Plan::try_new(vec![node]), "must reference");
+    }
+
+    #[test]
+    fn values_must_match_their_schema() {
+        let node = values(schema("id", DataType::LONG), Scalar::String("wrong".into()));
+        assert_result_error_with_message(Plan::try_new(vec![node]), "has type string");
+    }
+
+    #[test]
+    fn filter_is_rechecked_against_its_actual_input() {
+        let string_schema = schema("id", DataType::STRING);
+        let filter = Filter::try_new(
+            &string_schema,
+            Predicate::eq(col!("id"), lit("expected-string")),
+        )
+        .unwrap();
+        let nodes = vec![
+            values(schema("id", DataType::LONG), Scalar::Long(1)),
+            PlanNode::new(filter, vec![0]),
+        ];
+        assert_result_error_with_message(Plan::try_new(nodes), "has type string, expected long");
+    }
+
+    #[test]
+    fn joins_require_pairwise_compatible_key_types() {
+        let join = SemiJoin {
+            inverted: false,
+            probe_keys: vec![column_name!("id")],
+            build_keys: vec![column_name!("id")],
+        };
+        let nodes = vec![
+            values(schema("id", DataType::LONG), Scalar::Long(1)),
+            values(schema("id", DataType::STRING), Scalar::String("1".into())),
+            PlanNode::new(join, vec![0, 1]),
+        ];
+        assert_result_error_with_message(Plan::try_new(nodes), "different types");
+    }
+
+    #[test]
+    fn union_requires_identical_input_schemas() {
+        let nodes = vec![
+            values(schema("id", DataType::LONG), Scalar::Long(1)),
+            values(schema("id", DataType::STRING), Scalar::String("1".into())),
+            PlanNode::new(UnionAll, vec![0, 1]),
+        ];
+        assert_result_error_with_message(Plan::try_new(nodes), "different schema");
+    }
 }

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -24,6 +24,40 @@
 //! LEFT ANTI JOIN commit_keys k ON c.file_key = k.file_key
 //! ```
 //!
+//! # Expression boundary
+//!
+//! [`Expression`](crate::expressions::Expression) and
+//! [`Predicate`](crate::expressions::Predicate) are broad source types. A connector creates a
+//! predicate such as `price / 2 > 50` and passes it to a scan; Kernel also creates expressions for
+//! imperative [`EvaluationHandler`](crate::EvaluationHandler) work. These trees contain syntax and
+//! literal types, but column nodes do not carry their resolved type or effective nullability.
+//!
+//! A mandatory plan carries a smaller contract. [`PlanBuilder::project`] and
+//! [`PlanBuilder::filter`] resolve broad inputs against the current schema into
+//! [`PlanExpression`](ir::expression::PlanExpression) and
+//! [`PlanPredicate`](ir::expression::PlanPredicate). Resolution proves column paths, exact types,
+//! effective nested nullability, Boolean filters, and project assignment. It rejects arithmetic,
+//! casts, arrays, `IN`, opaque callbacks, and unknown nodes because replay does not require them.
+//!
+//! ```text
+//! connector or Kernel Expression/Predicate
+//!                 |
+//!                 v
+//!       Kernel resolution + validation
+//!                 |
+//!                 v
+//!       PlanExpression/PlanPredicate
+//!                 |
+//!                 v
+//!             PlanExecutor
+//! ```
+//!
+//! Data skipping is intentionally separate. A [`DataSkippingSite`](ir::nodes::DataSkippingSite)
+//! is an optional identity operation containing the broad source predicate, resolved statistics
+//! locations, protected-row rules, and possibly Kernel's portable keep predicate. An executor may
+//! apply that predicate, derive a richer conservative native filter, or keep every row. Thus an
+//! engine can analyze `price / 2 > 50` without making division mandatory for metadata replay.
+//!
 //! # Writing an executor
 //!
 //! An executor implements [`PlanExecutor::execute_op`], dispatching on the [`Operation`] it
@@ -35,9 +69,10 @@
 //!   evaluate [`Plan::nodes`](ir::plan::Plan::nodes) in slice order, which is topologically sorted
 //!   so a node's inputs are already evaluated, or compile the DAG into the engine's own plan.
 //!
-//! Every operator, expression, and predicate a plan contains must be handled; returning an error
-//! for an unsupported one is fine, and kernel surfaces it to the caller. The sync engine's
-//! `SyncPlanExecutor` is a complete reference implementation.
+//! Every mandatory operator, expression, and predicate a plan contains must be handled. A
+//! [`DataSkippingSite`](ir::nodes::DataSkippingSite) may be treated as identity, because it affects
+//! performance rather than correctness. The sync engine's `SyncPlanExecutor` is a reference
+//! implementation.
 //!
 //! # Consuming terminal results
 //!
@@ -65,8 +100,9 @@
 //!   its operator with a runnable example.
 //! - [`ir::nodes`] is the operator catalog: each [`Operator`](ir::nodes::Operator) variant's
 //!   payload struct carries its semantics, invariants, and worked examples.
-//! - [`crate::expressions`] defines the expressions and predicates operators evaluate, including
-//!   the type and null semantics an executor must match.
+//! - [`ir::expression`] defines the closed, resolved expressions and predicates executors match.
+//! - [`crate::expressions`] defines the broader public source language accepted at scan and
+//!   imperative-evaluation boundaries.
 //!
 //! This module is opt-in behind the `declarative-plans` feature flag.
 mod builder;

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -17,9 +17,13 @@ use crate::expressions::{
     OpaquePredicate, ParseJsonExpression, Predicate, Scalar, StructData, UnaryExpression,
     UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
 };
+use crate::plans::ir::expression::{
+    PlanComparison, PlanExpression, PlanExpressionKind, PlanExpressionRef, PlanFieldPatch,
+    PlanPredicate, PlanPredicateKind, PlanPredicateRef, PlanStructPatch,
+};
 use crate::plans::ir::nodes::{
-    Agg, Aggregate, DynamicScan, FileType, Filter, Operator, Project, ScanFile, ScanJson,
-    ScanParquet, SemiJoin, Values,
+    Agg, Aggregate, DataSkippingSite, DataSkippingStats, DataSkippingTarget, DynamicScan, FileType,
+    Filter, Operator, Project, ScanFile, ScanJson, ScanParquet, SemiJoin, Values,
 };
 use crate::plans::ir::plan::{Plan, PlanNode};
 use crate::plans::{IoOperation, Operation};
@@ -47,6 +51,20 @@ where
     E: AsRef<Expression>,
 {
     items.iter().map(|e| e.as_ref().into()).collect()
+}
+
+fn convert_plan_expr_vec(items: &[PlanExpressionRef]) -> Vec<proto_expr::PlanExpression> {
+    items
+        .iter()
+        .map(|expression| expression.as_ref().into())
+        .collect()
+}
+
+fn convert_plan_predicate_vec(items: &[PlanPredicateRef]) -> Vec<proto_expr::PlanPredicate> {
+    items
+        .iter()
+        .map(|predicate| predicate.as_ref().into())
+        .collect()
 }
 
 // === Operation / IoOperation to Proto ===
@@ -124,7 +142,7 @@ impl From<&FileMeta> for proto_plan::FileMeta {
 impl From<&Plan> for proto_plan::Plan {
     fn from(plan: &Plan) -> Self {
         proto_plan::Plan {
-            nodes: convert_vec(&plan.nodes),
+            nodes: convert_vec(plan.nodes()),
         }
     }
 }
@@ -132,8 +150,8 @@ impl From<&Plan> for proto_plan::Plan {
 impl From<&PlanNode> for proto_plan::PlanNode {
     fn from(node: &PlanNode) -> Self {
         proto_plan::PlanNode {
-            op: Some((&node.op).into()),
-            inputs: node.inputs.iter().map(|&i| i as u32).collect(),
+            op: Some(node.operator().into()),
+            inputs: node.inputs().iter().map(|&i| i as u32).collect(),
         }
     }
 }
@@ -147,6 +165,7 @@ impl From<&Operator> for proto_plan::Operator {
             Operator::Values(n) => Op::Values(n.into()),
             Operator::Project(n) => Op::Project(n.into()),
             Operator::Filter(n) => Op::Filter(n.into()),
+            Operator::DataSkipping(n) => Op::DataSkipping(n.into()),
             Operator::DynamicScan(n) => Op::DynamicScan(n.into()),
             Operator::Aggregate(n) => Op::Aggregate(n.into()),
             Operator::SemiJoin(n) => Op::SemiJoin(n.into()),
@@ -204,8 +223,8 @@ impl From<&Values> for proto_plan::ValuesNode {
 impl From<&Project> for proto_plan::ProjectNode {
     fn from(node: &Project) -> Self {
         proto_plan::ProjectNode {
-            expr: Some(node.expr.as_ref().into()),
-            schema: Some(node.schema.as_ref().into()),
+            expr: Some(node.expression().as_ref().into()),
+            schema: Some(node.schema().as_ref().into()),
         }
     }
 }
@@ -213,7 +232,45 @@ impl From<&Project> for proto_plan::ProjectNode {
 impl From<&Filter> for proto_plan::FilterNode {
     fn from(node: &Filter) -> Self {
         proto_plan::FilterNode {
-            predicate: Some(node.predicate.as_ref().into()),
+            predicate: Some(node.predicate().as_ref().into()),
+        }
+    }
+}
+
+impl From<&DataSkippingSite> for proto_plan::DataSkippingNode {
+    fn from(site: &DataSkippingSite) -> Self {
+        Self {
+            source_predicate: Some(site.source_predicate().as_ref().into()),
+            stats: Some(site.stats().into()),
+            target: Some(site.target().into()),
+            kernel_keep_predicate: site
+                .kernel_keep_predicate()
+                .map(|predicate| predicate.as_ref().into()),
+        }
+    }
+}
+
+impl From<&DataSkippingStats> for proto_plan::DataSkippingStats {
+    fn from(stats: &DataSkippingStats) -> Self {
+        Self {
+            source_schema: Some(stats.source_schema().as_ref().into()),
+            stats_column: stats.stats_column().map(|column| column.name().into()),
+            partition_values_column: stats
+                .partition_values_column()
+                .map(|column| column.name().into()),
+        }
+    }
+}
+
+impl From<&DataSkippingTarget> for proto_plan::DataSkippingTarget {
+    fn from(target: &DataSkippingTarget) -> Self {
+        use proto_plan::data_skipping_target::Target;
+        let target = match target {
+            DataSkippingTarget::AddsOnly => Target::AddsOnly(true),
+            DataSkippingTarget::MixedActions { is_add } => Target::IsAdd(is_add.name().into()),
+        };
+        Self {
+            target: Some(target),
         }
     }
 }
@@ -299,6 +356,118 @@ impl From<FileType> for proto_plan::FileType {
 
 // === Expressions to Proto ===
 
+impl From<&PlanExpression> for proto_expr::PlanExpression {
+    fn from(expression: &PlanExpression) -> Self {
+        use proto_expr::plan_expression::Kind;
+        let kind = match expression.kind() {
+            PlanExpressionKind::Literal(scalar) => Kind::Literal(scalar.into()),
+            PlanExpressionKind::Column(column) => Kind::Column(column.name().into()),
+            PlanExpressionKind::Predicate(predicate) => Kind::Predicate(Box::new(predicate.into())),
+            PlanExpressionKind::Struct {
+                fields,
+                nullability,
+            } => Kind::StructExpr(Box::new(proto_expr::PlanStructExpression {
+                fields: convert_plan_expr_vec(fields),
+                nullability: nullability.map(|expression| Box::new(expression.into())),
+            })),
+            PlanExpressionKind::StructPatch(patch) => Kind::StructPatch(patch.into()),
+            PlanExpressionKind::Coalesce(expressions) => Kind::Coalesce(proto_expr::PlanCoalesce {
+                expressions: convert_plan_expr_vec(expressions),
+            }),
+            PlanExpressionKind::ParseJson {
+                json,
+                output_schema,
+            } => Kind::ParseJson(Box::new(proto_expr::PlanParseJson {
+                json: Some(Box::new(json.into())),
+                output_schema: Some(output_schema.as_ref().into()),
+            })),
+            PlanExpressionKind::MapToStruct { map, output_schema } => {
+                Kind::MapToStruct(Box::new(proto_expr::PlanMapToStruct {
+                    map: Some(Box::new(map.into())),
+                    output_schema: Some(output_schema.into()),
+                }))
+            }
+        };
+        Self {
+            data_type: Some(expression.data_type().into()),
+            nullable: expression.is_nullable(),
+            kind: Some(kind),
+        }
+    }
+}
+
+impl From<&PlanPredicate> for proto_expr::PlanPredicate {
+    fn from(predicate: &PlanPredicate) -> Self {
+        use proto_expr::plan_predicate::Kind;
+        let kind = match predicate.kind() {
+            PlanPredicateKind::Boolean(expression) => {
+                Kind::BooleanExpression(Box::new(expression.into()))
+            }
+            PlanPredicateKind::Not(inner) => Kind::Not(Box::new(inner.into())),
+            PlanPredicateKind::IsNull {
+                expression,
+                inverted,
+            } => Kind::IsNull(Box::new(proto_expr::PlanIsNull {
+                expression: Some(Box::new(expression.into())),
+                inverted,
+            })),
+            PlanPredicateKind::Compare { op, left, right } => {
+                Kind::Compare(Box::new(proto_expr::PlanCompare {
+                    op: proto_expr::PlanComparison::from(op) as i32,
+                    left: Some(Box::new(left.into())),
+                    right: Some(Box::new(right.into())),
+                }))
+            }
+            PlanPredicateKind::And(predicates) => Kind::And(proto_expr::PlanJunction {
+                predicates: convert_plan_predicate_vec(predicates),
+            }),
+            PlanPredicateKind::Or(predicates) => Kind::Or(proto_expr::PlanJunction {
+                predicates: convert_plan_predicate_vec(predicates),
+            }),
+        };
+        Self {
+            nullable: predicate.is_nullable(),
+            kind: Some(kind),
+        }
+    }
+}
+
+impl From<&PlanStructPatch> for proto_expr::PlanStructPatch {
+    fn from(patch: &PlanStructPatch) -> Self {
+        Self {
+            input_path: patch.input_path().map(Into::into),
+            field_patches: patch
+                .field_patches()
+                .iter()
+                .map(|(name, patch)| (name.clone(), patch.into()))
+                .collect(),
+            prepended_fields: convert_plan_expr_vec(patch.prepended_fields()),
+            appended_fields: convert_plan_expr_vec(patch.appended_fields()),
+        }
+    }
+}
+
+impl From<&PlanFieldPatch> for proto_expr::PlanFieldPatch {
+    fn from(patch: &PlanFieldPatch) -> Self {
+        Self {
+            keep_input: patch.keeps_input(),
+            insertions: convert_plan_expr_vec(patch.insertions()),
+            optional: patch.is_optional(),
+        }
+    }
+}
+
+impl From<PlanComparison> for proto_expr::PlanComparison {
+    fn from(comparison: PlanComparison) -> Self {
+        match comparison {
+            PlanComparison::LessThan => Self::LessThan,
+            PlanComparison::GreaterThan => Self::GreaterThan,
+            PlanComparison::Equal => Self::Equal,
+            PlanComparison::Distinct => Self::Distinct,
+        }
+    }
+}
+
 impl From<&Expression> for proto_expr::Expression {
     fn from(expr: &Expression) -> Self {
         use proto_expr::expression::Kind;
@@ -324,8 +493,10 @@ impl From<&Expression> for proto_expr::Expression {
             Expression::MapToStruct(map_to_struct) => {
                 Kind::MapToStruct(Box::new(map_to_struct.into()))
             }
-            // No proto cast node yet; serialize as an opaque unknown.
-            Expression::Cast(cast) => Kind::Unknown(format!("cast_to_{}", cast.target)),
+            Expression::Cast(cast) => Kind::Cast(Box::new(proto_expr::CastExpression {
+                expr: Some(Box::new(cast.expr.as_ref().into())),
+                target: Some((&cast.target).into()),
+            })),
         };
         proto_expr::Expression { kind: Some(kind) }
     }
@@ -966,8 +1137,6 @@ impl TryFrom<proto_schema::MetadataValue> for MetadataValue {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use bytes::Bytes;
     use rstest::rstest;
     use url::Url;
@@ -986,8 +1155,9 @@ mod tests {
         IndirectDataSkippingPredicateEvaluator,
     };
     use crate::plans::ir::nodes::{
-        Agg, Aggregate, DynamicScan, FileType, Filter, Operator, Project, ScanFile, ScanJson,
-        ScanParquet, SemiJoin, UnionAll, Values,
+        Agg, Aggregate, DataSkippingSite, DataSkippingStats, DataSkippingTarget, DynamicScan,
+        FileType, Filter, Operator, Project, ScanFile, ScanJson, ScanParquet, SemiJoin, UnionAll,
+        Values,
     };
     use crate::plans::ir::plan::{Plan, PlanNode};
     use crate::plans::proto::{
@@ -1068,7 +1238,7 @@ mod tests {
     }
 
     fn decode(op: &Operation) -> proto_op::Operation {
-        let bytes = op.to_proto_bytes();
+        let bytes = op.to_proto_bytes().unwrap();
         prost::Message::decode(bytes.as_slice()).expect("decode succeeds")
     }
 
@@ -1104,7 +1274,10 @@ mod tests {
         Operation::IoOperation(IoOperation::head_file(Url::parse("memory:///h").unwrap())),
         "io"
     )]
-    #[case(Operation::QueryPlan(Plan { nodes: vec![] }), "query_plan")]
+    #[case(Operation::QueryPlan(Plan::try_new(vec![PlanNode::new(
+        Values::new(sample_schema(), vec![]),
+        vec![],
+    )]).unwrap()), "query_plan")]
     fn from_operation(#[case] op: Operation, #[case] expected: &str) {
         use proto_op::operation::Op;
         let kind = match decode(&op).op.unwrap() {
@@ -1220,24 +1393,23 @@ mod tests {
             nullable "id": INTEGER,
             not_null "name": STRING,
         };
-        let plan = Plan {
-            nodes: vec![
-                PlanNode {
-                    op: Operator::ScanParquet(ScanParquet {
-                        files: vec![ScanFile::new(sample_file_meta())],
-                        file_constant_columns: vec![],
-                        schema: schema.clone(),
-                    }),
-                    inputs: vec![],
-                },
-                PlanNode {
-                    op: Operator::Filter(Filter {
-                        predicate: Arc::new(Predicate::gt(col!("id"), lit(5i32))),
-                    }),
-                    inputs: vec![0],
-                },
-            ],
-        };
+        let plan = Plan::try_new(vec![
+            PlanNode::new(
+                Operator::ScanParquet(ScanParquet {
+                    files: vec![ScanFile::new(sample_file_meta())],
+                    file_constant_columns: vec![],
+                    schema: schema.clone(),
+                }),
+                vec![],
+            ),
+            PlanNode::new(
+                Operator::Filter(
+                    Filter::try_new(&schema, Predicate::gt(col!("id"), lit(5i32))).unwrap(),
+                ),
+                vec![0],
+            ),
+        ])
+        .unwrap();
 
         let Some(proto_op::operation::Op::QueryPlan(plan)) = decode(&Operation::QueryPlan(plan)).op
         else {
@@ -1264,13 +1436,56 @@ mod tests {
             panic!("expected Filter");
         };
         let predicate = filter.predicate.as_ref().unwrap();
-        let Some(proto_expr::predicate::Kind::Binary(binary)) = &predicate.kind else {
-            panic!("expected a binary predicate");
+        let Some(proto_expr::plan_predicate::Kind::Compare(compare)) = &predicate.kind else {
+            panic!("expected a resolved comparison predicate");
         };
-        assert_eq!(binary.op, proto_expr::BinaryPredicateOp::GreaterThan as i32);
+        assert_eq!(compare.op, proto_expr::PlanComparison::GreaterThan as i32);
         assert!(matches!(
-            binary.left.as_ref().unwrap().kind,
-            Some(proto_expr::expression::Kind::Column(_))
+            compare.left.as_ref().unwrap().kind,
+            Some(proto_expr::plan_expression::Kind::Column(_))
+        ));
+    }
+
+    #[test]
+    fn data_skipping_source_divide_is_serialized_as_optional_analysis_input() {
+        let stats_type = schema! {
+            nullable "maxValues": { nullable "x": LONG },
+        };
+        let input_schema = schema_ref! {
+            nullable "stats": (stats_type),
+            not_null "is_add": BOOLEAN,
+        };
+        let source_schema = schema_ref! { nullable "x": LONG };
+        let source_predicate = Predicate::gt(
+            Expression::binary(BinaryExpressionOp::Divide, col!("x"), lit(2i64)),
+            lit(50i64),
+        );
+        let stats = DataSkippingStats::try_new(
+            &input_schema,
+            source_schema,
+            Some(column_name!("stats")),
+            None,
+        )
+        .unwrap();
+        let target =
+            DataSkippingTarget::mixed_actions(&input_schema, column_name!("is_add")).unwrap();
+        let site = DataSkippingSite::try_new(&input_schema, source_predicate, stats, target, None)
+            .unwrap();
+
+        let proto = proto_plan::DataSkippingNode::from(&site);
+        let source = proto.source_predicate.unwrap();
+        let proto_expr::predicate::Kind::Binary(comparison) = source.kind.unwrap() else {
+            panic!("expected source comparison");
+        };
+        let proto_expr::expression::Kind::Binary(divide) = comparison.left.unwrap().kind.unwrap()
+        else {
+            panic!("expected source divide");
+        };
+        assert_eq!(divide.op, proto_expr::BinaryExpressionOp::Divide as i32);
+        assert!(proto.kernel_keep_predicate.is_none());
+        assert!(matches!(
+            proto.target.unwrap().target,
+            Some(proto_plan::data_skipping_target::Target::IsAdd(_))
         ));
     }
 
@@ -1293,13 +1508,17 @@ mod tests {
     )]
     #[case(Operator::Values(Values { schema: sample_schema(), rows: vec![] }), "values")]
     #[case(
-        Operator::Project(Project {
-            expr: Arc::new(Expression::struct_from([lit(1)])),
-            schema: sample_schema(),
-        }),
+        Operator::Project(
+            Project::try_new(
+                &sample_schema(),
+                Expression::struct_from([lit(1)]),
+                sample_schema(),
+            )
+            .unwrap(),
+        ),
         "project"
     )]
-    #[case(Operator::Filter(Filter { predicate: Arc::new(Predicate::TRUE) }), "filter")]
+    #[case(Operator::Filter(Filter::try_new(&sample_schema(), Predicate::TRUE).unwrap()), "filter")]
     #[case(
         Operator::DynamicScan(DynamicScan {
             schema: sample_schema(),
@@ -1334,6 +1553,7 @@ mod tests {
             Op::Values(_) => "values",
             Op::Project(_) => "project",
             Op::Filter(_) => "filter",
+            Op::DataSkipping(_) => "data_skipping",
             Op::DynamicScan(_) => "dynamic_scan",
             Op::Aggregate(_) => "aggregate",
             Op::SemiJoin(_) => "semi_join",
@@ -1393,22 +1613,33 @@ mod tests {
 
     #[test]
     fn from_project() {
-        let node = Project {
-            expr: Arc::new(Expression::struct_from([lit(1)])),
-            schema: sample_schema(),
-        };
+        let node = Project::try_new(
+            &sample_schema(),
+            Expression::struct_from([lit(1)]),
+            sample_schema(),
+        )
+        .unwrap();
         let proto = proto_plan::ProjectNode::from(&node);
-        assert!(proto.expr.is_some());
+        let expression = proto.expr.unwrap();
+        assert!(expression.data_type.is_some());
+        assert!(!expression.nullable);
+        assert!(matches!(
+            expression.kind,
+            Some(proto_expr::plan_expression::Kind::StructExpr(_))
+        ));
         assert!(proto.schema.is_some());
     }
 
     #[test]
     fn from_filter() {
-        let node = Filter {
-            predicate: Arc::new(Predicate::TRUE),
-        };
+        let node = Filter::try_new(&sample_schema(), Predicate::TRUE).unwrap();
         let proto = proto_plan::FilterNode::from(&node);
-        assert!(proto.predicate.is_some());
+        let predicate = proto.predicate.unwrap();
+        assert!(!predicate.nullable);
+        assert!(matches!(
+            predicate.kind,
+            Some(proto_expr::plan_predicate::Kind::BooleanExpression(_))
+        ));
     }
 
     fn sample_dynamic_scan_input_schema() -> SchemaRef {
@@ -1575,6 +1806,7 @@ mod tests {
     #[case(Expression::parse_json(lit("{}"), sample_schema()), "parse_json")]
     #[case(Expression::map_to_struct(col!("m")), "map_to_struct")]
     #[case(Expression::unknown("x"), "unknown")]
+    #[case(Expression::cast(col!("a"), DataType::LONG), "cast")]
     fn from_expression(#[case] expr: Expression, #[case] expected: &str) {
         use proto_expr::expression::Kind;
         let kind = match proto_expr::Expression::from(&expr).kind.unwrap() {
@@ -1591,6 +1823,7 @@ mod tests {
             Kind::ParseJson(_) => "parse_json",
             Kind::MapToStruct(_) => "map_to_struct",
             Kind::Unknown(_) => "unknown",
+            Kind::Cast(_) => "cast",
         };
         assert_eq!(kind, expected);
     }
@@ -1663,6 +1896,23 @@ mod tests {
         assert_eq!(binary.op, proto_expr::BinaryExpressionOp::Plus as i32);
         assert!(binary.left.is_some());
         assert!(binary.right.is_some());
+    }
+
+    #[test]
+    fn from_cast_expression_preserves_child_and_target() {
+        let proto_expr::expression::Kind::Cast(cast) =
+            expr_kind_of(Expression::cast(col!("a"), DataType::LONG))
+        else {
+            panic!("expected a cast expression");
+        };
+        assert!(matches!(
+            cast.expr.unwrap().kind,
+            Some(proto_expr::expression::Kind::Column(_))
+        ));
+        assert_eq!(
+            DataType::try_from(cast.target.unwrap()).unwrap(),
+            DataType::LONG
+        );
     }
 
     #[test]

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -19,7 +19,9 @@ use crate::expressions::{
     col, column_name, joined_column_expr, lit, ColumnName, Expression as Expr, ExpressionRef,
     Predicate,
 };
-use crate::plans::ir::nodes::{DynamicScan, FileType, ScanFile};
+use crate::plans::ir::nodes::{
+    DataSkippingSite, DataSkippingStats, DataSkippingTarget, DynamicScan, FileType, ScanFile,
+};
 use crate::plans::ir::plan::Plan;
 use crate::scan::log_replay::{PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME};
 use crate::schema::{
@@ -58,32 +60,19 @@ impl Scan {
             return Ok(None);
         }
 
-        let prune = stats_skipping_predicate(state);
-        let prune = prune.as_ref();
-
         // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's
         // dedup carrier and both terminal `{ add }` projections, so every arm agrees on the
         // union schema.
         let add_field = self.normalized_add_field()?;
         let (output_expr, output_schema) = self.metadata_output_projection(&add_field)?;
 
-        let commit_actions = self.commit_arm()?.try_fold_with(prune, |p, prune| {
-            // We filter so that:
-            // * All remove actions are kept
-            // * Add actions that do not match the partition pruning or stats predicate are removed.
-            //
-            // NOTE: It is important that add actions are filtered by the partition predicate
-            // because partition filtering may not be applied on data rows. On the other
-            // hand, failing to skip based on data columns is safe because the data
-            // predicate will also be evaluated on data rows. Thus it is crucial that we partition
-            // prune adds here.
-            //
-            // NOTE: It is not safe to prune remove actions using the partition filter. This is
-            // because a NULL result for `remove.partitionValues.partCol` may be due to
-            // `remove.partitionValues` being NULL, or it may be from `partCol` being
-            // NULL. Thus, we simply do not prune removes.
-            p.filter(Predicate::or(col!("add").is_null(), prune.clone()))
-        })?;
+        // This site is optional: ignoring it returns extra candidate Adds, never an incorrect live
+        // file listing. The mixed-action target makes Remove preservation explicit to executors.
+        let commit_actions = data_skipping_site(
+            self.commit_arm()?,
+            state,
+            DataSkippingSiteTarget::MixedActions,
+        )?;
 
         let deduped_commit = commit_actions.aggregate_by([column_name!(FILE_ACTION_KEY)], |a| {
             // Each group with a non-null FILE_ACTION_KEY contains the adds and removes for a given
@@ -96,9 +85,11 @@ impl Scan {
             )
         })?;
 
-        let checkpoint_adds = self
-            .checkpoint_arm(shape)?
-            .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
+        let checkpoint_adds = data_skipping_site(
+            self.checkpoint_arm(shape)?,
+            state,
+            DataSkippingSiteTarget::AddsOnly,
+        )?;
 
         let checkpoint_live_adds = checkpoint_adds
             .anti_join(
@@ -361,12 +352,15 @@ fn sidecar_actions(
     let sidecar_files = scan(root_parts, &[VERSION], SIDECAR_READ_SCHEMA.clone())?
         .filter(col!(SIDECAR_NAME, FILE_PATH).is_not_null())?
         .project(
-            Expr::struct_from([
-                col!(SIDECAR_NAME, FILE_PATH),
-                col!(SIDECAR_NAME, SIDECAR_SIZE),
-                col!(SIDECAR_NAME, SIDECAR_FILE_MOD),
-                col!(VERSION),
-            ]),
+            Expr::struct_with_nullability_from(
+                [
+                    col!(SIDECAR_NAME, FILE_PATH),
+                    col!(SIDECAR_NAME, SIDECAR_SIZE),
+                    col!(SIDECAR_NAME, SIDECAR_FILE_MOD),
+                    col!(VERSION),
+                ],
+                Expr::from_pred(col!(SIDECAR_NAME, FILE_PATH).is_not_null()),
+            ),
             SIDECAR_FILE_META_SCHEMA.clone(),
         )?;
 
@@ -519,6 +513,60 @@ fn project_nested_struct_to_schema(
     )
 }
 
+#[derive(Clone, Copy)]
+enum DataSkippingSiteTarget {
+    AddsOnly,
+    MixedActions,
+}
+
+/// Adds an optional pruning site whenever the scan has a source predicate and usable metadata.
+///
+/// The source predicate may be broader than the mandatory plan language. Kernel's portable keep
+/// predicate is present only when the built-in rewriter can derive one; otherwise the site remains
+/// useful to an executor with its own conservative range analysis.
+fn data_skipping_site(
+    input: PlanBuilder,
+    state: &StateInfo,
+    target: DataSkippingSiteTarget,
+) -> DeltaResult<PlanBuilder> {
+    let PhysicalPredicate::Some(source_predicate, source_schema) = &state.physical_predicate else {
+        return Ok(input);
+    };
+    let stats_column = state
+        .physical_stats_schema
+        .as_ref()
+        .map(|_| column_name!(ADD_NAME, STATS_PARSED_NAME));
+    let partition_values_column = state
+        .physical_partition_schema
+        .as_ref()
+        .map(|_| column_name!(ADD_NAME, PARTITION_VALUES_PARSED_NAME));
+    if stats_column.is_none() && partition_values_column.is_none() {
+        return Ok(input);
+    }
+
+    let stats = DataSkippingStats::try_new(
+        input.schema(),
+        Arc::clone(source_schema),
+        stats_column,
+        partition_values_column,
+    )?;
+    let target = match target {
+        DataSkippingSiteTarget::AddsOnly => DataSkippingTarget::AddsOnly,
+        DataSkippingSiteTarget::MixedActions => {
+            DataSkippingTarget::mixed_actions(input.schema(), column_name!(IS_ADD))?
+        }
+    };
+    let kernel_keep_predicate = stats_skipping_predicate(state).map(Arc::new);
+    let site = DataSkippingSite::try_new(
+        input.schema(),
+        Arc::clone(source_predicate),
+        stats,
+        target,
+        kernel_keep_predicate,
+    )?;
+    input.data_skipping_site(site)
+}
+
 /// Build the metadata pruning predicate, or `None` when no pruning is possible.
 fn stats_skipping_predicate(state: &StateInfo) -> Option<Predicate> {
     /// Re-roots metadata columns under `add`.
@@ -559,7 +607,8 @@ fn stats_skipping_predicate(state: &StateInfo) -> Option<Predicate> {
     // A null skipping verdict means the available metadata cannot prove the file is skippable.
     let skipping = Predicate::distinct(skipping, lit(false));
     let mut prefixer = MetadataSkippingColumnPrefixer;
-    Some(prefixer.transform_pred(&skipping).into_owned())
+    let skipping = prefixer.transform_pred(&skipping).into_owned();
+    (!skipping.references().is_empty()).then_some(skipping)
 }
 
 #[cfg(test)]
@@ -572,6 +621,7 @@ mod tests {
     use crate::arrow::array::{StringArray, StructArray};
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::sync::SyncEngine;
+    use crate::expressions::BinaryExpressionOp;
     use crate::log_segment::LogSegment;
     use crate::log_segment_files::LogSegmentFiles;
     use crate::object_store::memory::InMemory;
@@ -656,7 +706,10 @@ mod tests {
     }
 
     fn tags(plan: &Plan) -> Vec<String> {
-        plan.nodes.iter().map(|node| node.op.to_string()).collect()
+        plan.nodes()
+            .iter()
+            .map(|node| node.operator().to_string())
+            .collect()
     }
 
     fn add_struct(schema: &SchemaRef) -> &StructType {
@@ -763,6 +816,44 @@ mod tests {
         "project",   // extract add
     ];
 
+    #[test]
+    fn unsupported_portable_divide_remains_available_for_native_skipping() -> DeltaResult<()> {
+        let segment = log_segment(
+            log_root(),
+            &["file:///_delta_log/00000000000000000001.json"],
+            None,
+        );
+        let predicate = Predicate::gt(
+            Expr::binary(BinaryExpressionOp::Divide, col!("x"), lit(2i64)),
+            lit(50i64),
+        );
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_predicate(Arc::new(predicate))
+            .build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
+        let site = plan
+            .nodes()
+            .iter()
+            .find_map(|node| match node.operator() {
+                Operator::DataSkipping(site) => Some(site),
+                _ => None,
+            })
+            .expect("data-skipping site");
+
+        assert!(
+            site.kernel_keep_predicate().is_none(),
+            "{:?}",
+            site.kernel_keep_predicate()
+                .map(|predicate| predicate.source_predicate())
+        );
+        assert!(site.stats().stats_column().is_some());
+        assert!(site.target().is_add().is_some());
+        Ok(())
+    }
+
     #[rstest::rstest]
     #[case::leaf_parquet(shape(CheckpointType::Leaf, None), FileType::Parquet,
         vec!["scan_parquet", "filter", "project", "semi_join", "project"])]
@@ -810,9 +901,9 @@ mod tests {
             .expect("non-empty");
 
         let dynamic_scan = plan
-            .nodes
+            .nodes()
             .iter()
-            .find_map(|n| match &n.op {
+            .find_map(|n| match n.operator() {
                 Operator::DynamicScan(dynamic_scan) => Some(dynamic_scan),
                 _ => None,
             })

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -267,11 +267,11 @@ fn declarative_metadata_scans_sidecars_from_checkpoint_hint(
         .expect("metadata plan");
 
     assert!(plan
-        .nodes
+        .nodes()
         .iter()
-        .all(|node| !matches!(&node.op, Operator::DynamicScan(_))));
-    assert!(plan.nodes.iter().any(|node| {
-        let Operator::ScanParquet(scan) = &node.op else {
+        .all(|node| !matches!(node.operator(), Operator::DynamicScan(_))));
+    assert!(plan.nodes().iter().any(|node| {
+        let Operator::ScanParquet(scan) = node.operator() else {
             return false;
         };
         scan.files


### PR DESCRIPTION
## What changes are proposed in this pull request?

### Executive summary

A `PlanExecutor` should not also need to be an expression analyzer. Kernel already knows the
input and output schemas while constructing a declarative plan, so it can resolve column paths,
determine exact result types and effective nullability, and reject malformed or unsupported
expressions once.

This change performs that analysis in Kernel and passes every executor a small, closed
`PlanExpression` / `PlanPredicate` language. Executors translate a proven plan into their native
representation instead of independently reconstructing schema facts and deciding which parts of
Kernel's broad expression language are executable.

The broad public `Expression` remains useful as an ergonomic source language for caller scan
predicates, imperative evaluation, and optional optimization. It may describe operations such as
`x / 2 > 50` or `CAST(x AS LONG)`. Those operations do not become mandatory `PlanExecutor`
requirements unless Kernel deliberately adds them to the resolved plan dialect.

Resolution is a plan-construction operation, not a per-row execution cost. It is linear in the
small expression tree and replaces analysis that executors otherwise perform separately. The
additional type and nullability metadata is small relative to log I/O and execution, and may
reduce downstream planning work.

### Problems with the existing boundary

An expression such as `add.path` identifies a column path, but does not record its resolved type or
effective nullability. If `add` is nullable and `path` is non-null within it, `add.path` is still
nullable. Each executor previously had to rediscover facts like this, creating room for different
schemas and results.

The broad language also contains arithmetic, casts, arrays, `IN`, opaque callbacks, and unknown
nodes. These are useful at other API boundaries, but replay does not emit them. Allowing them in a
mandatory plan meant an optional or unsupported expression could become an execution failure.

Finally, public plan fields allowed construction to bypass the builder, and the wire format did not
faithfully distinguish the mandatory plan language from optional source syntax. In particular,
`Cast` was serialized as an `Unknown` placeholder that discarded its child and target type.

### How this simplifies a plan executor

An executor receiving a broad expression cannot translate syntax alone. It typically needs an
intermediate result resembling:

```rust
struct TranslatedExpression {
    expression: NativeExpression,
    data_type: DataType,
    nullable: bool,
}
```

The executor must recursively infer `data_type` and `nullable` while constructing its native
expression, then use those inferred facts to validate parent expressions and the declared output
schema. That duplicates a schema analyzer in every executor.

#### Work removed from each executor

Without a resolved plan dialect, each executor must:

- carry a native expression together with an inferred result type and effective nullability;
- pass the input schema and optional target output field through recursive translation;
- resolve column paths and account for nullable ancestors;
- infer and validate child and result types and nullability;
- validate argument counts, exact operand types, Boolean predicates, struct fields, and Project assignments; and
- match the broad `Expression` and `Predicate` enums and reject arithmetic, casts, arrays, `IN`, opaque callbacks, unknown nodes, and other operations outside mandatory execution.

With `PlanExpression` and `PlanPredicate`, Kernel performs these checks during plan construction. An executor reads the attached type and nullability, exhaustively lowers the closed node kinds, and implements their native runtime semantics. The input schema may still be needed for structural operations such as `StructPatch`, but the executor no longer needs a target output field or a `TranslatedExpression`-style result for type analysis.

#### Example 1: duplicated type and nullability analysis

Without a resolved boundary, translation needs both schema context and a target field:

```rust
fn translate(
    expression: &Expression,
    input_schema: &StructType,
    output_field: Option<&StructField>,
) -> Result<TranslatedExpression>;
```

The translator recursively computes types and nullability, validates assignment to
`output_field`, and threads that context into composite children. With this change, the input is
already a `PlanExpression` carrying `data_type()` and `is_nullable()`, and `Project` construction
has already proved assignment to its output schema:

```rust
fn translate(
    expression: &PlanExpression,
    input_schema: &StructType,
) -> Result<NativeExpression>;
```

The input schema may still help materialize structural operations such as `StructPatch`, but it is
no longer needed to independently infer every child's contract.

#### Example 2: column translation becomes mechanical

For a column, an executor currently has to walk the plan input schema:

```rust
let fields = input_schema.fields_of_path(column)?;
let data_type = fields.last().data_type();
let nullable = fields.iter().any(StructField::is_nullable);
```

The ancestor scan is essential. Given `add: nullable struct { path: non-null string }`, the leaf
`add.path` is effectively nullable even though `path` itself is non-null. With this change, Kernel
provides a `PlanColumn` containing the proved path, type, and effective nullability. Translation is
reduced to constructing the native column reference; an executor can read `column.data_type()` and
`column.is_nullable()` without deriving them.

#### Example 3: `COALESCE` translation stops being an analyzer

An executor currently has to reject an empty argument list, infer the first child's type, require
every remaining child to have that exact type, and compute that the result is nullable only when
every child is nullable:

```rust
let first = translate(children.first()?)?;
for child in children.iter().skip(1) {
    let child = translate(child)?;
    require_same_type(&first, &child)?;
}
let nullable = children.iter().all(|child| child.nullable);
```

A resolved `PlanExpressionKind::Coalesce` has already passed those checks. The executor only maps
the children and constructs its native `COALESCE` call.

Struct construction compounds the same problem. An executor currently needs the separately
declared output field to obtain field names, validate arity, recursively validate each child
assignment, and decide whether a validity guard actually makes a nullable child safe for a
non-null nested field. The resolved struct carries its exact output type and resolved children, and
Kernel proves the guarded-nullability relationship during construction. The executor uses the
attached schema to name fields and construct a typed null, but does not re-prove assignment safety.

| Plan-executor concern | Broad plan expressions | Resolved plan expressions |
|---|---|---|
| Column type and effective nullability | Infer from every input schema | Read from `PlanColumn` |
| Composite result type | Infer and reconcile with a separate target | Read from `PlanExpression` |
| Malformed `COALESCE` or struct | Detect during translation | Rejected during Kernel plan construction |
| Unsupported broad variants | Match and reject at execution time | Cannot enter a mandatory plan |
| Native attributes, functions, and runtime semantics | Executor responsibility | Executor responsibility |

The result is not less semantic rigor. It places that rigor at one boundary: Kernel binds and
validates the portable plan once, while each executor focuses on exhaustive native lowering and
the specified runtime behavior.

### Expression classes and ownership

| Class | Producer and consumer | Contract |
|---|---|---|
| `Expression` / `Predicate` | Connectors or Kernel -> scans, `EvaluationHandler`, optional analysis | Broad, unresolved source language. Examples include `x / 2 > 50`, casts, and opaque engine operations. |
| `PlanExpression` / `PlanPredicate` | `PlanBuilder` -> `PlanExecutor` | Closed, resolved language. Every executor must implement every variant. |
| `DataSkippingSite` | Kernel -> executor optimizer | Optional, conservative pruning opportunity. Ignoring it preserves plan results. |

The mandatory expression inventory is limited to resolved columns, typed literals,
predicate-as-expression, structs, struct patches, same-type `COALESCE`, `ParseJson`, and
`MapToStruct`. Predicates contain Boolean expressions, null tests, `NOT`, exact-type comparisons,
`IS DISTINCT FROM`, `AND`, and `OR`.

Arithmetic, casts, arrays, `IN`, opaque callbacks, and unknown nodes cannot enter a mandatory
`Project` or `Filter`.

### Architecture

```text
Broad Expression / Predicate
             |
             | PlanBuilder resolves against the input schema
             v
  PlanExpression / PlanPredicate
  - closed node kind
  - exact output type
  - effective nullability
  - resolved column metadata
             |
             v
     protobuf / PlanExecutor
```

`PlanBuilder::project` and `PlanBuilder::filter` continue accepting the broad public types for
ergonomic construction, but immediately resolve them into the closed plan types. Resolution checks
column paths, exact operand types, Boolean filters, struct shape, project assignment, and nested
nullability. There is no implicit numeric or common-type coercion at this boundary.

The resulting `PlanExpressionKind` and `PlanPredicateKind` are exhaustive borrowed views. An
executor translates these resolved nodes instead of re-analyzing arbitrary source trees. Kernel
therefore owns plan validity; the executor owns compilation into its native representation and
execution.

Plan safety is broader than expressions. `Plan::try_new` validates topological ordering, input
arity, propagated schemas, literal rows, scan constants, projects, filters, dynamic scans,
aggregates, joins, and unions. `Plan`, `PlanNode`, `Project`, and `Filter` hide writable fields and
expose validated constructors and read-only accessors. Serialization revalidates the plan as
defense in depth.

The protobuf schema mirrors the resolved plan dialect. Broad expressions remain serializable only
where they are explicitly analysis input, and `Cast` is now represented losslessly there.

### Data skipping remains extensible

Data skipping has a different correctness contract from replay: it may remove a file only after
proving that no row in the file can satisfy the source predicate. Missing, malformed, or
inconclusive statistics must keep the file.

Kernel inserts a `DataSkippingSite` only at a safe location with a source predicate and usable
statistics or partition-value metadata. The site contains:

- the original broad row predicate and its source schema;
- resolved locations of statistics and exact partition values;
- an `AddsOnly` or `MixedActions` target describing which rows may be pruned; and
- an optional resolved Kernel keep predicate.

The node is semantically an identity operation. An executor may apply Kernel's portable keep
predicate, derive a sound native filter from the broad predicate and metadata description, or pass
every row through. Mixed-action sites protect every non-Add row automatically.

For `x > 100`, Kernel can provide a portable predicate based on `maxValues.x`, with SQL
three-valued logic retaining unknown results. For `x / 2 > 50`, Kernel may perform a sound,
type-aware rewrite into the portable core or provide no portable predicate. An executor with sound
range analysis for division may still derive a native filter; another executor keeps all candidate
files. `Divide` therefore remains available for optional optimization without becoming mandatory
replay syntax.

ANSI semantics still govern operations that are in the closed dialect, including three-valued
Boolean logic and `IS DISTINCT FROM`. This architectural split does not require generalized ANSI
coercion, arithmetic, or cast support. The mandatory dialect should expand only when a concrete
Kernel feature emits a new operation and its type rules, wire representation, executor support,
and conformance tests land together.

### This PR affects the following public APIs

- Adds resolved `PlanColumn`, `PlanExpression`, `PlanPredicate`, and exhaustive kind views.
- Makes `Plan`, `PlanNode`, `Project`, and `Filter` fields private and adds validated construction
  and accessors.
- Makes plan-building transforms fallible when their expression or schema contract is invalid.
- Adds `DataSkippingSite`, `DataSkippingStats`, and `DataSkippingTarget`.
- Makes `Operation::to_proto_bytes` fallible so invalid plans cannot emit bytes.
- Changes plan protobuf nodes to carry the resolved dialect instead of broad executable trees.

## How was this change tested?

- Kernel all-feature suite: 4,843 passed, 38 ignored
- DataFusion executor suite: 248 passed
- Kernel and DataFusion clippy checks
- FFI compilation, nightly formatting, and diff checks
