### PR TITLE
ci: prototype inline AI review comments

### DIFF
--- a/.github/omnigent/inline_review.py
+++ b/.github/omnigent/inline_review.py
@@ -1,0 +1,275 @@
+"""Build a SHA-bound GitHub review payload from validated AI findings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from review_publish import format_review_body as _format_review_body
+
+
+MAX_INLINE_FINDINGS = 12
+INLINE_FINDING_FIELDS = ("id", "path", "line", "side", "body")
+INLINE_FINDING_SIDES = ("LEFT", "RIGHT")
+_FINDING_ID = re.compile(r"[BN][1-9][0-9]*")
+_HUNK_HEADER = re.compile(
+    r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@"
+)
+
+
+def extract_inline_findings(
+    review: str, marker: str
+) -> tuple[str, list[dict[str, Any]]]:
+    """Remove and decode the per-run inline-finding block from a review."""
+    start, end = _inline_markers(marker)
+    if review.count(start) != 1 or review.count(end) != 1:
+        raise ValueError("inline review output must contain one location block")
+
+    start_index = review.index(start)
+    payload_start = start_index + len(start)
+    end_index = review.index(end, payload_start)
+    document = json.loads(review[payload_start:end_index].strip())
+    if not isinstance(document, dict) or set(document) != {"findings"}:
+        raise ValueError("inline review document must contain only 'findings'")
+    findings = document["findings"]
+    if not isinstance(findings, list):
+        raise ValueError("inline review findings must be a list")
+    if len(findings) > MAX_INLINE_FINDINGS:
+        raise ValueError(
+            f"inline review contains more than {MAX_INLINE_FINDINGS} findings"
+        )
+
+    clean_review = (review[:start_index] + review[end_index + len(end) :]).strip()
+    if not clean_review:
+        raise ValueError("inline review has no human-readable content")
+    return clean_review, findings
+
+
+def inline_prompt_instructions(marker: str) -> str:
+    """Build the prompt contract for machine-readable inline findings."""
+    start, end = _inline_markers(marker)
+    example = json.dumps(
+        {
+            "findings": [
+                dict(
+                    zip(
+                        INLINE_FINDING_FIELDS,
+                        (
+                            "N1",
+                            "kernel/src/file.rs",
+                            10,
+                            "RIGHT",
+                            (
+                                "Complete, concise finding with failure mode, "
+                                "reviewer attribution, and suggested fix."
+                            ),
+                        ),
+                        strict=True,
+                    )
+                )
+            ]
+        },
+        separators=(",", ":"),
+    )
+    return f"""
+
+This review will also be published as GitHub inline comments. After the
+human-readable review and before the final end marker, emit this exact
+machine-readable block:
+
+{start}
+{example}
+{end}
+
+Include entries for up to {MAX_INLINE_FINDINGS} B/N findings, prioritizing
+blockers and then the most useful notes. Findings omitted from this block remain
+in the collapsed review. Use IDs matching `{_FINDING_ID.pattern}` (for example,
+`B1` or `N1`) and do not add an entry for the Summary. Use the repository-relative
+path with no backticks. Use {INLINE_FINDING_SIDES[1]} and the head-file line
+number for additions or context; use {INLINE_FINDING_SIDES[0]} and the base-file
+line number only for deleted lines. The location must occur in the supplied
+unified diff. Use an empty findings list when there are no findings. Do not wrap
+the JSON in a Markdown code fence.
+"""
+
+
+def diff_positions(diff: str) -> set[tuple[str, int, str]]:
+    """Return GitHub-reviewable ``(path, line, side)`` positions from a diff."""
+    positions: set[tuple[str, int, str]] = set()
+    old_path: str | None = None
+    new_path: str | None = None
+    old_line: int | None = None
+    new_line: int | None = None
+    in_hunk = False
+
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("diff --git "):
+            old_path = None
+            new_path = None
+            old_line = None
+            new_line = None
+            in_hunk = False
+            continue
+        if not in_hunk and raw_line.startswith("--- "):
+            old_path = _diff_path(raw_line[4:])
+            continue
+        if not in_hunk and raw_line.startswith("+++ "):
+            new_path = _diff_path(raw_line[4:])
+            continue
+
+        hunk = _HUNK_HEADER.match(raw_line)
+        if hunk:
+            old_line = int(hunk.group(1))
+            new_line = int(hunk.group(3))
+            in_hunk = True
+            continue
+        if old_line is None or new_line is None:
+            continue
+        if raw_line.startswith("\\ No newline at end of file"):
+            continue
+
+        review_path = new_path or old_path
+        if review_path is None:
+            continue
+        if raw_line.startswith("+"):
+            positions.add((review_path, new_line, "RIGHT"))
+            new_line += 1
+        elif raw_line.startswith("-"):
+            positions.add((review_path, old_line, "LEFT"))
+            old_line += 1
+        else:
+            positions.add((review_path, new_line, "RIGHT"))
+            old_line += 1
+            new_line += 1
+
+    return positions
+
+
+def build_review_payload(
+    *,
+    review: str,
+    findings: list[dict[str, Any]],
+    diff: str,
+    head_sha: str,
+    run_url: str,
+) -> tuple[dict[str, Any], list[str]]:
+    """Build a non-blocking review and return labels for findings not attached."""
+    if re.fullmatch(r"[0-9a-f]{40}", head_sha) is None:
+        raise ValueError("head SHA must be a 40-character lowercase hex value")
+
+    allowed_positions = diff_positions(diff)
+    comments: list[dict[str, Any]] = []
+    unmapped: list[str] = []
+    seen_ids: set[str] = set()
+
+    for index, finding in enumerate(findings, start=1):
+        try:
+            finding_id, path, line, side, body = _validate_finding(finding)
+        except ValueError:
+            unmapped.append(f"entry {index}")
+            continue
+        if finding_id in seen_ids:
+            unmapped.append(finding_id)
+            continue
+        seen_ids.add(finding_id)
+
+        if (path, line, side) not in allowed_positions:
+            unmapped.append(finding_id)
+            continue
+        comments.append(
+            {
+                "path": path,
+                "line": line,
+                "side": side,
+                "body": f"**{finding_id}** {body}",
+            }
+        )
+
+    return (
+        {
+            "body": _format_review_body(review, run_url, collapsed=True),
+            "commit_id": head_sha,
+            "event": "COMMENT",
+            "comments": comments,
+        },
+        unmapped,
+    )
+
+
+def _diff_path(value: str) -> str | None:
+    value = value.split("\t", 1)[0]
+    if value == "/dev/null":
+        return None
+    if value.startswith(("a/", "b/")):
+        value = value[2:]
+    return value
+
+
+def _inline_markers(marker: str) -> tuple[str, str]:
+    return (
+        f"<!-- AI_REVIEW_INLINE_START_{marker} -->",
+        f"<!-- AI_REVIEW_INLINE_END_{marker} -->",
+    )
+
+
+def _validate_finding(finding: Any) -> tuple[str, str, int, str, str]:
+    expected = set(INLINE_FINDING_FIELDS)
+    if not isinstance(finding, dict) or set(finding) != expected:
+        fields = ", ".join(INLINE_FINDING_FIELDS)
+        raise ValueError(f"each inline finding must contain exactly: {fields}")
+
+    finding_id = finding["id"]
+    path = finding["path"]
+    line = finding["line"]
+    side = finding["side"]
+    body = finding["body"]
+    if not isinstance(finding_id, str) or _FINDING_ID.fullmatch(finding_id) is None:
+        raise ValueError("inline finding ID must match B1 or N1 form")
+    if (
+        not isinstance(path, str)
+        or not path
+        or len(path) > 500
+        or path.startswith("/")
+        or "\x00" in path
+        or ".." in Path(path).parts
+    ):
+        raise ValueError(f"inline finding {finding_id} has an invalid path")
+    if isinstance(line, bool) or not isinstance(line, int) or line < 1:
+        raise ValueError(f"inline finding {finding_id} has an invalid line")
+    if side not in INLINE_FINDING_SIDES:
+        raise ValueError(f"inline finding {finding_id} has an invalid side")
+    if not isinstance(body, str) or not body.strip() or len(body) > 10_000:
+        raise ValueError(f"inline finding {finding_id} has an invalid body")
+    if any(ord(char) < 32 and char not in "\n\t" for char in body):
+        raise ValueError(f"inline finding {finding_id} has control characters")
+    return finding_id, path, line, side, body.strip()
+
+
+def main() -> None:
+    """Build a GitHub review request from workflow-owned files."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--review", required=True, type=Path)
+    parser.add_argument("--findings", required=True, type=Path)
+    parser.add_argument("--diff", required=True, type=Path)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--unmapped-output", required=True, type=Path)
+    args = parser.parse_args()
+
+    payload, unmapped = build_review_payload(
+        review=args.review.read_text(),
+        findings=json.loads(args.findings.read_text()),
+        diff=args.diff.read_text(errors="replace"),
+        head_sha=args.head_sha,
+        run_url=args.run_url,
+    )
+    args.output.write_text(json.dumps(payload))
+    args.unmapped_output.write_text("\n".join(unmapped) + ("\n" if unmapped else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/omnigent/review_publish.py
+++ b/.github/omnigent/review_publish.py
@@ -1,0 +1,18 @@
+"""Format validated AI review text for GitHub publication."""
+
+
+def format_review_body(review: str, run_url: str, *, collapsed: bool) -> str:
+    """Add the shared header and footer to a publishable review."""
+    if not run_url.startswith("https://github.com/"):
+        raise ValueError("run URL must be a GitHub HTTPS URL")
+
+    body = review.strip()
+    if collapsed:
+        body = f"<details><summary>Show review</summary>\n\n{body}\n\n</details>"
+    return (
+        "<!-- ai-review-bot -->\n"
+        "## AI Review <sub>(draft - human review required)</sub>\n\n"
+        f"{body}\n\n"
+        "---\n"
+        f"<sub>Automated review - [workflow run]({run_url})</sub>"
+    )

--- a/.github/omnigent/reviewer/REVIEW.md
+++ b/.github/omnigent/reviewer/REVIEW.md
@@ -87,6 +87,13 @@ Each finding must include:
 - `Suggested fix:` with a concrete change. Include a short code snippet when
   it makes the fix clearer; omit snippets for trivial one-line fixes.
 
+When the invocation prompt requests inline output, append the exact
+machine-readable block it specifies after the human-readable review and before
+the final per-run marker. Select findings according to the invocation's cap and
+priority order, using locations from the supplied unified diff. Findings not
+selected for inline publication remain in the collapsed review. The workflow
+validates this data and removes it before publication.
+
 ## Final writing pass
 Before returning the final comment, do one human-style polish pass over the
 consolidated review. This pass may rewrite wording only; it must not add,
@@ -121,8 +128,9 @@ Failure code: dispatch_failed|reviewer_failed|disprove_failed|timeout|other
 Failed agents: comma-separated agent names, or none
 Do not downgrade a finding to bypass a failed gate.
 
-Your output is posted verbatim as a PR comment. Output ONLY the final
-consolidated review -- no narration and no status updates. Include reviewer
-attribution on findings as required above. Begin and end your response with
-the exact per-run markers supplied in the invocation prompt. Put each marker
-on its own line. Nothing outside those markers will be shown.
+The human-readable part of your output is published verbatim. Output ONLY the
+final consolidated review and any requested machine-readable block -- no
+narration and no status updates. Include reviewer attribution on findings as
+required above. Begin and end your response with the exact per-run markers
+supplied in the invocation prompt. Put each marker on its own line. Nothing
+outside those markers will be shown.

--- a/.github/omnigent/tests/test_inline_review.py
+++ b/.github/omnigent/tests/test_inline_review.py
@@ -1,0 +1,310 @@
+"""Tests for SHA-bound inline GitHub review publication."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+def _load_module(name):
+    module_dir = Path(__file__).parents[1]
+    path = module_dir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(module_dir))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+DIFF = """\
+diff --git a/kernel/src/example.rs b/kernel/src/example.rs
+index 1111111..2222222 100644
+--- a/kernel/src/example.rs
++++ b/kernel/src/example.rs
+@@ -8,5 +8,6 @@ fn example() {
+ unchanged();
+-old_call();
++new_call();
++added_call();
+--- old heading;
++++ new heading;
+ trailing();
+"""
+
+FILE_LIFECYCLE_DIFF = """\
+diff --git a/kernel/src/new.rs b/kernel/src/new.rs
+new file mode 100644
+--- /dev/null
++++ b/kernel/src/new.rs
+@@ -0,0 +1 @@
++new line
+\\ No newline at end of file
+diff --git a/kernel/src/old.rs b/kernel/src/old.rs
+deleted file mode 100644
+--- a/kernel/src/old.rs
++++ /dev/null
+@@ -1 +0,0 @@
+-old line
+\\ No newline at end of file
+"""
+
+
+class InlineReviewTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.inline_review = _load_module("inline_review")
+        self.review_publish = _load_module("review_publish")
+
+    def test_extract_inline_findings_removes_machine_block(self) -> None:
+        marker = "a" * 32
+        review, findings = self.inline_review.extract_inline_findings(
+            "Summary\n"
+            f"<!-- AI_REVIEW_INLINE_START_{marker} -->\n"
+            '{"findings":[{"id":"N1"}]}\n'
+            f"<!-- AI_REVIEW_INLINE_END_{marker} -->",
+            marker,
+        )
+
+        self.assertEqual(review, "Summary")
+        self.assertEqual(findings, [{"id": "N1"}])
+
+    def test_inline_prompt_uses_parser_contract(self) -> None:
+        marker = "a" * 32
+        prompt = self.inline_review.inline_prompt_instructions(marker)
+
+        self.assertIn(f"AI_REVIEW_INLINE_START_{marker}", prompt)
+        self.assertIn(f"up to {self.inline_review.MAX_INLINE_FINDINGS}", prompt)
+        for field in self.inline_review.INLINE_FINDING_FIELDS:
+            self.assertIn(f'"{field}"', prompt)
+        self.assertIn(self.inline_review._FINDING_ID.pattern, prompt)
+        for side in self.inline_review.INLINE_FINDING_SIDES:
+            self.assertIn(side, prompt)
+
+    def test_diff_positions_tracks_both_sides_and_context(self) -> None:
+        self.assertEqual(
+            self.inline_review.diff_positions(DIFF),
+            {
+                ("kernel/src/example.rs", 8, "RIGHT"),
+                ("kernel/src/example.rs", 9, "LEFT"),
+                ("kernel/src/example.rs", 9, "RIGHT"),
+                ("kernel/src/example.rs", 10, "LEFT"),
+                ("kernel/src/example.rs", 10, "RIGHT"),
+                ("kernel/src/example.rs", 11, "RIGHT"),
+                ("kernel/src/example.rs", 12, "RIGHT"),
+            },
+        )
+
+    def test_diff_positions_handles_added_deleted_and_no_newline_files(self) -> None:
+        self.assertEqual(
+            self.inline_review.diff_positions(FILE_LIFECYCLE_DIFF),
+            {
+                ("kernel/src/new.rs", 1, "RIGHT"),
+                ("kernel/src/old.rs", 1, "LEFT"),
+            },
+        )
+
+    def test_build_payload_keeps_only_locations_in_diff(self) -> None:
+        payload, unmapped = self.inline_review.build_review_payload(
+            review="### N1: use the new call",
+            findings=[
+                {
+                    "id": "N1",
+                    "path": "kernel/src/example.rs",
+                    "line": 10,
+                    "side": "RIGHT",
+                    "body": "This is attached to the added line.",
+                },
+                {
+                    "id": "N2",
+                    "path": "kernel/src/example.rs",
+                    "line": 100,
+                    "side": "RIGHT",
+                    "body": "This remains in the full review only.",
+                },
+            ],
+            diff=DIFF,
+            head_sha="b" * 40,
+            run_url="https://github.com/delta-io/delta-kernel-rs/actions/runs/1",
+        )
+
+        self.assertEqual(payload["event"], "COMMENT")
+        self.assertEqual(payload["commit_id"], "b" * 40)
+        self.assertEqual(
+            payload["comments"],
+            [
+                {
+                    "path": "kernel/src/example.rs",
+                    "line": 10,
+                    "side": "RIGHT",
+                    "body": "**N1** This is attached to the added line.",
+                }
+            ],
+        )
+        self.assertIn("<details><summary>Show review</summary>", payload["body"])
+        self.assertTrue(payload["body"].startswith("<!-- ai-review-bot -->"))
+        self.assertEqual(unmapped, ["N2"])
+
+    def test_build_payload_accepts_multiline_finding_body(self) -> None:
+        payload, unmapped = self.inline_review.build_review_payload(
+            review="review",
+            findings=[
+                {
+                    "id": "N1",
+                    "path": "kernel/src/example.rs",
+                    "line": 10,
+                    "side": "RIGHT",
+                    "body": "First line.\n\tIndented detail.",
+                }
+            ],
+            diff=DIFF,
+            head_sha="b" * 40,
+            run_url="https://github.com/delta-io/delta-kernel-rs/actions/runs/1",
+        )
+
+        self.assertEqual(len(payload["comments"]), 1)
+        self.assertEqual(unmapped, [])
+
+    def test_format_review_body_supports_expanded_comments(self) -> None:
+        body = self.review_publish.format_review_body(
+            "Review",
+            "https://github.com/delta-io/delta-kernel-rs/actions/runs/1",
+            collapsed=False,
+        )
+
+        self.assertNotIn("<details>", body)
+        self.assertIn("\nReview\n", body)
+
+    def test_build_payload_skips_duplicate_ids(self) -> None:
+        finding = {
+            "id": "B1",
+            "path": "kernel/src/example.rs",
+            "line": 9,
+            "side": "RIGHT",
+            "body": "Duplicate.",
+        }
+
+        payload, unmapped = self.inline_review.build_review_payload(
+            review="review",
+            findings=[finding, finding],
+            diff=DIFF,
+            head_sha="c" * 40,
+            run_url="https://github.com/delta-io/delta-kernel-rs/actions/runs/1",
+        )
+
+        self.assertEqual(len(payload["comments"]), 1)
+        self.assertEqual(unmapped, ["B1"])
+
+    def test_build_payload_skips_untrusted_finding_fields(self) -> None:
+        valid = {
+            "id": "N1",
+            "path": "kernel/src/example.rs",
+            "line": 10,
+            "side": "RIGHT",
+            "body": "Finding.",
+        }
+        invalid_updates = (
+            {"id": "other"},
+            {"id": 1},
+            {"path": ""},
+            {"path": "a" * 501},
+            {"path": "/etc/passwd"},
+            {"path": "bad\x00path"},
+            {"path": "../example.rs"},
+            {"line": True},
+            {"line": "10"},
+            {"line": 0},
+            {"side": "BOTH"},
+            {"body": ""},
+            {"body": 1},
+            {"body": "a" * 10_001},
+            {"body": "bad\x00body"},
+        )
+
+        for update in invalid_updates:
+            with self.subTest(update=update):
+                payload, unmapped = self.inline_review.build_review_payload(
+                    review="review",
+                    findings=[valid | update, valid],
+                    diff=DIFF,
+                    head_sha="d" * 40,
+                    run_url="https://github.com/delta-io/delta-kernel-rs/actions/runs/1",
+                )
+                self.assertEqual(len(payload["comments"]), 1)
+                self.assertEqual(unmapped, ["entry 1"])
+
+        invalid_findings = (None, {}, valid | {"extra": "field"})
+        for finding in invalid_findings:
+            with self.subTest(finding=finding):
+                payload, unmapped = self.inline_review.build_review_payload(
+                    review="review",
+                    findings=[finding, valid],
+                    diff=DIFF,
+                    head_sha="d" * 40,
+                    run_url="https://github.com/delta-io/delta-kernel-rs/actions/runs/1",
+                )
+                self.assertEqual(len(payload["comments"]), 1)
+                self.assertEqual(unmapped, ["entry 1"])
+
+    def test_build_payload_rejects_untrusted_metadata(self) -> None:
+        finding = {
+            "id": "N1",
+            "path": "kernel/src/example.rs",
+            "line": 10,
+            "side": "RIGHT",
+            "body": "Finding.",
+        }
+        invalid_metadata = (
+            {"head_sha": "ABC"},
+            {"run_url": "http://github.com/actions/runs/1"},
+            {"run_url": "https://example.com/actions/runs/1"},
+        )
+
+        for update in invalid_metadata:
+            arguments = {
+                "review": "review",
+                "findings": [finding],
+                "diff": DIFF,
+                "head_sha": "d" * 40,
+                "run_url": "https://github.com/delta-io/delta-kernel-rs/actions/runs/1",
+            }
+            with self.subTest(update=update), self.assertRaises(ValueError):
+                self.inline_review.build_review_payload(**(arguments | update))
+
+    def test_extract_inline_findings_rejects_invalid_envelopes(self) -> None:
+        marker = "e" * 32
+        start = f"<!-- AI_REVIEW_INLINE_START_{marker} -->"
+        end = f"<!-- AI_REVIEW_INLINE_END_{marker} -->"
+        invalid_reviews = (
+            "Review",
+            f"Review\n{start}\nnot-json\n{end}",
+            f'Review\n{start}\n{{"findings":[],"extra":true}}\n{end}',
+            f'Review\n{start}\n{{"findings":{{}}}}\n{end}',
+            f"{start}\n{{\"findings\":[]}}\n{end}",
+        )
+
+        for review in invalid_reviews:
+            with self.subTest(review=review), self.assertRaises(ValueError):
+                self.inline_review.extract_inline_findings(review, marker)
+
+    def test_extract_inline_findings_enforces_cap(self) -> None:
+        marker = "e" * 32
+        document = {"findings": [{"id": f"N{index}"} for index in range(1, 14)]}
+        review = (
+            "Review\n"
+            f"<!-- AI_REVIEW_INLINE_START_{marker} -->\n"
+            f"{json.dumps(document)}\n"
+            f"<!-- AI_REVIEW_INLINE_END_{marker} -->"
+        )
+
+        with self.assertRaisesRegex(ValueError, "more than"):
+            self.inline_review.extract_inline_findings(review, marker)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,18 +1,17 @@
 # =============================================================================
 # AI PR Review - Omnigent-powered reviewer for GitHub PRs.
 #
-# Setup (Settings -> Environments -> ai-review), as ENVIRONMENT secrets:
+# Setup as repository secrets:
 #   LLM_API_KEY       Bearer token for the LLM gateway.
 #   GATEWAY_BASE_URL  Gateway base URL, e.g. https://<host>/serving-endpoints
-# Required variable:
+# Required repository variables:
 #   GATEWAY_HOST      Bare hostname of GATEWAY_BASE_URL, for the egress allowlist.
-# Optional named-bot comments:
-#   vars.OMNIGENT_BOT_APP_ID + secrets.OMNIGENT_BOT_APP_KEY
-# Required environment variables:
 #   MODEL                    Default Claude model.
 #   CLAUDE_MAINTAINER_MODEL  Claude maintainer-pass model.
 #   CODEX_MAINTAINER_MODEL   Codex maintainer-pass model.
 #   DISPROVE_MODEL           GPT disprove-gate model.
+# Optional named-bot comments:
+#   vars.OMNIGENT_BOT_APP_ID + secrets.OMNIGENT_BOT_APP_KEY
 #
 # Ready PRs from authors with write-or-higher permission are reviewed
 # automatically and published to the workflow summary and a non-blocking PR
@@ -41,14 +40,17 @@ on:
           - artifact
           - summary
           - collapsed
+          - inline
           - comment
 
 permissions:
   contents: read
 
 concurrency:
+  # Keep comments isolated until the authorize job has parsed and approved a command.
   group: >-
     ai-review-${{
+      github.event_name == 'issue_comment' && github.run_id ||
       github.event.pull_request.number ||
       github.event.issue.number ||
       inputs.pr
@@ -125,9 +127,10 @@ jobs:
                   artifact|dark) mode=artifact ;;
                   summary) mode=summary ;;
                   collapsed) mode=collapsed ;;
+                  inline) mode=inline ;;
                   comment) mode=comment ;;
                   *)
-                    echo "::error::Unknown /review option '$word'. Use artifact, summary, collapsed, or comment."
+                    echo "::error::Unknown /review option '$word'. Use artifact, summary, collapsed, inline, or comment."
                     exit 1
                     ;;
                 esac
@@ -153,7 +156,7 @@ jobs:
             exit 1
           fi
           case "$mode" in
-            artifact|summary|collapsed|comment) ;;
+            artifact|summary|collapsed|inline|comment) ;;
             *) echo "::error::Invalid output mode '$mode'."; exit 1 ;;
           esac
 
@@ -204,6 +207,9 @@ jobs:
     if: >-
       needs.authorize.outputs.skip != 'true' &&
       needs.authorize.outputs.allowed == 'true'
+    concurrency:
+      group: ai-review-job-${{ needs.authorize.outputs.pr_number }}
+      cancel-in-progress: true
     permissions:
       checks: write
       contents: read
@@ -423,6 +429,9 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/.github/omnigent
         run: |
           set -euo pipefail
+          python3 -m unittest discover \
+            --start-directory .github/omnigent/tests \
+            --pattern test_inline_review.py
           python3 - <<'PYEOF'
           import json
           import os
@@ -708,6 +717,7 @@ jobs:
         id: context
         env:
           GH_TOKEN: ${{ github.token }}
+          OUTPUT_MODE: ${{ needs.authorize.outputs.output_mode }}
           PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
@@ -746,12 +756,20 @@ jobs:
           import json
           import os
           import pathlib
+          import sys
+
+          sys.path.insert(0, ".github/omnigent")
+          from inline_review import inline_prompt_instructions
 
           max_diff_bytes = 80_000
           max_prompt_bytes = 100_000
+          output_mode = os.environ["OUTPUT_MODE"]
           review_marker = os.environ["REVIEW_MARKER"]
           start_marker = f"<!-- AI_REVIEW_START_{review_marker} -->"
           end_marker = f"<!-- AI_REVIEW_END_{review_marker} -->"
+          inline_instructions = ""
+          if output_mode == "inline":
+              inline_instructions = inline_prompt_instructions(review_marker)
           meta = json.loads(pathlib.Path("/tmp/pr_meta.json").read_text())
           body = (meta.get("body") or "")[:4096]
           diff_bytes = pathlib.Path("/tmp/pr_diff.txt").read_bytes()
@@ -821,7 +839,7 @@ jobs:
           destination. Output ONLY the final consolidated review, with no
           narration or status updates. Begin your response with the exact marker
           {start_marker} on its own line, then the review. End with the exact
-          marker {end_marker} on its own line.
+          marker {end_marker} on its own line.{inline_instructions}
 
           Emit those markers only if every dispatched reviewer completed
           successfully and every required disprove gate returned a verdict. If
@@ -935,6 +953,7 @@ jobs:
           steps.run_review.outcome == 'success'
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          OUTPUT_MODE: ${{ needs.authorize.outputs.output_mode }}
           REVIEW_MARKER: ${{ steps.context.outputs.review_marker }}
           REVIEW_STATUS: ${{ steps.run_review.outputs.review_status }}
         run: |
@@ -1012,10 +1031,14 @@ jobs:
           fi
 
           python3 - <<'PYEOF'
+          import json
           import os
           import pathlib
           import re
           import sys
+
+          sys.path.insert(0, ".github/omnigent")
+          from inline_review import extract_inline_findings
 
           raw = pathlib.Path("/tmp/review_raw_output.txt").read_text(errors="replace")
           marker = os.environ.get("REVIEW_MARKER", "")
@@ -1084,6 +1107,16 @@ jobs:
               print("::error::AI review contains unsupported control characters.")
               sys.exit(1)
 
+          if os.environ.get("OUTPUT_MODE") == "inline":
+              try:
+                  body, findings = extract_inline_findings(body, marker)
+              except ValueError as error:
+                  print(f"::error::AI inline review metadata is invalid: {error}.")
+                  sys.exit(1)
+              pathlib.Path("/tmp/inline_findings.json").write_text(
+                  json.dumps(findings)
+              )
+
           pathlib.Path("/tmp/review_output.txt").write_text(body + "\n")
           PYEOF
 
@@ -1119,30 +1152,61 @@ jobs:
           OUTPUT_MODE: ${{ needs.authorize.outputs.output_mode }}
           PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
           REPO: ${{ github.repository }}
-          REVIEW_TEXT: ${{ steps.review.outputs.review_text }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
           set -euo pipefail
-          {
-            echo "<!-- ai-review-bot -->"
-            echo "## AI Review <sub>(draft - human review required)</sub>"
-            echo ""
-            if [ "$OUTPUT_MODE" = "collapsed" ]; then
-              echo "<details><summary>Show review</summary>"
-              echo ""
-            fi
-            echo "$REVIEW_TEXT"
-            if [ "$OUTPUT_MODE" = "collapsed" ]; then
-              echo ""
-              echo "</details>"
-            fi
-            echo ""
-            echo "---"
-            echo "<sub>Automated review - [workflow run](${RUN_URL})</sub>"
-          } > /tmp/comment.md
+          python3 - <<'PYEOF'
+          import os
+          import pathlib
+          import sys
+
+          sys.path.insert(0, ".github/omnigent")
+          from review_publish import format_review_body
+
+          review = pathlib.Path("/tmp/review_output.txt").read_text()
+          body = format_review_body(
+              review,
+              os.environ["RUN_URL"],
+              collapsed=os.environ["OUTPUT_MODE"] == "collapsed",
+          )
+          pathlib.Path("/tmp/comment.md").write_text(body + "\n")
+          PYEOF
 
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
           echo "Posted review comment."
+
+      - name: Post inline review
+        if: >-
+          steps.review.outputs.review_text != '' &&
+          needs.authorize.outputs.output_mode == 'inline'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -euo pipefail
+          python3 .github/omnigent/inline_review.py \
+            --review /tmp/review_output.txt \
+            --findings /tmp/inline_findings.json \
+            --diff /tmp/pr_diff.txt \
+            --head-sha "$HEAD_SHA" \
+            --run-url "$RUN_URL" \
+            --output /tmp/inline-review.json \
+            --unmapped-output /tmp/unmapped-findings.txt
+
+          mapped_count="$(jq '.comments | length' /tmp/inline-review.json)"
+          unmapped_count="$(wc -l < /tmp/unmapped-findings.txt | tr -d ' ')"
+          if ! gh api --method POST "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --input /tmp/inline-review.json --silent; then
+            echo "::warning::GitHub rejected the inline review; posting the collapsed review without inline comments."
+            jq -r '.body' /tmp/inline-review.json > /tmp/comment.md
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+            exit 0
+          fi
+          printf 'Posted %s inline finding(s); %s remained in the collapsed review.\n' \
+            "$mapped_count" "$unmapped_count"
 
       - name: Publish review summary
         if: >-


### PR DESCRIPTION
## What changes are proposed in this pull request?

1. Prototype a manual `/review inline` mode. It submits one non-blocking GitHub `COMMENT` review, attaches up to 12 high-priority findings to exact lines in the SHA-pinned diff, and keeps the full review in a collapsed top-level body. Unmappable or malformed inline findings are skipped without losing the validated collapsed review. If GitHub rejects the atomic inline request, the workflow falls back to a plain collapsed comment.

This is experimental and intended to validate the review UI on a maintainer-owned PR before considering broader use. It does not change Rust code or binary dependencies.

## How was this change tested?

- Added 12 unit tests covering prompt/parser consistency, partial publication with invalid findings, multiline finding text, location-block extraction, the 12-finding cap, unified-diff mapping including added/deleted files and no-newline markers, framing, SHA-bound payloads, and invalid model-produced metadata.
- Posted a synthetic `COMMENT` review on this PR and confirmed GitHub attached N1 to the expected file, line, side, and head SHA.
- Parsed the workflow as YAML, compiled the Python files, and ran `git diff --check`.
- Passed the repository pre-commit hook: rustfmt, Clippy, 4,032 unit tests, 69 doc tests, and coverage.