### PR TITLE
test: remove racy allocator assertion

### DIFF
--- a/ffi/src/alloc_stats.rs
+++ b/ffi/src/alloc_stats.rs
@@ -116,6 +116,5 @@ mod global_allocator_tests {
         drop(buf);
         let previous_peak = reset_peak_native_bytes();
         assert!(previous_peak >= during);
-        assert!(peak_native_bytes() >= current_native_bytes());
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove the final post-reset `peak >= current` assertion from the allocation-tracking test.

The coverage job runs the FFI unit tests concurrently in one process, so unrelated tests update the process-wide allocator counters while this test runs. `peak_alloc` updates current and peak usage with separate relaxed atomic operations, and resetting the peak separately samples current usage before storing it. A concurrent allocation can therefore leave the reported peak below current usage, which is also documented by `reset_peak_native_bytes`.

The remaining assertions still verify that the installed allocator tracks the large allocation and that resetting returns the observed peak.

## How was this change tested?

- `cargo test -p delta_kernel_ffi --lib --all-features alloc_stats::global_allocator_tests::installed_global_allocator_accounts_a_large_allocation -- --exact`