### PR TITLE
feat: add option to skip checkpoints during incremental snapshot updates

### DIFF
--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -30,6 +30,10 @@ Built via `Snapshot::builder_for(url).build(engine)` (latest version) or
 `.at_version(v).build(engine)` (specific version). For catalog-managed tables,
 `.with_log_tail(commits)` supplies recent unpublished commits from the catalog and
 `.with_max_catalog_version(v)` caps the snapshot at the latest catalog-ratified version.
+`Snapshot::builder_from(snapshot)` returns an `IncrementalSnapshotBuilder` that reuses the input
+snapshot. Its opt-in `skip_new_checkpoints()` mode keeps the input checkpoint and every commit in
+the update window so a snapshot-derived `CommitRange` can inspect them without another log
+listing.
 
 **Snapshot loading internals:**
 1. **LogSegment** (`kernel/src/log_segment/`): discovers commits + checkpoints for the
@@ -128,7 +132,8 @@ all returned batches: the engine may split a single file across multiple batches
 
 ## Key Modules
 
-- `kernel/src/snapshot/`: `Snapshot`, `SnapshotBuilder`, entry point for reads/writes
+- `kernel/src/snapshot/`: `Snapshot`, `SnapshotBuilder`, `IncrementalSnapshotBuilder`, entry point
+  for reads/writes
 - `kernel/src/scan/`: `Scan`, `ScanBuilder`, log replay, data skipping
 - `kernel/src/incremental_scan/`: `IncrementalScanBuilder`, streaming file-action diff
   between two versions

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1275,21 +1275,50 @@ pub unsafe extern "C" fn snapshot_builder_build(
 }
 
 fn snapshot_builder_build_impl(builder: FfiSnapshotBuilder) -> DeltaResult<Handle<SharedSnapshot>> {
-    let engine = builder.engine.engine();
-    let mut rust_builder = match builder.source {
-        FfiSnapshotBuilderSource::TableRoot(url) => Snapshot::builder_for(url),
-        FfiSnapshotBuilderSource::ExistingSnapshot(snap) => Snapshot::builder_from(snap),
-    };
-    if let Some(v) = builder.version {
-        rust_builder = rust_builder.at_version(v);
+    let FfiSnapshotBuilder {
+        engine,
+        source,
+        version,
+        log_tail,
+        max_catalog_version,
+    } = builder;
+    let engine = engine.engine();
+
+    fn build<Mode>(
+        mut builder: delta_kernel::snapshot::SnapshotBuilder<Mode>,
+        engine: &dyn Engine,
+        version: Option<Version>,
+        log_tail: Vec<LogPath>,
+        max_catalog_version: Option<Version>,
+    ) -> DeltaResult<SnapshotRef> {
+        if let Some(version) = version {
+            builder = builder.at_version(version);
+        }
+        if !log_tail.is_empty() {
+            builder = builder.with_log_tail(log_tail);
+        }
+        if let Some(max_catalog_version) = max_catalog_version {
+            builder = builder.with_max_catalog_version(max_catalog_version);
+        }
+        builder.build(engine)
     }
-    if !builder.log_tail.is_empty() {
-        rust_builder = rust_builder.with_log_tail(builder.log_tail);
-    }
-    if let Some(mcv) = builder.max_catalog_version {
-        rust_builder = rust_builder.with_max_catalog_version(mcv);
-    }
-    let snapshot = rust_builder.build(engine.as_ref())?;
+
+    let snapshot = match source {
+        FfiSnapshotBuilderSource::TableRoot(url) => build(
+            Snapshot::builder_for(url),
+            engine.as_ref(),
+            version,
+            log_tail,
+            max_catalog_version,
+        ),
+        FfiSnapshotBuilderSource::ExistingSnapshot(snapshot) => build(
+            Snapshot::builder_from(snapshot),
+            engine.as_ref(),
+            version,
+            log_tail,
+            max_catalog_version,
+        ),
+    }?;
     Ok(snapshot.into())
 }
 

--- a/kernel/src/commit_range/builder.rs
+++ b/kernel/src/commit_range/builder.rs
@@ -10,8 +10,8 @@ use crate::{DeltaResult, Engine, Error, Version};
 ///
 /// Created via [`CommitRange::builder_for`] (path-based) or
 /// [`CommitRange::builder_from`] (snapshot-based). Supports configuring an end version
-/// and the commit ordering. [`Self::build`] performs delta-log listing and contiguity
-/// validation.
+/// and the commit ordering. [`Self::build`] lists the log for a path-based builder or reuses the
+/// commit-file metadata in a snapshot-based builder, then validates contiguity.
 // TODO(#2781): support UC catalog commit via `with_log_tail(self, Vec<LogPath>)` and
 // `with_max_catalog_version(self, Version)`
 pub struct CommitRangeBuilder {
@@ -57,8 +57,9 @@ impl CommitRangeBuilder {
         self
     }
 
-    /// List `_delta_log/`, validate contiguity, and produce a [`CommitRange`]. Performs
-    /// filesystem listing but no JSON reads.
+    /// Resolve commit-file metadata, validate contiguity, and produce a [`CommitRange`]. A
+    /// path-based builder lists `_delta_log/`; a snapshot-based builder reuses the snapshot's log
+    /// segment. Neither path reads commit JSON.
     ///
     /// Returns [`Error::MissingVersion`] if a snapshot-derived range requires a commit that is not
     /// available in the snapshot's log segment. Returns an error if the resolved version range is

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -339,36 +339,37 @@ impl ListingAccumulator {
     /// only the latest commit.
     fn select_checkpoint_for_group(&mut self, version: Version) {
         let pending_checkpoint_parts = std::mem::take(&mut self.pending_checkpoint_parts);
-        if let Some((_, complete_checkpoint)) = group_checkpoint_parts(pending_checkpoint_parts)
+        let Some((_, complete_checkpoint)) = group_checkpoint_parts(pending_checkpoint_parts)
             .into_iter()
             .filter(|(instance, part_files)| instance.is_complete(part_files))
             .max_by(|(a, _), (b, _)| a.cmp(b))
+        else {
+            return;
+        };
+        if self.checkpoint_handling == CheckpointHandling::Ignore {
+            // TODO(#3269): Return `complete_checkpoint` separately so `Snapshot` can
+            //              track it outside its active `LogSegment`.
+            return;
+        }
+        self.output.checkpoint_parts = complete_checkpoint;
+        // Keep the commit at the checkpoint version (if any) before clearing all older commits.
+        self.output.latest_commit_file = self
+            .output
+            .ascending_commit_files
+            .last()
+            .filter(|c| c.version == version)
+            .cloned();
+        // Log replay only uses commits/compactions after a complete checkpoint
+        self.output.ascending_commit_files.clear();
+        self.output.ascending_compaction_files.clear();
+        // Drop CRC file if older than checkpoint (CRC must be >= checkpoint version)
+        if self
+            .output
+            .latest_crc_file
+            .as_ref()
+            .is_some_and(|crc| crc.version < version)
         {
-            if self.checkpoint_handling == CheckpointHandling::Ignore {
-                // TODO(#3269): Return `complete_checkpoint` separately so `Snapshot` can
-                //              track it outside its active `LogSegment`.
-                return;
-            }
-            self.output.checkpoint_parts = complete_checkpoint;
-            // Keep the commit at the checkpoint version (if any) before clearing all older commits.
-            self.output.latest_commit_file = self
-                .output
-                .ascending_commit_files
-                .last()
-                .filter(|c| c.version == version)
-                .cloned();
-            // Log replay only uses commits/compactions after a complete checkpoint
-            self.output.ascending_commit_files.clear();
-            self.output.ascending_compaction_files.clear();
-            // Drop CRC file if older than checkpoint (CRC must be >= checkpoint version)
-            if self
-                .output
-                .latest_crc_file
-                .as_ref()
-                .is_some_and(|crc| crc.version < version)
-            {
-                self.output.latest_crc_file = None;
-            }
+            self.output.latest_crc_file = None;
         }
     }
 }

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -239,6 +239,19 @@ pub(crate) fn should_process_log_file(file: &ParsedLogPath) -> bool {
     false
 }
 
+/// Controls whether listing adopts discovered checkpoints as the replay base.
+///
+/// See [`crate::snapshot::IncrementalSnapshotBuilder::skip_new_checkpoints`] for why `Ignore` is
+/// needed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum CheckpointHandling {
+    /// Adopt the latest complete checkpoint and discard the files it covers.
+    #[default]
+    Adopt,
+    /// Recognize complete checkpoints without adopting them, retaining all listed commits.
+    Ignore,
+}
+
 /// Accumulates and groups log files during listing. Each "group" consists of all files that
 /// share the same version number (e.g., commit, checkpoint parts, CRC files).
 ///
@@ -262,6 +275,7 @@ struct ListingAccumulator {
     end_version: Option<Version>,
     /// The version of the current group being accumulated
     group_version: Option<Version>,
+    checkpoint_handling: CheckpointHandling,
 }
 
 impl ListingAccumulator {
@@ -330,6 +344,11 @@ impl ListingAccumulator {
             .filter(|(instance, part_files)| instance.is_complete(part_files))
             .max_by(|(a, _), (b, _)| a.cmp(b))
         {
+            if self.checkpoint_handling == CheckpointHandling::Ignore {
+                // TODO(#3269): Return `complete_checkpoint` separately so `Snapshot` can
+                //              track it outside its active `LogSegment`.
+                return;
+            }
             self.output.checkpoint_parts = complete_checkpoint;
             // Keep the commit at the checkpoint version (if any) before clearing all older commits.
             self.output.latest_commit_file = self
@@ -367,11 +386,13 @@ impl LogSegmentFiles {
     /// - `start_version`: start version of the entire listing range provided; in practice, this is
     ///   the lower bound (inclusive) for log_tail entries included in the result
     /// - `end_version`: upper bound (inclusive) on versions to include, `None` means no bound
+    /// - `checkpoint_handling`: whether complete checkpoints replace the replay base
     pub(crate) fn build_log_segment_files(
         fs_files: impl Iterator<Item = DeltaResult<ParsedLogPath>>,
         log_tail: Vec<ParsedLogPath>,
         start_version: Version,
         end_version: Option<Version>,
+        checkpoint_handling: CheckpointHandling,
     ) -> DeltaResult<Self> {
         // check log_tail is only commits
         // note that LogSegment checks no gaps/duplicates so we don't duplicate that here
@@ -385,6 +406,7 @@ impl LogSegmentFiles {
 
         let mut acc = ListingAccumulator {
             end_version,
+            checkpoint_handling,
             ..Default::default()
         };
 
@@ -442,8 +464,8 @@ impl LogSegmentFiles {
             acc.select_checkpoint_for_group(gv);
         }
 
-        // Since ascending_commit_files is cleared at each checkpoint, if it's non-empty here
-        // it contains only commits after the most recent checkpoint. The last element is the
+        // Since ascending_commit_files is cleared when a checkpoint is adopted, a non-empty list
+        // contains only commits after the most recent adopted checkpoint. The last element is the
         // highest version commit overall, so we update latest_commit_file to it. If it's empty,
         // we keep the value set at the checkpoint (if a commit existed at the checkpoint version),
         // or remains None.
@@ -582,11 +604,31 @@ impl LogSegmentFiles {
         end_version: Option<Version>,
         cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Self> {
+        Self::list_with_checkpoint_handling(
+            storage,
+            log_root,
+            log_tail,
+            start_version,
+            end_version,
+            CheckpointHandling::Adopt,
+            cancellation_token,
+        )
+    }
+
+    pub(crate) fn list_with_checkpoint_handling(
+        storage: &dyn StorageHandler,
+        log_root: &Url,
+        log_tail: Vec<ParsedLogPath>,
+        start_version: Option<Version>,
+        end_version: Option<Version>,
+        checkpoint_handling: CheckpointHandling,
+        cancellation_token: Option<&CancellationTokenRef>,
+    ) -> DeltaResult<Self> {
         let start = start_version.unwrap_or(0);
         let end = end_version.unwrap_or(Version::MAX);
         let fs_iter =
             list_delta_log_from_storage(storage, log_root, start, end, cancellation_token)?;
-        Self::build_log_segment_files(fs_iter, log_tail, start, end_version)
+        Self::build_log_segment_files(fs_iter, log_tail, start, end_version, checkpoint_handling)
     }
 
     /// List all commit and checkpoint files after the provided checkpoint. It is guaranteed that
@@ -716,6 +758,12 @@ impl LogSegmentFiles {
 
         let fs_iter = windows.into_iter().rev().flatten().map(Ok);
         let start = found_checkpoint_version.unwrap_or(0);
-        Self::build_log_segment_files(fs_iter, log_tail, start, Some(end_version))
+        Self::build_log_segment_files(
+            fs_iter,
+            log_tail,
+            start,
+            Some(end_version),
+            CheckpointHandling::Adopt,
+        )
     }
 }

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -1302,6 +1302,44 @@ async fn test_list_commits_keeps_commits_across_checkpoint() {
     assert_eq!(versions, vec![0, 1, 2, 3, 4, 5]);
 }
 
+#[tokio::test]
+async fn test_list_ignoring_checkpoints_keeps_commits_and_crc() {
+    let mut files: Vec<_> = (0..=5)
+        .map(|v| (v, LogPathFileType::Commit, CommitSource::Filesystem))
+        .collect();
+    files.extend([
+        (
+            3,
+            LogPathFileType::ClassicCheckpoint,
+            CommitSource::Filesystem,
+        ),
+        (4, LogPathFileType::Crc, CommitSource::Filesystem),
+    ]);
+    let (storage, log_root) = create_storage(files).await;
+
+    let result = LogSegmentFiles::list_with_checkpoint_handling(
+        storage.as_ref(),
+        &log_root,
+        vec![],
+        Some(0),
+        Some(5),
+        CheckpointHandling::Ignore,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        result
+            .ascending_commit_files
+            .iter()
+            .map(|commit| commit.version)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 2, 3, 4, 5]
+    );
+    assert!(result.checkpoint_parts.is_empty());
+    assert_eq!(result.latest_crc_file.unwrap().version, 4);
+}
+
 // ---------------------------------------------------------------------------
 // find_complete_checkpoint_version direct unit tests
 // (other cases already covered by tests above)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use url::Url;
 
 use self::data_skipping::as_checkpoint_skipping_predicate;
@@ -452,6 +452,17 @@ impl ScanBuilder {
             &state_info,
             &self.stats,
         )?;
+
+        let commits_since_checkpoint = self.snapshot.log_segment().commits_since_checkpoint();
+        if self.snapshot.skipped_new_checkpoints() && commits_since_checkpoint > 0 {
+            warn!(
+                snapshot_version = self.snapshot.version(),
+                checkpoint_version = ?self.snapshot.log_segment().checkpoint_version,
+                commits_since_checkpoint,
+                "Full scan may replay extra transaction-log commits because the snapshot was \
+                 built with skip_new_checkpoints()"
+            );
+        }
 
         Ok(Scan {
             snapshot: self.snapshot,

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -170,17 +170,14 @@ impl SnapshotBuilder<FromSnapshot> {
 
     /// Skip adopting new checkpoints while updating the input snapshot.
     ///
-    /// This supports conflict rebasing. If a transaction read snapshot N, attempted to commit at
-    /// N+1, and lost to commits N+1 through N+5, this option builds a snapshot that preserves that
-    /// full range for [`CommitRange::builder_from`]. A checkpoint at N+3 is recognized but not
-    /// adopted, so commits N+1 and N+2 remain available to the range.
+    /// The resulting snapshot retains newly listed commits instead of adopting a newer checkpoint
+    /// as its replay base. For example, when updating snapshot N to N+5, a checkpoint at N+3 is
+    /// recognized but not adopted, and commits N+1 through N+5 remain in the log segment.
     ///
     /// The update fails if the new commits are not contiguous.
     ///
     /// This option increases memory use and may increase full-scan log replay. It is available
     /// only for builders created by [`Snapshot::builder_from`].
-    ///
-    /// [`CommitRange::builder_from`]: crate::commit_range::CommitRange::builder_from
     pub fn skip_new_checkpoints(mut self) -> Self {
         self.checkpoint_handling = CheckpointHandling::Ignore;
         self

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -1,5 +1,6 @@
 //! Builder for creating [`Snapshot`] instances.
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use tracing::{info, instrument};
@@ -7,12 +8,21 @@ use tracing::{info, instrument};
 use crate::cancellation::CancellationTokenRef;
 use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
+use crate::log_segment_files::CheckpointHandling;
 use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
 use crate::metrics::{LogSegmentLoadType, MetricId, SnapshotLoadMetricContext};
 use crate::path::LogPathFileType;
 use crate::snapshot::SnapshotRef;
 use crate::utils::{require, try_parse_uri};
 use crate::{DeltaResult, Engine, Error, Snapshot, Version};
+
+/// Marker for builders that load a snapshot from a table root.
+#[doc(hidden)]
+pub struct FromTableRoot;
+
+/// Marker for builders that incrementally update an existing snapshot.
+#[doc(hidden)]
+pub struct FromSnapshot;
 
 /// Builder for creating [`Snapshot`] instances.
 ///
@@ -32,17 +42,14 @@ use crate::{DeltaResult, Engine, Error, Snapshot, Version};
 /// # Ok(())
 /// # }
 /// ```
-//
-// Note the SnapshotBuilder must have either a table_root or an existing_snapshot (but not both).
-// We enforce this in the constructors. We could improve this in the future with different
-// types/add type state.
-pub struct SnapshotBuilder {
+pub struct SnapshotBuilder<Mode = FromTableRoot> {
     table_root: Option<String>,
     existing_snapshot: Option<SnapshotRef>,
     version: Option<Version>,
     log_tail: Vec<LogPath>,
     max_catalog_version: Option<Version>,
     incremental_replay: IncrementalReplay,
+    checkpoint_handling: CheckpointHandling,
     /// Kernel-minted id correlating this build's metric events with its child events.
     operation_id: MetricId,
     /// Opaque, caller-supplied id recorded on this build's metric events. Not interpreted by
@@ -52,11 +59,16 @@ pub struct SnapshotBuilder {
     /// [`with_cancellation_token`](Self::with_cancellation_token). `None` means the build is not
     /// cancellable.
     cancellation_token: Option<CancellationTokenRef>,
+    // Carries the zero-sized typestate that limits mode-specific methods at compile time.
+    mode: PhantomData<Mode>,
 }
+
+/// Builder for incrementally updating an existing [`Snapshot`].
+pub type IncrementalSnapshotBuilder = SnapshotBuilder<FromSnapshot>;
 
 // Hand-written because `CancellationToken` is not `Debug`: the token is projected to a bool. Ends
 // with `finish_non_exhaustive` so a future field is not silently dropped from the output.
-impl std::fmt::Debug for SnapshotBuilder {
+impl<Mode> std::fmt::Debug for SnapshotBuilder<Mode> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SnapshotBuilder")
             .field("table_root", &self.table_root)
@@ -65,6 +77,7 @@ impl std::fmt::Debug for SnapshotBuilder {
             .field("log_tail", &self.log_tail)
             .field("max_catalog_version", &self.max_catalog_version)
             .field("incremental_replay", &self.incremental_replay)
+            .field("checkpoint_handling", &self.checkpoint_handling)
             .field("operation_id", &self.operation_id)
             .field("correlation_id", &self.correlation_id)
             .field("cancellable", &self.cancellation_token.is_some())
@@ -116,7 +129,7 @@ impl IncrementalReplay {
     }
 }
 
-impl SnapshotBuilder {
+impl SnapshotBuilder<FromTableRoot> {
     // ============================================================================
     // Constructors
     // ============================================================================
@@ -129,12 +142,16 @@ impl SnapshotBuilder {
             log_tail: Vec::new(),
             max_catalog_version: None,
             incremental_replay: IncrementalReplay::default(),
+            checkpoint_handling: CheckpointHandling::Adopt,
             operation_id: MetricId::new(),
             correlation_id: None,
             cancellation_token: None,
+            mode: PhantomData,
         }
     }
+}
 
+impl SnapshotBuilder<FromSnapshot> {
     pub(crate) fn new_from(existing_snapshot: SnapshotRef) -> Self {
         Self {
             table_root: None,
@@ -143,12 +160,34 @@ impl SnapshotBuilder {
             log_tail: Vec::new(),
             max_catalog_version: None,
             incremental_replay: IncrementalReplay::default(),
+            checkpoint_handling: CheckpointHandling::Adopt,
             operation_id: MetricId::new(),
             correlation_id: None,
             cancellation_token: None,
+            mode: PhantomData,
         }
     }
 
+    /// Skip adopting new checkpoints while updating the input snapshot.
+    ///
+    /// This supports conflict rebasing. If a transaction read snapshot N, attempted to commit at
+    /// N+1, and lost to commits N+1 through N+5, this option builds a snapshot that preserves that
+    /// full range for [`CommitRange::builder_from`]. A checkpoint at N+3 is recognized but not
+    /// adopted, so commits N+1 and N+2 remain available to the range.
+    ///
+    /// The update fails if the new commits are not contiguous.
+    ///
+    /// This option increases memory use and may increase full-scan log replay. It is available
+    /// only for builders created by [`Snapshot::builder_from`].
+    ///
+    /// [`CommitRange::builder_from`]: crate::commit_range::CommitRange::builder_from
+    pub fn skip_new_checkpoints(mut self) -> Self {
+        self.checkpoint_handling = CheckpointHandling::Ignore;
+        self
+    }
+}
+
+impl<Mode> SnapshotBuilder<Mode> {
     // ============================================================================
     // Chainable configuration
     // ============================================================================
@@ -282,9 +321,11 @@ impl SnapshotBuilder {
             log_tail,
             max_catalog_version,
             incremental_replay,
+            checkpoint_handling,
             operation_id,
             correlation_id,
             cancellation_token,
+            mode: _,
         } = self;
 
         let metric_context = SnapshotLoadMetricContext {
@@ -340,6 +381,7 @@ impl SnapshotBuilder {
                 effective_version,
                 metric_context,
                 incremental_replay,
+                checkpoint_handling,
                 built_as_latest,
                 cancellation_token.as_ref(),
             )?

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 use super::{IncrementalReplay, Snapshot};
 use crate::cancellation::CancellationTokenRef;
 use crate::log_segment::LogSegment;
-use crate::log_segment_files::LogSegmentFiles;
+use crate::log_segment_files::{CheckpointHandling, LogSegmentFiles};
 use crate::metrics::{
     emit_log_segment_load, emit_log_segment_load_failure, emit_protocol_metadata_load,
     emit_protocol_metadata_load_failure, SnapshotLoadMetricContext,
@@ -108,6 +108,7 @@ impl Snapshot {
         target_version: impl Into<Option<Version>>,
         metric_context: SnapshotLoadMetricContext,
         incremental_replay: IncrementalReplay,
+        checkpoint_handling: CheckpointHandling,
         built_as_latest: bool,
         cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Arc<Self>> {
@@ -131,6 +132,8 @@ impl Snapshot {
             tracing::Span::current().record("version", existing_snapshot_version);
         }
 
+        let skipped_new_checkpoints = checkpoint_handling == CheckpointHandling::Ignore;
+
         // Assemble the new segment as one fallible unit so a load failure emits exactly once, via
         // the `inspect_err` below.
         let segment_load_start = std::time::Instant::now();
@@ -140,12 +143,17 @@ impl Snapshot {
             existing_snapshot_version,
             log_tail,
             requested_version,
+            checkpoint_handling,
             cancellation_token,
         )
         .inspect_err(|_| emit_log_segment_load_failure(&metric_context))?
         {
             NewSegment::Unchanged => {
-                return Self::reuse_promoting_built_as_latest(&existing_snapshot, built_as_latest);
+                return Self::reuse_with_build_metadata(
+                    &existing_snapshot,
+                    built_as_latest,
+                    skipped_new_checkpoints,
+                );
             }
             NewSegment::Rebuild(new_log_segment) => {
                 emit_log_segment_load(
@@ -225,6 +233,7 @@ impl Snapshot {
             table_configuration,
             crc_at_version.map(|(crc, _)| crc).or(base_crc),
             built_as_latest,
+            skipped_new_checkpoints,
         )?))
     }
 
@@ -241,20 +250,36 @@ impl Snapshot {
         existing_snapshot_version: Version,
         log_tail: Vec<ParsedLogPath>,
         requested_version: Option<Version>,
+        checkpoint_handling: CheckpointHandling,
         cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<NewSegment> {
         let log_root = existing_log_segment.log_root.clone();
         let storage = engine.storage_handler();
 
-        // Start listing just after the previous segment's checkpoint, if any.
-        let listing_start = existing_log_segment.checkpoint_version.unwrap_or(0) + 1;
-
-        let new_listed_files = LogSegmentFiles::list(
+        let listing_base_version = match checkpoint_handling {
+            CheckpointHandling::Adopt => {
+                // Start listing just after the previous segment's checkpoint, if any.
+                existing_log_segment.checkpoint_version.unwrap_or(0)
+            }
+            CheckpointHandling::Ignore => {
+                // TODO(#3269): If Ignore retains checkpoints, list from the existing checkpoint as
+                //              Adopt does and filter already-held commits before combining.
+                // Today Ignore discards checkpoints, so start after the snapshot to avoid relisting
+                // commits already held by the existing segment.
+                existing_snapshot_version
+            }
+        };
+        let Some(listing_start) = listing_base_version.checked_add(1) else {
+            // No version can follow Version::MAX.
+            return Ok(NewSegment::Unchanged);
+        };
+        let new_listed_files = LogSegmentFiles::list_with_checkpoint_handling(
             storage.as_ref(),
             &log_root,
             log_tail,
             Some(listing_start),
             requested_version,
+            checkpoint_handling,
             cancellation_token,
         )?;
 
@@ -411,20 +436,24 @@ impl Snapshot {
     }
 
     /// Reuse `existing`, promoting its `built_as_latest` flag to `true` if this build confirmed
-    /// latest.
-    fn reuse_promoting_built_as_latest(
+    /// latest (and updating the checkpoint-retention flag).
+    fn reuse_with_build_metadata(
         existing: &Arc<Snapshot>,
         built_as_latest: bool,
+        skipped_new_checkpoints: bool,
     ) -> DeltaResult<Arc<Snapshot>> {
-        // Promote only false -> true; every other case reuses the Arc unchanged.
-        if existing.built_as_latest || !built_as_latest {
+        let built_as_latest = existing.built_as_latest || built_as_latest;
+        if existing.built_as_latest == built_as_latest
+            && existing.skipped_new_checkpoints == skipped_new_checkpoints
+        {
             return Ok(existing.clone());
         }
         Ok(Arc::new(Snapshot::new_with_crc(
             existing.log_segment.clone(),
             existing.table_configuration.clone(),
             existing.base_crc().cloned(),
-            true, // reached only when the flag flips false -> true
+            built_as_latest,
+            skipped_new_checkpoints,
         )?))
     }
 
@@ -478,13 +507,14 @@ mod tests {
 
     use rstest::rstest;
     use serde_json::json;
-    use test_utils::delta_path_for_version;
     use test_utils::table_builder::TestTableBuilder;
+    use test_utils::{delta_path_for_version, LoggingTest};
     use url::Url;
 
     use super::*;
     use crate::arrow::array::StringArray;
     use crate::arrow::record_batch::RecordBatch;
+    use crate::commit_range::CommitRange;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::SyncEngine;
     use crate::metrics::{
@@ -495,7 +525,7 @@ mod tests {
     use crate::object_store::ObjectStoreExt as _;
     use crate::parquet::arrow::ArrowWriter;
     use crate::path::LogPathFileType;
-    use crate::snapshot::commit;
+    use crate::snapshot::{commit, CheckpointWriteResult};
     use crate::unit_test_utils::{
         install_thread_local_metrics_reporter, string_array_to_engine_data, CapturingReporter,
     };
@@ -641,6 +671,7 @@ mod tests {
             None,
             SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
+            CheckpointHandling::Adopt,
             true, /* built_as_latest */
             None, /* cancellation_token */
         )?;
@@ -722,6 +753,7 @@ mod tests {
             Some(2),
             SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
+            CheckpointHandling::Adopt,
             false, /* built_as_latest */
             None,  /* cancellation_token */
         )?;
@@ -782,6 +814,7 @@ mod tests {
             Some(1),
             SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
+            CheckpointHandling::Adopt,
             false, /* built_as_latest */
             None,  /* cancellation_token */
         )?;
@@ -795,6 +828,7 @@ mod tests {
             Some(0),
             SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
+            CheckpointHandling::Adopt,
             false, /* built_as_latest */
             None,  /* cancellation_token */
         );
@@ -809,6 +843,346 @@ mod tests {
     // ============================================================================
     // Tests: incremental builder paths (Cases A/B/C/D.1/D.2/E/F)
     // ============================================================================
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_skip_new_checkpoints_preserves_checkpoint_history_across_updates(
+    ) -> DeltaResult<()> {
+        // ===== GIVEN =====
+        let ctx = setup_incremental_snapshot_test()?;
+        let table_root = ctx.url.as_str();
+
+        commit(
+            table_root,
+            &ctx.store,
+            0,
+            vec![
+                protocol_action(1, 1),
+                metadata_action(json!({})),
+                add_action("file0.parquet"),
+            ],
+        )
+        .await;
+        commit(table_root, &ctx.store, 1, vec![add_action("file1.parquet")]).await;
+        Snapshot::builder_for(table_root)
+            .at_version(1)
+            .build(ctx.engine.as_ref())?
+            .checkpoint(ctx.engine.as_ref(), None)?;
+
+        commit(table_root, &ctx.store, 2, vec![add_action("file2.parquet")]).await;
+        commit(table_root, &ctx.store, 3, vec![add_action("file3.parquet")]).await;
+        let base = Snapshot::builder_for(table_root)
+            .at_version(3)
+            .build(ctx.engine.as_ref())?;
+        assert_eq!(base.log_segment.checkpoint_version, Some(1));
+
+        commit(
+            table_root,
+            &ctx.store,
+            4,
+            vec![
+                protocol_action(1, 2),
+                metadata_action(json!({"skip_new_checkpoints": "true"})),
+            ],
+        )
+        .await;
+        commit(table_root, &ctx.store, 5, vec![add_action("file5.parquet")]).await;
+        Snapshot::builder_for(table_root)
+            .at_version(5)
+            .build(ctx.engine.as_ref())?
+            .checkpoint(ctx.engine.as_ref(), None)?;
+        commit(table_root, &ctx.store, 6, vec![add_action("file6.parquet")]).await;
+
+        // ===== WHEN =====
+        // Build one normal update and one that deliberately retains the full commit tail.
+        let default_update = Snapshot::builder_from(base.clone())
+            .at_version(6)
+            .build(ctx.engine.as_ref())?;
+        let updated = Snapshot::builder_from(base.clone())
+            .at_version(6)
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref())?;
+
+        // ===== THEN =====
+        // The retained snapshot keeps the original checkpoint and every commit needed by the range.
+        assert_eq!(default_update.log_segment.checkpoint_version, Some(5));
+        assert_eq!(updated.version(), 6);
+        assert_eq!(updated.log_segment.checkpoint_version, Some(1));
+        assert_eq!(
+            updated.log_segment.listed.checkpoint_parts,
+            base.log_segment.listed.checkpoint_parts
+        );
+        assert_eq!(
+            updated.log_segment.last_checkpoint_metadata,
+            base.log_segment.last_checkpoint_metadata
+        );
+        assert_eq!(
+            updated
+                .log_segment
+                .listed
+                .ascending_commit_files
+                .iter()
+                .map(|file| file.version)
+                .collect::<Vec<_>>(),
+            vec![2, 3, 4, 5, 6]
+        );
+        assert_eq!(
+            updated
+                .metadata_configuration()
+                .get("skip_new_checkpoints")
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            updated
+                .table_configuration()
+                .protocol()
+                .min_reader_version(),
+            1
+        );
+        assert_eq!(
+            updated
+                .table_configuration()
+                .protocol()
+                .min_writer_version(),
+            2
+        );
+        let range = CommitRange::builder_from(updated.clone(), 4).build(ctx.engine.as_ref())?;
+        assert_eq!(range.start_version(), 4);
+        assert_eq!(range.end_version(), 6);
+
+        // ===== WHEN =====
+        // Remove the first update's source commits, then advance from its retained file metadata.
+        for version in 4..=6 {
+            ctx.store
+                .delete(&delta_path_for_version(version, "json"))
+                .await?;
+        }
+        commit(table_root, &ctx.store, 7, vec![add_action("file7.parquet")]).await;
+        let updated_again = Snapshot::builder_from(updated)
+            .at_version(7)
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref())?;
+
+        // ===== THEN =====
+        // The second update still carries the complete retained history through version 7.
+        assert_eq!(
+            updated_again
+                .log_segment
+                .listed
+                .ascending_commit_files
+                .iter()
+                .map(|file| file.version)
+                .collect::<Vec<_>>(),
+            vec![2, 3, 4, 5, 6, 7]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_skip_new_checkpoints_preserves_incremental_builder_boundaries() -> DeltaResult<()>
+    {
+        // ===== GIVEN =====
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 2).await?;
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(1)
+            .build(ctx.engine.as_ref())?;
+
+        // ===== WHEN =====
+        // Ask for the latest snapshot when the input is already latest.
+        let unchanged = Snapshot::builder_from(base.clone())
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref())?;
+
+        // ===== THEN =====
+        // The reused snapshot records the requested checkpoint policy and latest-version status.
+        assert_eq!(unchanged, base);
+        assert!(unchanged.is_built_as_latest());
+        assert!(unchanged.skipped_new_checkpoints());
+
+        // ===== WHEN =====
+        let refreshed = Snapshot::builder_from(unchanged).build(ctx.engine.as_ref())?;
+
+        // ===== THEN =====
+        // A normal update replaces the previous build policy even when the version is unchanged.
+        assert!(!refreshed.skipped_new_checkpoints());
+
+        // ===== WHEN =====
+        // Request the existing snapshot's version explicitly.
+        let pinned = Snapshot::builder_from(base.clone())
+            .at_version(1)
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref())?;
+
+        // ===== THEN =====
+        assert!(Arc::ptr_eq(&pinned, &base));
+        assert!(!pinned.skipped_new_checkpoints());
+
+        // ===== WHEN =====
+        let older = Snapshot::builder_from(base.clone())
+            .at_version(0)
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref())
+            .expect_err("an incremental update cannot move backward");
+
+        // ===== THEN =====
+        assert!(older
+            .to_string()
+            .contains("older than snapshot hint version"));
+
+        // ===== WHEN =====
+        let unavailable = Snapshot::builder_from(base.clone())
+            .at_version(2)
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref())
+            .expect_err("version 2 does not exist");
+
+        // ===== THEN =====
+        assert!(unavailable
+            .to_string()
+            .contains("no new commits were found"));
+
+        // ===== WHEN =====
+        commit(
+            ctx.url.as_str(),
+            &ctx.store,
+            2,
+            vec![add_action("file2.parquet")],
+        )
+        .await;
+        let partially_available = Snapshot::builder_from(base)
+            .at_version(3)
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref())
+            .expect_err("version 3 is beyond the latest commit");
+
+        // ===== THEN =====
+        assert!(partially_available
+            .to_string()
+            .contains("end version 2 not the same as the specified end version 3"));
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_full_scan_warns_when_snapshot_skipped_new_checkpoints(
+        #[values(false, true)] skip_new_checkpoints: bool,
+    ) -> DeltaResult<()> {
+        // ===== GIVEN =====
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 3).await?;
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(0)
+            .build(ctx.engine.as_ref())?;
+        let builder = Snapshot::builder_from(base).at_version(2);
+        let snapshot = if skip_new_checkpoints {
+            builder.skip_new_checkpoints().build(ctx.engine.as_ref())?
+        } else {
+            builder.build(ctx.engine.as_ref())?
+        };
+        assert_eq!(snapshot.skipped_new_checkpoints(), skip_new_checkpoints);
+
+        // ===== WHEN =====
+        // Build an incremental scan, which consumes exactly the caller-selected commit range.
+        let logging = LoggingTest::new();
+        let _incremental_scan = snapshot
+            .clone()
+            .incremental_scan_builder(0)
+            .build(ctx.engine.as_ref())?;
+
+        // ===== THEN =====
+        assert!(!logging.logs().contains("skip_new_checkpoints()"));
+
+        // ===== WHEN =====
+        // Build a full scan, which may replay the extra commits retained by the snapshot.
+        let _full_scan = snapshot.scan_builder().build()?;
+
+        // ===== THEN =====
+        assert_eq!(
+            logging.logs().contains("skip_new_checkpoints()"),
+            skip_new_checkpoints
+        );
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_checkpoint_clears_skipped_new_checkpoints_warning() -> DeltaResult<()> {
+        // ===== GIVEN =====
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 3).await?;
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(0)
+            .build(ctx.engine.as_ref())?;
+        let snapshot = Snapshot::builder_from(base)
+            .at_version(2)
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref())?;
+
+        // ===== WHEN =====
+        let logging = LoggingTest::new();
+        let _scan = snapshot.clone().scan_builder().build()?;
+
+        // ===== THEN =====
+        // Before reduction, a full scan warns about replaying the deliberately retained commits.
+        assert!(logging.logs().contains("skip_new_checkpoints()"));
+        drop(logging);
+
+        // ===== WHEN =====
+        // Writing a checkpoint produces a reduced snapshot rooted at that checkpoint.
+        let (result, checkpointed) = snapshot.checkpoint(ctx.engine.as_ref(), None)?;
+
+        // ===== THEN =====
+        assert_eq!(result, CheckpointWriteResult::Written);
+        assert!(!checkpointed.skipped_new_checkpoints());
+
+        let logging = LoggingTest::new();
+        let _scan = checkpointed.scan_builder().build()?;
+        assert!(!logging.logs().contains("skip_new_checkpoints()"));
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_skip_new_checkpoints_rejects_missing_history_hidden_by_newer_checkpoint(
+    ) -> DeltaResult<()> {
+        // ===== GIVEN =====
+        let ctx = setup_incremental_snapshot_test()?;
+        let table_root = ctx.url.as_str();
+        setup_test_table_with_commits(table_root, &ctx.store, 6).await?;
+
+        let base = Snapshot::builder_for(table_root)
+            .at_version(1)
+            .build(ctx.engine.as_ref())?;
+        Snapshot::builder_for(table_root)
+            .at_version(4)
+            .build(ctx.engine.as_ref())?
+            .checkpoint(ctx.engine.as_ref(), None)?;
+        ctx.store.delete(&delta_path_for_version(3, "json")).await?;
+
+        // ===== WHEN =====
+        // A normal update may use the checkpoint to bridge the missing pre-checkpoint commit.
+        let default_update = Snapshot::builder_from(base.clone())
+            .at_version(5)
+            .build(ctx.engine.as_ref())?;
+
+        // ===== THEN =====
+        assert_eq!(default_update.log_segment.checkpoint_version, Some(4));
+
+        // ===== WHEN =====
+        // Retaining commits requires the full range instead of allowing the checkpoint bridge.
+        let updated = Snapshot::builder_from(base)
+            .at_version(5)
+            .skip_new_checkpoints()
+            .build(ctx.engine.as_ref());
+
+        // ===== THEN =====
+        let error = updated.expect_err("the missing commit must not be hidden by the checkpoint");
+        assert!(error
+            .to_string()
+            .contains("Expected contiguous commit files"));
+
+        Ok(())
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_incremental_snapshot_picks_up_checkpoint_written_at_current_version(
@@ -1319,6 +1693,7 @@ mod tests {
     async fn test_incremental_update_advances_in_memory_crc_within_budget(
         #[case] mode: IncrementalReplay,
         #[case] expected_crc_v: Option<u64>,
+        #[values(false, true)] skip_new_checkpoints: bool,
     ) -> DeltaResult<()> {
         let ctx = setup_incremental_snapshot_test()?;
         setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 6).await?;
@@ -1335,9 +1710,16 @@ mod tests {
             .build(ctx.engine.as_ref())?;
         assert_eq!(snapshot_a.crc_at_version().map(|c| c.version), Some(3));
 
-        let updated = Snapshot::builder_from(snapshot_a)
-            .with_incremental_crc_replay(mode)
-            .build(ctx.engine.as_ref())?;
+        // Advance with each CRC budget under both checkpoint-listing policies.
+        let builder = Snapshot::builder_from(snapshot_a).with_incremental_crc_replay(mode);
+        let builder = if skip_new_checkpoints {
+            builder.skip_new_checkpoints()
+        } else {
+            builder
+        };
+        let updated = builder.build(ctx.engine.as_ref())?;
+
+        // Checkpoint retention must not change whether the configured CRC budget can advance.
         assert_eq!(updated.version(), 5);
         assert_eq!(updated.crc_at_version().map(|c| c.version), expected_crc_v);
         assert_eq!(

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -1038,9 +1038,7 @@ mod tests {
             .expect_err("version 2 does not exist");
 
         // ===== THEN =====
-        assert!(unavailable
-            .to_string()
-            .contains("no new commits were found"));
+        assert!(matches!(unavailable, Error::MissingVersion(2)));
 
         // ===== WHEN =====
         commit(
@@ -1057,9 +1055,7 @@ mod tests {
             .expect_err("version 3 is beyond the latest commit");
 
         // ===== THEN =====
-        assert!(partially_available
-            .to_string()
-            .contains("end version 2 not the same as the specified end version 3"));
+        assert!(matches!(partially_available, Error::MissingVersion(3)));
 
         Ok(())
     }
@@ -1177,9 +1173,7 @@ mod tests {
 
         // ===== THEN =====
         let error = updated.expect_err("the missing commit must not be hidden by the checkpoint");
-        assert!(error
-            .to_string()
-            .contains("Expected contiguous commit files"));
+        assert!(matches!(error, Error::MissingVersion(3)));
 
         Ok(())
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -41,7 +41,9 @@ use crate::{DeltaResult, Engine, Error, LogCompactionWriter, Version};
 mod builder;
 mod incremental;
 mod snapshot_crc;
-pub use builder::{IncrementalReplay, SnapshotBuilder};
+#[doc(hidden)]
+pub use builder::{FromSnapshot, FromTableRoot};
+pub use builder::{IncrementalReplay, IncrementalSnapshotBuilder, SnapshotBuilder};
 use snapshot_crc::SnapshotCrc;
 
 /// A shared, thread-safe reference to a [`Snapshot`].
@@ -81,10 +83,12 @@ pub struct Snapshot {
     crc: SnapshotCrc,
     /// Best-effort "confirmed latest at build time" flag. See [`Snapshot::built_as_latest`].
     built_as_latest: bool,
+    /// Whether the last applicable incremental build requested ignoring new checkpoints.
+    skipped_new_checkpoints: bool,
 }
 
 impl PartialEq for Snapshot {
-    // Content equality: `built_as_latest` is best-effort build metadata, deliberately excluded.
+    // Content equality excludes build metadata that does not change the table state.
     fn eq(&self, other: &Self) -> bool {
         self.log_segment == other.log_segment
             && self.table_configuration == other.table_configuration
@@ -106,6 +110,7 @@ impl std::fmt::Debug for Snapshot {
             .field("version", &self.version())
             .field("metadata", &self.table_configuration().metadata())
             .field("log_segment", &self.log_segment)
+            .field("skipped_new_checkpoints", &self.skipped_new_checkpoints)
             .finish()
     }
 }
@@ -128,11 +133,9 @@ impl Snapshot {
         SnapshotBuilder::new_for(table_root)
     }
 
-    /// Create a new [`SnapshotBuilder`] to incrementally update an existing [`Snapshot`] to a
-    /// more recent version.
-    ///
-    /// See `Snapshot::try_new_from` for the case-by-case behavior.
-    pub fn builder_from(existing_snapshot: SnapshotRef) -> SnapshotBuilder {
+    /// Create a new [`IncrementalSnapshotBuilder`] to incrementally update an existing [`Snapshot`]
+    /// to a more recent version.
+    pub fn builder_from(existing_snapshot: SnapshotRef) -> IncrementalSnapshotBuilder {
         SnapshotBuilder::new_from(existing_snapshot)
     }
 
@@ -152,18 +155,21 @@ impl Snapshot {
             table_configuration,
             None,  /* crc */
             false, /* built_as_latest */
+            false, /* skipped_new_checkpoints */
         )
     }
 
     /// Internal constructor that accepts an explicit pre-resolved CRC.
     ///
     /// `built_as_latest` records whether the build confirmed this is the latest version
-    /// (best-effort). See [`Snapshot::built_as_latest`].
+    /// (best-effort). See [`Snapshot::built_as_latest`]. `skipped_new_checkpoints` records the last
+    /// applicable incremental build's checkpoint policy.
     pub(crate) fn new_with_crc(
         log_segment: LogSegment,
         table_configuration: TableConfiguration,
         crc: Option<Arc<Crc>>,
         built_as_latest: bool,
+        skipped_new_checkpoints: bool,
     ) -> DeltaResult<Self> {
         // Will perform version validations.
         let crc = SnapshotCrc::try_new(
@@ -184,6 +190,7 @@ impl Snapshot {
             table_configuration,
             crc,
             built_as_latest,
+            skipped_new_checkpoints,
         })
     }
 
@@ -225,7 +232,13 @@ impl Snapshot {
         tracing::Span::current().record("version", table_configuration.version());
 
         let crc = crc_at_version.map(|(crc, _)| crc).or(base_crc);
-        Self::new_with_crc(log_segment, table_configuration, crc, built_as_latest)
+        Self::new_with_crc(
+            log_segment,
+            table_configuration,
+            crc,
+            built_as_latest,
+            false, /* skipped_new_checkpoints */
+        )
     }
 
     /// Creates a new [`Snapshot`] representing the table state immediately after a commit.
@@ -286,6 +299,7 @@ impl Snapshot {
             new_table_configuration,
             new_crc,
             true, /* built_as_latest */
+            self.skipped_new_checkpoints,
         )
     }
 
@@ -297,6 +311,13 @@ impl Snapshot {
     #[internal_api]
     pub(crate) fn log_segment(&self) -> &LogSegment {
         &self.log_segment
+    }
+
+    /// Whether the last applicable incremental build requested ignoring new checkpoints.
+    ///
+    /// This records the build policy, not whether its listing actually found a checkpoint.
+    pub(crate) fn skipped_new_checkpoints(&self) -> bool {
+        self.skipped_new_checkpoints
     }
 
     /// The CRC iff it sits exactly at this snapshot's version. When `Some`, queries backed by the
@@ -994,6 +1015,7 @@ impl Snapshot {
                     self.table_configuration().clone(),
                     Some(crc),
                     self.built_as_latest,
+                    self.skipped_new_checkpoints,
                 )?);
                 Ok((ChecksumWriteResult::Written, new_snapshot))
             }
@@ -1215,6 +1237,7 @@ impl Snapshot {
                 self.table_configuration().clone(),
                 self.crc_at_version().cloned(),
                 self.built_as_latest,
+                false, /* skipped_new_checkpoints */
             )?),
         ))
     }
@@ -1285,6 +1308,7 @@ impl Snapshot {
             self.table_configuration().clone(),
             self.base_crc().cloned(),
             self.built_as_latest,
+            self.skipped_new_checkpoints,
         )?))
     }
 }
@@ -1453,6 +1477,7 @@ mod tests {
             table_cfg,
             None,  /* crc */
             false, /* built_as_latest */
+            false, /* skipped_new_checkpoints */
         )
     }
 
@@ -2278,6 +2303,7 @@ mod tests {
             built.table_configuration().clone(),
             Some(stale_crc),
             false, /* built_as_latest */
+            false, /* skipped_new_checkpoints */
         )
         .unwrap();
         assert!(parent.crc_at_version().is_none());

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -2203,6 +2203,7 @@ mod tests {
             loaded_snapshot.table_configuration().clone(),
             None,
             false,
+            false, /* skipped_new_checkpoints */
         )?;
         store.delete(&delta_path_for_version(0, "json")).await?;
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1345,7 +1345,8 @@ impl<S> Transaction<S> {
                     log_segment,
                     self.effective_table_config,
                     Some(Arc::new(crc)),
-                    true, /* built_as_latest */
+                    true,  /* built_as_latest */
+                    false, /* skipped_new_checkpoints */
                 )?;
                 (stats, Arc::new(snapshot))
             }

--- a/kernel/tests/integration/log/log_tail.rs
+++ b/kernel/tests/integration/log/log_tail.rs
@@ -1,13 +1,18 @@
 use std::sync::Arc;
 
+use delta_kernel::commit_range::CommitRange;
 use delta_kernel::history_manager::{first_version_after, latest_version_as_of, HistoryCommitType};
 use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::{Error, Snapshot};
-use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
+use rstest::rstest;
+use test_utils::delta_kernel_default_engine::executor::tokio::{
+    TokioBackgroundExecutor, TokioMultiThreadExecutor,
+};
 use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use test_utils::{
     actions_to_string, actions_to_string_catalog_managed, add_commit, add_staged_commit,
-    create_log_path, delta_path_for_version, TestAction,
+    create_log_path, delta_path_for_version, install_thread_local_metrics_reporter,
+    CountingReporter, TestAction,
 };
 use url::Url;
 
@@ -19,6 +24,24 @@ fn setup_test() -> (
     let storage = Arc::new(InMemory::new());
     let table_root = Url::parse("memory:///").unwrap();
     let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    (storage, engine, table_root)
+}
+
+fn setup_test_mt() -> (
+    Arc<InMemory>,
+    Arc<DefaultEngine<TokioMultiThreadExecutor>>,
+    Url,
+) {
+    let storage = Arc::new(InMemory::new());
+    let table_root = Url::parse("memory:///").unwrap();
+    let executor = Arc::new(TokioMultiThreadExecutor::new(
+        tokio::runtime::Handle::current(),
+    ));
+    let engine = Arc::new(
+        DefaultEngineBuilder::new(storage.clone())
+            .with_task_executor(executor)
+            .build(),
+    );
     (storage, engine, table_root)
 }
 
@@ -288,9 +311,15 @@ async fn log_tail_behind_filesystem() -> Result<(), Box<dyn std::error::Error>> 
     Ok(())
 }
 
-#[tokio::test]
-async fn incremental_snapshot_with_log_tail() -> Result<(), Box<dyn std::error::Error>> {
-    let (storage, engine, table_url) = setup_test();
+#[rstest]
+#[case::without_checkpoint(false)]
+#[case::with_checkpoint(true)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn incremental_snapshot_skip_new_checkpoints_with_log_tail(
+    #[case] with_checkpoint: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // ===== GIVEN =====
+    let (storage, engine, table_url) = setup_test_mt();
     let table_root = table_url.as_str();
 
     // commits 0, 1, 2 in storage (catalog-managed)
@@ -307,14 +336,29 @@ async fn incremental_snapshot_with_log_tail() -> Result<(), Box<dyn std::error::
     let actions = vec![TestAction::Add("file_2.parquet".to_string())];
     add_commit(table_root, storage.as_ref(), 2, actions_to_string(actions)).await?;
 
-    // initial snapshot at version 1
-    let initial_snapshot = Snapshot::builder_for(table_root)
+    let mut initial_snapshot = Snapshot::builder_for(table_root)
         .at_version(1)
         .with_max_catalog_version(2)
         .build(engine.as_ref())?;
     assert_eq!(initial_snapshot.version(), 1);
+    if with_checkpoint {
+        initial_snapshot.clone().checkpoint(engine.as_ref(), None)?;
+        initial_snapshot = Snapshot::builder_for(table_root)
+            .at_version(1)
+            .with_max_catalog_version(2)
+            .build(engine.as_ref())?;
+        Snapshot::builder_for(table_root)
+            .at_version(2)
+            .with_max_catalog_version(2)
+            .build(engine.as_ref())?
+            .checkpoint(engine.as_ref(), None)?;
+    }
 
-    // add commit 3, 4
+    // Add a published version 3 that the staged catalog commit will supersede.
+    let actions = vec![TestAction::Add("published_file_3.parquet".to_string())];
+    add_commit(table_root, storage.as_ref(), 3, actions_to_string(actions)).await?;
+
+    // The catalog tail overrides the published version 3.
     let actions = vec![TestAction::Add("file_3.parquet".to_string())];
     let path3 =
         add_staged_commit(table_root, storage.as_ref(), 3, actions_to_string(actions)).await?;
@@ -322,21 +366,76 @@ async fn incremental_snapshot_with_log_tail() -> Result<(), Box<dyn std::error::
     let path4 =
         add_staged_commit(table_root, storage.as_ref(), 4, actions_to_string(actions)).await?;
 
-    // log_tail with commits 2, 3, 4
     let log_tail = vec![
         create_log_path(&table_url, delta_path_for_version(2, "json")),
-        create_log_path(&table_url, path3),
-        create_log_path(&table_url, path4),
+        create_log_path(&table_url, path3.clone()),
+        create_log_path(&table_url, path4.clone()),
     ];
 
-    // Build incremental snapshot with log_tail
+    let reporter = Arc::new(CountingReporter::new());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    // ===== WHEN =====
+    // Build from version 1 using the catalog tail while retaining every intervening commit.
     let new_snapshot = Snapshot::builder_from(initial_snapshot)
         .with_log_tail(log_tail)
         .with_max_catalog_version(4)
+        .skip_new_checkpoints()
         .build(engine.as_ref())?;
 
-    // Verify we advanced to version 4
+    // ===== THEN =====
+    // The staged tail wins, all required commits remain available, and listing occurs only once.
     assert_eq!(new_snapshot.version(), 4);
+    assert_eq!(reporter.list_calls.get(), 1);
+    assert_eq!(
+        new_snapshot.log_segment().checkpoint_version,
+        with_checkpoint.then_some(1)
+    );
+    assert_eq!(
+        new_snapshot.log_segment().listed.max_published_version,
+        Some(3)
+    );
+    assert_eq!(
+        new_snapshot
+            .log_segment()
+            .listed
+            .latest_commit_file
+            .as_ref()
+            .map(|file| &file.location.location),
+        Some(&table_url.join(path4.as_ref())?)
+    );
+    let mut expected_commit_paths = if with_checkpoint {
+        Vec::new()
+    } else {
+        vec![
+            table_url.join(delta_path_for_version(0, "json").as_ref())?,
+            table_url.join(delta_path_for_version(1, "json").as_ref())?,
+        ]
+    };
+    expected_commit_paths.extend([
+        table_url.join(delta_path_for_version(2, "json").as_ref())?,
+        table_url.join(path3.as_ref())?,
+        table_url.join(path4.as_ref())?,
+    ]);
+    assert_eq!(
+        new_snapshot
+            .log_segment()
+            .listed
+            .ascending_commit_files
+            .iter()
+            .map(|file| file.location.location.clone())
+            .collect::<Vec<_>>(),
+        expected_commit_paths
+    );
+
+    // ===== WHEN =====
+    let range = CommitRange::builder_from(new_snapshot, 2).build(engine.as_ref())?;
+
+    // ===== THEN =====
+    // Building the range reuses the retained commit metadata without another listing.
+    assert_eq!(range.start_version(), 2);
+    assert_eq!(range.end_version(), 4);
+    assert_eq!(reporter.list_calls.get(), 1);
 
     Ok(())
 }

--- a/kernel/tests/integration/log/snapshot_build.rs
+++ b/kernel/tests/integration/log/snapshot_build.rs
@@ -37,11 +37,11 @@ impl TableKind {
     }
 }
 
-fn maybe_attach_max_catalog_version(
-    builder: SnapshotBuilder,
+fn maybe_attach_max_catalog_version<Mode>(
+    builder: SnapshotBuilder<Mode>,
     max_catalog_version: Version,
     kind: TableKind,
-) -> SnapshotBuilder {
+) -> SnapshotBuilder<Mode> {
     match kind {
         TableKind::FileSystem => builder,
         TableKind::CatalogManaged => builder.with_max_catalog_version(max_catalog_version),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Note to reviewers: Please don't be intimidated by the 700+ LOC size of this PR. It's about 55% test code, 25% prod code, with the rest comments/blank lines.

Incremental snapshot updates normally adopt a newer checkpoint, which removes commit-file metadata covered by that checkpoint from the snapshot. Conflict rebasing instead needs every winning commit since the transaction's read snapshot.

For example, a transaction may read snapshot N and attempt to commit at N+1, while commits N+1 through N+5 win first. If a checkpoint exists at N+3, adopting it hides the N+1 and N+2 commit files needed for conflict analysis.

This adds `IncrementalSnapshotBuilder::skip_new_checkpoints()`. The opt-in mode still discovers checkpoints, but retains the input snapshot's checkpoint and every contiguous commit after it. `CommitRange::builder_from` can then inspect the complete winning range without listing the log again. Default incremental updates continue to adopt useful checkpoints.

Full scans warn when retained history may require extra log replay, and writing a checkpoint clears that state. 

### This PR affects the following public APIs

- Adds the `IncrementalSnapshotBuilder` alias and its `skip_new_checkpoints()` method.
- Adds a source-mode type parameter to `SnapshotBuilder`; `Snapshot::builder_from` now returns
  `IncrementalSnapshotBuilder`.

## How was this change tested?

- Added unit coverage for checkpoint retention, repeated updates, missing commit history, scan warnings, and incremental CRC replay.
- Added integration coverage for catalog-provided log tails and snapshot-derived commit ranges that reuse the original listing.
- Ran `cargo +nightly fmt --check`, workspace clippy with all features and warnings denied, and workspace documentation checks.

