### PR TITLE
feat!: add row tracking metadata ackowledgement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,9 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
   in development). Gates `KernelSupport` for the `geospatial` reader+writer feature: with the
   cargo feature off, any table listing it is rejected; with it on, scans and CDF are supported
   but writes are still blocked.
+- `row-tracking-preservation-in-dev`: enables `Transaction::ack_row_tracking_preservation()` and
+  acknowledged file removals and deletion-vector updates on Row Tracking tables. This remains
+  experimental until Kernel emits `delta.rowTracking.preserved` in CommitInfo tags.
 - `internal-api`: unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
 - `declarative-plans`: experimental declarative-plan IR (`kernel/src/plans/`) and the prost

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -132,6 +132,9 @@ adaptive-metadata-in-dev = []
 # Experimental, temporary, test-only feature flag guarding the in-progress geospatial
 # (geometry/geography) type work. TODO(#2949): remove once full geo support ships.
 geo-type-in-dev = []
+# Experimental feature flag guarding Row Tracking preservation for file removals and
+# deletion-vector updates. TODO(#3227): remove once preservation support is ready.
+row-tracking-preservation-in-dev = []
 
 # Enables shared Arrow-based engine support modules (arrow_data, arrow_expression,
 # ensure_data_types, parquet_row_group_skipping). Used by the delta_kernel_default_engine crate

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -133,7 +133,8 @@ adaptive-metadata-in-dev = []
 # (geometry/geography) type work. TODO(#2949): remove once full geo support ships.
 geo-type-in-dev = []
 # Experimental feature flag guarding Row Tracking preservation for file removals and
-# deletion-vector updates. TODO(#3227): remove once preservation support is ready.
+# deletion-vector updates. TODO(#3227): remove the flag and emit `delta.rowTracking.preserved` in
+# CommitInfo tags when preservation support is ready.
 row-tracking-preservation-in-dev = []
 
 # Enables shared Arrow-based engine support modules (arrow_data, arrow_expression,

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -922,17 +922,15 @@ impl TableConfiguration {
         self.is_feature_enabled(&TableFeature::IcebergCompatV3)
     }
 
-    /// TODO(#2538): Row-tracking is not fully supported for removeFile currently.
-    /// See `crate::table_features::ROW_TRACKING_INFO` for more details.
     pub(crate) fn validate_feature_support_for_remove(&self) -> DeltaResult<()> {
-        // RowTracking is a prerequisite for IcebergCompatV3, so the IcebergCompatV3 arm is
-        // technically redundant. Just be conservative here to check both.
-        if self.should_write_row_tracking() {
-            return Err(Error::unsupported(
+        #[cfg(not(feature = "row-tracking-preservation-in-dev"))]
+        require!(
+            !self.should_write_row_tracking(),
+            Error::unsupported(
                 "Remove actions are not yet supported on tables with rowTracking supported \
                  and not suspended",
-            ));
-        }
+            )
+        );
         if self.is_feature_enabled(&TableFeature::IcebergCompatV3) {
             return Err(Error::unsupported(
                 "Remove actions are not yet supported on tables with icebergCompatV3 enabled",
@@ -958,10 +956,12 @@ mod test {
         ColumnMappingMode, FeatureType, Operation, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
         TABLE_FEATURES_MIN_WRITER_VERSION,
     };
+    #[cfg(not(feature = "row-tracking-preservation-in-dev"))]
+    use crate::table_properties::ROW_TRACKING_SUSPENDED;
     use crate::table_properties::{
         TableProperties, ENABLE_DELETION_VECTORS, ENABLE_ICEBERG_COMPAT_V1,
         ENABLE_ICEBERG_COMPAT_V2, ENABLE_ICEBERG_COMPAT_V3, ENABLE_IN_COMMIT_TIMESTAMPS,
-        ENABLE_ROW_TRACKING, ROW_TRACKING_SUSPENDED,
+        ENABLE_ROW_TRACKING,
     };
     use crate::unit_test_utils::{
         assert_result_error_with_message, test_schema_flat, test_schema_flat_with_column_mapping,
@@ -2875,6 +2875,37 @@ mod test {
         );
     }
 
+    #[cfg(feature = "row-tracking-preservation-in-dev")]
+    #[rstest]
+    #[case::iceberg_compat_v3_supported(&[], None)]
+    #[case::iceberg_compat_v3_enabled(
+        &[
+            (ENABLE_ICEBERG_COMPAT_V3, "true"),
+            (ENABLE_ROW_TRACKING, "true"),
+        ],
+        Some("icebergCompatV3"),
+    )]
+    fn validate_feature_support_for_remove_respects_iceberg_compat_v3_enablement(
+        #[case] properties: &[(&str, &str)],
+        #[case] expected_error: Option<&str>,
+    ) {
+        let config = MockTableConfigurationBuilder::new()
+            .with_properties(properties)
+            .with_protocol(
+                MockProtocolBuilder::new()
+                    .with_features([TableFeature::IcebergCompatV3, TableFeature::RowTracking])
+                    .build(),
+            )
+            .build();
+        let result = config.validate_feature_support_for_remove();
+        if let Some(expected_error) = expected_error {
+            assert_result_error_with_message(result, expected_error);
+        } else {
+            assert!(result.is_ok(), "expected Ok, got {result:?}");
+        }
+    }
+
+    #[cfg(not(feature = "row-tracking-preservation-in-dev"))]
     /// `validate_feature_support_for_remove` must fire whenever row tracking is _supported_
     /// and not _suspended_, which is broader than _enabled_.
     #[rstest]

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -371,12 +371,9 @@ static IN_COMMIT_TIMESTAMP_INFO: FeatureInfo = FeatureInfo {
     }),
 };
 
-// TODO(#2538): Currently we reject `Transaction::commit` when it contains staged remove-file
-// actions on RowTracking-supported (and not-suspended) tables because
-//   1. kernel does not yet materialize stable row IDs / commit versions on write, which blocks COW
-//      rewrites,
-//   2. kernel does not yet validate if remove actions correctly reserved row IDs / commit versions.
-// Unblock after both 1 and 2 are supported.
+// Row Tracking rewrites require connectors to preserve stable row metadata. Kernel records the
+// feature-gated acknowledgment but does not validate materialized values. IcebergCompatV3 removals
+// remain unsupported.
 //
 // TODO: When kernel writes the materialized `row_id` / `row_commit_version` columns, they must
 // use the reserved parquet field IDs defined by the protocol on IcebergCompatV3 tables, not

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -68,6 +68,8 @@ impl AlterTableTransaction {
             user_domain_removals: vec![],
             data_change: false,
             column_defaults_acknowledged: false,
+            #[cfg(feature = "row-tracking-preservation-in-dev")]
+            row_tracking_preservation_acknowledged: false,
             engine_commit_info: None,
             // TODO(#2446): match delta-spark's per-op isBlindAppend policy
             // (ADD/DROP/DROP NOT NULL -> true, SET NOT NULL -> false). Hardcoded false for

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -171,6 +171,8 @@ impl CreateTableTransaction {
             user_domain_removals: vec![],
             data_change: true,
             column_defaults_acknowledged: false,
+            #[cfg(feature = "row-tracking-preservation-in-dev")]
+            row_tracking_preservation_acknowledged: false,
             engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -244,6 +244,10 @@ pub struct Transaction<S = ExistingTable> {
     // handling. Whether the connector acknowledged responsibility for applying column
     // defaults.
     column_defaults_acknowledged: bool,
+    // Whether the connector acknowledged responsibility for preserving Row IDs and Row Commit
+    // Versions.
+    #[cfg(feature = "row-tracking-preservation-in-dev")]
+    row_tracking_preservation_acknowledged: bool,
     // Whether this transaction should be marked as a blind append.
     is_blind_append: bool,
     // Files matched by update_deletion_vectors() with new DV descriptors appended. These are used
@@ -356,7 +360,14 @@ impl<S> Transaction<S> {
     pub fn commit(self, engine: &dyn Engine) -> DeltaResult<CommitResult<S>> {
         let commit_start = Instant::now();
 
-        // Some table features don't yet support removeFiles. Reject here.
+        #[cfg(feature = "row-tracking-preservation-in-dev")]
+        if !self.remove_files_metadata.is_empty() || self.num_dv_updates > 0 {
+            self.effective_table_config
+                .validate_feature_support_for_remove()?;
+            self.ensure_row_tracking_preservation_acknowledged()?;
+        }
+
+        #[cfg(not(feature = "row-tracking-preservation-in-dev"))]
         if !self.remove_files_metadata.is_empty() {
             self.effective_table_config
                 .validate_feature_support_for_remove()?;
@@ -852,6 +863,26 @@ impl<S> Transaction<S> {
             Error::invalid_transaction_state(
                 "Writing data to a table with column defaults requires calling \
                  Transaction::ack_column_defaults() first",
+            )
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "row-tracking-preservation-in-dev")]
+    fn ensure_row_tracking_preservation_acknowledged(&self) -> DeltaResult<()> {
+        if !self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::RowTracking)
+        {
+            return Ok(());
+        }
+        require!(
+            self.row_tracking_preservation_acknowledged,
+            Error::invalid_transaction_state(
+                "Data manipulation on a table with Row Tracking enabled requires preserving stable \
+                 Row IDs for copied or updated rows and stable Row Commit Versions for copied \
+                 rows. If you applied these rules correctly, acknowledge this by calling \
+                 Transaction::ack_row_tracking_preservation() before committing",
             )
         );
         Ok(())

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -361,6 +361,8 @@ impl<S> Transaction<S> {
         let commit_start = Instant::now();
 
         #[cfg(feature = "row-tracking-preservation-in-dev")]
+        // Kernel cannot distinguish Remove actions and DV updates that only delete rows from those
+        // that accompany copied or updated rows, so both require the preservation acknowledgment.
         if !self.remove_files_metadata.is_empty() || self.num_dv_updates > 0 {
             self.effective_table_config
                 .validate_feature_support_for_remove()?;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -881,8 +881,7 @@ impl<S> Transaction<S> {
             Error::invalid_transaction_state(
                 "Data manipulation on a table with Row Tracking enabled requires preserving stable \
                  Row IDs for copied or updated rows and stable Row Commit Versions for copied \
-                 rows. If you applied these rules correctly, acknowledge this by calling \
-                 Transaction::ack_row_tracking_preservation() before committing",
+                 rows. See Transaction::ack_row_tracking_preservation() for more details",
             )
         );
         Ok(())

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -105,6 +105,8 @@ impl Transaction {
             user_domain_removals: vec![],
             data_change: true,
             column_defaults_acknowledged: false,
+            #[cfg(feature = "row-tracking-preservation-in-dev")]
+            row_tracking_preservation_acknowledged: false,
             engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],
@@ -146,6 +148,16 @@ impl Transaction {
     pub fn with_domain_metadata_removed(mut self, domain: String) -> Self {
         self.user_domain_removals.push(domain);
         self
+    }
+
+    /// Acknowledges that the connector preserved stable Row IDs for copied and updated rows and
+    /// stable Row Commit Versions for copied rows.
+    ///
+    /// Call this before committing file removals or deletion-vector updates on tables with Row
+    /// Tracking enabled.
+    #[cfg(feature = "row-tracking-preservation-in-dev")]
+    pub fn ack_row_tracking_preservation(&mut self) {
+        self.row_tracking_preservation_acknowledged = true;
     }
 
     /// Remove files from the table in this transaction. This API generally enables the engine to

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -161,6 +161,9 @@ impl Transaction {
     ///
     /// See [Row Tracking] in the Delta protocol for more details.
     ///
+    /// Kernel does not validate rewritten files or materialized values. Calling this method asserts
+    /// that the connector has satisfied these requirements.
+    ///
     /// The Delta protocol specifies this preservation as a SHOULD requirement. Kernel requires it
     /// for compatibility.
     ///

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -150,11 +150,24 @@ impl Transaction {
         self
     }
 
-    /// Acknowledges that the connector preserved stable Row IDs for copied and updated rows and
-    /// stable Row Commit Versions for copied rows.
+    /// Acknowledges that the connector correctly preserves Stable Row IDs and Stable Row Commit
+    /// Versions. That is:
     ///
-    /// Call this before committing file removals or deletion-vector updates on tables with Row
-    /// Tracking enabled.
+    /// - Copied or updated rows retain their Stable Row IDs.
+    /// - Copied rows retain their Stable Row Commit Versions.
+    /// - The connector preserves these values in the materialized Row ID and Row Commit Version
+    ///   columns.
+    /// - The connector also satisfies all protocol MUST requirements for those columns.
+    ///
+    /// See [Row Tracking] in the Delta protocol for more details.
+    ///
+    /// The Delta protocol specifies this preservation as a SHOULD requirement. Kernel requires it
+    /// for compatibility.
+    ///
+    /// This acknowledgment is required before committing Remove actions or deletion-vector updates
+    /// on tables with Row Tracking enabled.
+    ///
+    /// [Row Tracking]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#row-tracking
     #[cfg(feature = "row-tracking-preservation-in-dev")]
     pub fn ack_row_tracking_preservation(&mut self) {
         self.row_tracking_preservation_acknowledged = true;

--- a/kernel/tests/integration/common/read_utils.rs
+++ b/kernel/tests/integration/common/read_utils.rs
@@ -1,10 +1,33 @@
 //! Shared read helpers for integration tests.
 
 use std::fs::File;
+use std::sync::Arc;
 
 use delta_kernel::arrow::array::RecordBatch;
 use delta_kernel::arrow::compute::concat_batches;
 use delta_kernel::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use delta_kernel::schema::MetadataColumnSpec;
+use delta_kernel::{DeltaResult, Engine, Snapshot};
+use test_utils::read_scan;
+
+/// Reads table data with the requested Row Tracking metadata columns.
+pub fn read_row_tracking_scan(
+    snapshot: Arc<Snapshot>,
+    engine: Arc<dyn Engine>,
+    metadata_columns: impl IntoIterator<Item = MetadataColumnSpec>,
+) -> DeltaResult<Vec<RecordBatch>> {
+    let scan_schema = metadata_columns.into_iter().try_fold(
+        snapshot.schema().as_ref().clone(),
+        |schema, metadata_column| {
+            schema.add_metadata_column(metadata_column.text_value(), metadata_column)
+        },
+    )?;
+    let scan = snapshot
+        .scan_builder()
+        .with_schema(Arc::new(scan_schema))
+        .build()?;
+    read_scan(&scan, engine)
+}
 
 pub fn read_parquet_file(path: &std::path::Path) -> RecordBatch {
     let file = File::open(path).expect("failed to open parquet file");

--- a/kernel/tests/integration/features/mod.rs
+++ b/kernel/tests/integration/features/mod.rs
@@ -8,4 +8,4 @@ mod dv;
 mod iceberg_compat;
 mod interval;
 mod maintenance_ops;
-mod row_tracking;
+pub(crate) mod row_tracking;

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -31,6 +31,7 @@ use test_utils::{
 };
 use url::Url;
 
+use crate::common::read_utils::read_row_tracking_scan;
 use crate::common::write_utils::{
     create_dv_update_transaction, get_scan_files, set_table_properties,
     write_deletion_vector_to_store,
@@ -128,7 +129,7 @@ async fn setup_number_table(
 
 /// Helper function to create a row-tracking table with a single `number: INTEGER` column and
 /// additional features enabled.
-async fn setup_number_table_with_features(
+pub(crate) async fn setup_number_table_with_features(
     tmp_dir: &TempDir,
     name: &str,
     extra_reader_writer_features: &[&str],
@@ -858,32 +859,18 @@ async fn test_no_row_tracking_fields_without_feature() -> DeltaResult<()> {
     Ok(())
 }
 
-fn read_row_tracking_scan(
-    snapshot: Arc<Snapshot>,
-    engine: Arc<dyn delta_kernel::Engine>,
-    metadata_column: MetadataColumnSpec,
-) -> DeltaResult<Vec<RecordBatch>> {
-    let scan_schema = Arc::new(
-        snapshot
-            .schema()
-            .add_metadata_column(metadata_column.text_value(), metadata_column)?,
-    );
-    let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
-    read_scan(&scan, engine)
-}
-
 fn read_row_id_scan(
     snapshot: Arc<Snapshot>,
     engine: Arc<dyn delta_kernel::Engine>,
 ) -> DeltaResult<Vec<RecordBatch>> {
-    read_row_tracking_scan(snapshot, engine, MetadataColumnSpec::RowId)
+    read_row_tracking_scan(snapshot, engine, [MetadataColumnSpec::RowId])
 }
 
 fn read_row_commit_version_scan(
     snapshot: Arc<Snapshot>,
     engine: Arc<dyn delta_kernel::Engine>,
 ) -> DeltaResult<Vec<RecordBatch>> {
-    read_row_tracking_scan(snapshot, engine, MetadataColumnSpec::RowCommitVersion)
+    read_row_tracking_scan(snapshot, engine, [MetadataColumnSpec::RowCommitVersion])
 }
 
 /// Basic read: write one file with 3 rows, verify row IDs are sequential starting from 0.
@@ -1216,7 +1203,7 @@ async fn test_read_row_tracking_metadata_stable_across_deletion_vector_update(
     let column_name = metadata_column.text_value();
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let before = collect_number_to_column(
-        &read_row_tracking_scan(snapshot.clone(), engine.clone(), metadata_column)?,
+        &read_row_tracking_scan(snapshot.clone(), engine.clone(), [metadata_column])?,
         column_name,
     );
     let expected_before = (100..110)
@@ -1259,11 +1246,13 @@ async fn test_read_row_tracking_metadata_stable_across_deletion_vector_update(
             .into_iter()
             .map(Ok),
     )?;
+    #[cfg(feature = "row-tracking-preservation-in-dev")]
+    txn.ack_row_tracking_preservation();
     txn.commit(engine.as_ref())?.unwrap_committed();
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let after = collect_number_to_column(
-        &read_row_tracking_scan(snapshot, engine.clone(), metadata_column)?,
+        &read_row_tracking_scan(snapshot, engine.clone(), [metadata_column])?,
         column_name,
     );
 

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -1454,6 +1454,8 @@ async fn test_v2_sidecar_preserves_dv_and_row_tracking_on_add(
         HashMap::from([(path, dv.clone())]),
         scan_files.into_iter().map(Ok),
     )?;
+    #[cfg(feature = "row-tracking-preservation-in-dev")]
+    txn.ack_row_tracking_preservation();
     let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
 
     // === Step 4: Write a V2 sidecar checkpoint. ===

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -148,6 +148,8 @@ mod row_tracking_preservation {
     }
 
     impl RemoveTestCase {
+        // Each pair is a table property name/value used to create the test table. Acknowledgment is
+        // transaction state, so acknowledged and unacknowledged cases share table properties.
         fn create_table_properties(self) -> &'static [(&'static str, &'static str)] {
             match self {
                 Self::EnabledUnacknowledged | Self::EnabledAcknowledged => {
@@ -174,7 +176,7 @@ mod row_tracking_preservation {
                 || self == Self::IcebergCompatV3EnabledAcknowledged
         }
 
-        fn expected_error(self) -> Option<&'static str> {
+        fn expects_error(self) -> Option<&'static str> {
             match self {
                 Self::EnabledUnacknowledged => Some("Transaction::ack_row_tracking_preservation()"),
                 Self::IcebergCompatV3EnabledUnacknowledged
@@ -248,7 +250,7 @@ mod row_tracking_preservation {
         }
 
         // === Commit and verify the result ===
-        if let Some(expected_error) = test_case.expected_error() {
+        if let Some(expected_error) = test_case.expects_error() {
             assert_result_error_with_message(txn.commit(engine.as_ref()), expected_error);
         } else {
             let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -10,14 +10,20 @@ use delta_kernel::schema::{schema_ref, MetadataColumnSpec};
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
 use delta_kernel::transaction::RowTrackingMetadataColumns;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
+#[cfg(feature = "row-tracking-preservation-in-dev")]
+use test_utils::read_scan;
 use test_utils::{
-    assert_result_error_with_message, insert_data, into_record_batch, read_scan, test_table_setup,
+    assert_result_error_with_message, insert_data, into_record_batch, test_table_setup,
     test_table_setup_mt,
 };
+#[cfg(not(feature = "row-tracking-preservation-in-dev"))]
 use url::Url;
 
+use crate::common::read_utils::read_row_tracking_scan;
+#[cfg(not(feature = "row-tracking-preservation-in-dev"))]
 use crate::common::write_utils::set_table_properties;
 
+#[cfg(not(feature = "row-tracking-preservation-in-dev"))]
 /// `Transaction::commit` is rejected when it contains staged removeFiles and row
 /// tracking is _supported_ and not _suspended_, which is broader than _enabled_.
 #[rstest::rstest]
@@ -75,7 +81,7 @@ async fn test_row_tracking_remove_gate(
     };
 
     // Insert a file.
-    test_utils::insert_data(
+    insert_data(
         initial_snapshot,
         &engine,
         vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
@@ -109,6 +115,468 @@ async fn test_row_tracking_remove_gate(
         txn.commit(engine.as_ref())?.unwrap_committed();
     }
     Ok(())
+}
+
+#[cfg(feature = "row-tracking-preservation-in-dev")]
+mod row_tracking_preservation {
+    use std::collections::HashMap;
+
+    use delta_kernel::actions::deletion_vector_writer::KernelDeletionVector;
+    use delta_kernel::arrow::array::Array;
+    use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
+    use test_utils::delta_kernel_default_engine::DefaultEngine;
+    use test_utils::read_add_infos;
+    use url::Url;
+
+    use super::*;
+    use crate::common::read_utils::read_parquet_file;
+    use crate::common::write_utils::{
+        create_dv_update_transaction, get_scan_files, set_table_properties,
+        write_deletion_vector_to_store,
+    };
+    use crate::features::row_tracking::setup_number_table_with_features;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum RemoveTestCase {
+        EnabledUnacknowledged,
+        EnabledAcknowledged,
+        SupportedUnacknowledged,
+        SuspendedUnacknowledged,
+        IcebergCompatV3SupportedAcknowledged,
+        IcebergCompatV3EnabledUnacknowledged,
+        IcebergCompatV3EnabledAcknowledged,
+    }
+
+    impl RemoveTestCase {
+        fn create_table_properties(self) -> &'static [(&'static str, &'static str)] {
+            match self {
+                Self::EnabledUnacknowledged | Self::EnabledAcknowledged => {
+                    &[("delta.enableRowTracking", "true")]
+                }
+                Self::SupportedUnacknowledged | Self::SuspendedUnacknowledged => {
+                    &[("delta.feature.rowTracking", "supported")]
+                }
+                Self::IcebergCompatV3SupportedAcknowledged => &[
+                    ("delta.enableRowTracking", "true"),
+                    ("delta.columnMapping.mode", "name"),
+                    ("delta.feature.icebergCompatV3", "supported"),
+                ],
+                Self::IcebergCompatV3EnabledUnacknowledged
+                | Self::IcebergCompatV3EnabledAcknowledged => {
+                    &[("delta.enableIcebergCompatV3", "true")]
+                }
+            }
+        }
+
+        fn acknowledges_preservation(self) -> bool {
+            self == Self::EnabledAcknowledged
+                || self == Self::IcebergCompatV3SupportedAcknowledged
+                || self == Self::IcebergCompatV3EnabledAcknowledged
+        }
+
+        fn expected_error(self) -> Option<&'static str> {
+            match self {
+                Self::EnabledUnacknowledged => Some("Transaction::ack_row_tracking_preservation()"),
+                Self::IcebergCompatV3EnabledUnacknowledged
+                | Self::IcebergCompatV3EnabledAcknowledged => Some("icebergCompatV3"),
+                _ => None,
+            }
+        }
+    }
+
+    #[rstest::rstest]
+    #[case::enabled_without_acknowledgment(RemoveTestCase::EnabledUnacknowledged)]
+    #[case::enabled_with_acknowledgment(RemoveTestCase::EnabledAcknowledged)]
+    #[case::supported_without_acknowledgment(RemoveTestCase::SupportedUnacknowledged)]
+    #[case::suspended_without_acknowledgment(RemoveTestCase::SuspendedUnacknowledged)]
+    #[case::iceberg_compat_v3_supported_with_acknowledgment(
+        RemoveTestCase::IcebergCompatV3SupportedAcknowledged
+    )]
+    #[case::iceberg_compat_v3_enabled_without_acknowledgment(
+        RemoveTestCase::IcebergCompatV3EnabledUnacknowledged
+    )]
+    #[case::iceberg_compat_v3_enabled_with_acknowledgment(
+        RemoveTestCase::IcebergCompatV3EnabledAcknowledged
+    )]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remove_files_requires_row_tracking_preservation_acknowledgment(
+        #[case] test_case: RemoveTestCase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+        let schema = schema_ref! { nullable "number": INTEGER };
+        let table_url = Url::from_directory_path(&table_path).unwrap();
+        kernel_create_table(table_path.as_str(), schema.clone(), "Test/1.0")
+            .with_table_properties(test_case.create_table_properties().iter().copied())
+            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+            .commit(engine.as_ref())?
+            .unwrap_committed();
+
+        let initial_snapshot = if test_case == RemoveTestCase::SuspendedUnacknowledged {
+            set_table_properties(
+                &table_path,
+                &table_url,
+                engine.as_ref(),
+                0, /* current_version */
+                &[("delta.rowTrackingSuspended", "true")],
+            )?
+        } else {
+            Snapshot::builder_for(&table_path).build(engine.as_ref())?
+        };
+        insert_data(
+            initial_snapshot,
+            &engine,
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .await?
+        .unwrap_committed();
+
+        let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+        let scan = snapshot.clone().scan_builder().build()?;
+        let scan_files = scan
+            .scan_metadata(engine.as_ref())?
+            .next()
+            .unwrap()?
+            .scan_files;
+        let mut txn = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_data_change(true);
+        txn.remove_files(scan_files);
+        if test_case.acknowledges_preservation() {
+            txn.ack_row_tracking_preservation();
+        }
+
+        if let Some(expected_error) = test_case.expected_error() {
+            assert_result_error_with_message(txn.commit(engine.as_ref()), expected_error);
+        } else {
+            let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+            let scan = snapshot.scan_builder().build()?;
+            let row_count: usize = read_scan(&scan, engine)?
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum();
+            assert_eq!(row_count, 0);
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deletion_vector_update_requires_preservation_acknowledgment(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir()?;
+        let (_schema, table_url, engine, store) = setup_number_table_with_features(
+            &tmp_dir,
+            "dv_update_without_preservation_acknowledgment",
+            &["deletionVectors"],
+            &[],
+        )
+        .await?;
+        let snapshot = Snapshot::builder_for(&table_url).build(engine.as_ref())?;
+        let snapshot = insert_data(
+            snapshot,
+            &engine,
+            vec![Arc::new(Int32Array::from(vec![1, 2]))],
+        )
+        .await?
+        .unwrap_post_commit_snapshot();
+
+        let mut txn = create_dv_update_transaction(&table_url, engine.as_ref())?;
+        let write_context = txn.write_state()?.write_context_builder().build()?;
+        let mut deletion_vector = KernelDeletionVector::new();
+        deletion_vector.add_deleted_row_indexes([0]);
+        let descriptor =
+            write_deletion_vector_to_store(&store, &write_context, deletion_vector, "").await?;
+        let file_path = read_add_infos(snapshot.as_ref(), engine.as_ref())?[0]
+            .path
+            .clone();
+        txn.update_deletion_vectors(
+            HashMap::from([(file_path, descriptor)]),
+            get_scan_files(snapshot, engine.as_ref())?
+                .into_iter()
+                .map(Ok),
+        )?;
+
+        assert_result_error_with_message(
+            txn.commit(engine.as_ref()),
+            "Transaction::ack_row_tracking_preservation()",
+        );
+        Ok(())
+    }
+
+    #[rstest::rstest]
+    #[case::minimum_feature_set(&[("delta.enableRowTracking", "true")])]
+    #[case::maximum_feature_set(&[
+        ("delta.columnMapping.mode", "name"),
+        ("delta.enableDeletionVectors", "true"),
+        ("delta.enableRowTracking", "true"),
+        ("delta.feature.domainMetadata", "supported"),
+        ("delta.enableInCommitTimestamps", "true"),
+        ("delta.feature.v2Checkpoint", "supported"),
+        ("delta.feature.vacuumProtocolCheck", "supported"),
+        ("delta.enableChangeDataFeed", "true"),
+        ("delta.feature.icebergCompatV3", "supported"),
+    ])]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn optimize_preserves_row_tracking_metadata_in_data_and_checkpoint(
+        #[case] table_properties: &[(&str, &str)],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // === Write two source files ===
+        let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+        let schema = schema_ref! { nullable "number": INTEGER };
+        let snapshot = kernel_create_table(table_path.as_str(), schema, "Test/1.0")
+            .with_table_properties(table_properties.iter().copied())
+            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
+        let snapshot = insert_data(
+            snapshot,
+            &engine,
+            vec![Arc::new(Int32Array::from(vec![10, 20]))],
+        )
+        .await?
+        .unwrap_post_commit_snapshot();
+        let source_snapshot = insert_data(
+            snapshot,
+            &engine,
+            vec![Arc::new(Int32Array::from(vec![30, 40, 50]))],
+        )
+        .await?
+        .unwrap_post_commit_snapshot();
+
+        // === Read and merge the source files ===
+        let source_batches = read_row_tracking_scan(
+            source_snapshot.clone(),
+            engine.clone(),
+            [
+                MetadataColumnSpec::RowId,
+                MetadataColumnSpec::RowCommitVersion,
+            ],
+        )?;
+        let source_schema = source_batches
+            .first()
+            .expect("source scan must return data")
+            .schema();
+        let merged_batch = concat_batches(&source_schema, &source_batches)?;
+        let expected_rows = vec![(10, 0, 1), (20, 1, 1), (30, 2, 2), (40, 3, 2), (50, 4, 2)];
+        assert_eq!(
+            collect_rows(
+                std::slice::from_ref(&merged_batch),
+                "number",
+                "row_id",
+                "row_commit_version",
+            ),
+            expected_rows
+        );
+
+        // === Rewrite the rows into one file ===
+        let optimized_snapshot =
+            rewrite_preserving_row_tracking(source_snapshot, &engine, merged_batch).await?;
+        let optimize_version = optimized_snapshot.version();
+
+        let optimized_batches = read_row_tracking_scan(
+            optimized_snapshot.clone(),
+            engine.clone(),
+            [
+                MetadataColumnSpec::RowId,
+                MetadataColumnSpec::RowCommitVersion,
+            ],
+        )?;
+        assert_eq!(
+            collect_rows(&optimized_batches, "number", "row_id", "row_commit_version",),
+            expected_rows
+        );
+
+        // === Checkpoint the OPTIMIZE commit ===
+        optimized_snapshot.checkpoint(engine.as_ref(), None)?;
+        let checkpoint_path = std::path::Path::new(&table_path)
+            .join("_delta_log")
+            .join(format!("{optimize_version:020}.checkpoint.parquet"));
+        let checkpoint = read_parquet_file(&checkpoint_path);
+        assert_eq!(
+            collect_checkpoint_row_tracking_metadata(&checkpoint, "add"),
+            vec![(5, 3)]
+        );
+        assert_eq!(
+            collect_checkpoint_row_tracking_metadata(&checkpoint, "remove"),
+            vec![(0, 1), (2, 2)]
+        );
+
+        let checkpoint_snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+        assert_eq!(
+            collect_rows(
+                &read_row_tracking_scan(
+                    checkpoint_snapshot,
+                    engine.clone(),
+                    [
+                        MetadataColumnSpec::RowId,
+                        MetadataColumnSpec::RowCommitVersion,
+                    ],
+                )?,
+                "number",
+                "row_id",
+                "row_commit_version",
+            ),
+            expected_rows
+        );
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn optimize_preserves_row_tracking_metadata_after_deletion_vector_update(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // === Write the source file ===
+        let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+        let table_url = Url::from_directory_path(&table_path).unwrap();
+        let snapshot = kernel_create_table(
+            table_path.as_str(),
+            schema_ref! { nullable "number": INTEGER },
+            "Test/1.0",
+        )
+        .with_table_properties([
+            ("delta.enableDeletionVectors", "true"),
+            ("delta.enableRowTracking", "true"),
+        ])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+        let source_snapshot = insert_data(
+            snapshot,
+            &engine,
+            vec![Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50]))],
+        )
+        .await?
+        .unwrap_post_commit_snapshot();
+
+        // === Delete rows 20 and 40 with a deletion vector ===
+        let mut txn = source_snapshot
+            .clone()
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_operation("DELETE".to_string());
+        let write_context = txn.write_state()?.write_context_builder().build()?;
+        let mut deletion_vector = KernelDeletionVector::new();
+        deletion_vector.add_deleted_row_indexes([1, 3]);
+        let store = engine
+            .get_object_store_for_url(&table_url)
+            .expect("default engine must expose its object store");
+        let descriptor =
+            write_deletion_vector_to_store(&store, &write_context, deletion_vector, "").await?;
+        let file_path = read_add_infos(source_snapshot.as_ref(), engine.as_ref())?[0]
+            .path
+            .clone();
+        txn.update_deletion_vectors(
+            HashMap::from([(file_path, descriptor)]),
+            get_scan_files(source_snapshot, engine.as_ref())?
+                .into_iter()
+                .map(Ok),
+        )?;
+        txn.ack_row_tracking_preservation();
+        let deletion_vector_snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+
+        // === Read and merge the surviving rows ===
+        let survivor_batches = read_row_tracking_scan(
+            deletion_vector_snapshot.clone(),
+            engine.clone(),
+            [
+                MetadataColumnSpec::RowId,
+                MetadataColumnSpec::RowCommitVersion,
+            ],
+        )?;
+        let survivor_schema = survivor_batches
+            .first()
+            .expect("deletion vector scan must return data")
+            .schema();
+        let merged_batch = concat_batches(&survivor_schema, &survivor_batches)?;
+        let expected_rows = vec![(10, 0, 1), (30, 2, 1), (50, 4, 1)];
+        assert_eq!(
+            collect_rows(
+                std::slice::from_ref(&merged_batch),
+                "number",
+                "row_id",
+                "row_commit_version",
+            ),
+            expected_rows
+        );
+
+        // === Rewrite the surviving rows into a file without a deletion vector ===
+        let optimized_snapshot =
+            rewrite_preserving_row_tracking(deletion_vector_snapshot, &engine, merged_batch)
+                .await?;
+
+        // === Verify the OPTIMIZE result ===
+        let optimized_batches = read_row_tracking_scan(
+            optimized_snapshot,
+            engine,
+            [
+                MetadataColumnSpec::RowId,
+                MetadataColumnSpec::RowCommitVersion,
+            ],
+        )?;
+        assert_eq!(
+            collect_rows(&optimized_batches, "number", "row_id", "row_commit_version",),
+            expected_rows
+        );
+        Ok(())
+    }
+
+    async fn rewrite_preserving_row_tracking(
+        snapshot: Arc<Snapshot>,
+        engine: &Arc<DefaultEngine<TokioMultiThreadExecutor>>,
+        batch: RecordBatch,
+    ) -> DeltaResult<Arc<Snapshot>> {
+        let source_files = get_scan_files(snapshot.clone(), engine.as_ref())?;
+        let mut txn = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_operation("OPTIMIZE".to_string())
+            .with_data_change(false);
+        let write_context = txn
+            .write_state()?
+            .write_context_builder()
+            .with_row_tracking_columns(RowTrackingMetadataColumns {
+                row_id_col_name: Some("row_id"),
+                row_commit_version_col_name: Some("row_commit_version"),
+            })
+            .build()?;
+        txn.add_files(
+            engine
+                .write_parquet(&ArrowEngineData::new(batch), &write_context)
+                .await?,
+        );
+        for files in source_files {
+            txn.remove_files(files);
+        }
+        txn.ack_row_tracking_preservation();
+        Ok(txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot())
+    }
+
+    fn collect_checkpoint_row_tracking_metadata(
+        checkpoint: &RecordBatch,
+        action_name: &str,
+    ) -> Vec<(i64, i64)> {
+        let actions = checkpoint
+            .column_by_name(action_name)
+            .unwrap_or_else(|| panic!("{action_name} column not found"))
+            .as_struct();
+        let base_row_ids = actions
+            .column_by_name("baseRowId")
+            .unwrap_or_else(|| panic!("{action_name}.baseRowId column not found"))
+            .as_primitive::<Int64Type>();
+        let default_row_commit_versions = actions
+            .column_by_name("defaultRowCommitVersion")
+            .unwrap_or_else(|| panic!("{action_name}.defaultRowCommitVersion column not found"))
+            .as_primitive::<Int64Type>();
+        let mut metadata = (0..checkpoint.num_rows())
+            .filter(|row| actions.is_valid(*row))
+            .map(|row| {
+                assert!(base_row_ids.is_valid(row));
+                assert!(default_row_commit_versions.is_valid(row));
+                (
+                    base_row_ids.value(row),
+                    default_row_commit_versions.value(row),
+                )
+            })
+            .collect::<Vec<_>>();
+        metadata.sort_unstable();
+        metadata
+    }
 }
 
 #[rstest::rstest]
@@ -191,17 +659,14 @@ async fn write_context_maps_row_tracking_metadata_to_physical(
     .unwrap_post_commit_snapshot();
 
     // === Read data with row tracking ===
-    let read_with_row_tracking = |snapshot: Arc<Snapshot>| -> DeltaResult<Vec<RecordBatch>> {
-        let scan_schema = Arc::new(
-            snapshot
-                .schema()
-                .add_metadata_column("row_id", MetadataColumnSpec::RowId)?
-                .add_metadata_column("row_commit_version", MetadataColumnSpec::RowCommitVersion)?,
-        );
-        let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
-        read_scan(&scan, engine.clone())
-    };
-    let source_batches = read_with_row_tracking(source_snapshot.clone())?;
+    let source_batches = read_row_tracking_scan(
+        source_snapshot.clone(),
+        engine.clone(),
+        [
+            MetadataColumnSpec::RowId,
+            MetadataColumnSpec::RowCommitVersion,
+        ],
+    )?;
 
     // === Merge the batches ===
     let merged_batch = concat_batches(&source_batches[0].schema(), &source_batches)?;

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -202,6 +202,7 @@ mod row_tracking_preservation {
     async fn remove_files_requires_row_tracking_preservation_acknowledgment(
         #[case] test_case: RemoveTestCase,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        // === Create the table and insert data ===
         let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
         let schema = schema_ref! { nullable "number": INTEGER };
         let table_url = Url::from_directory_path(&table_path).unwrap();
@@ -230,6 +231,7 @@ mod row_tracking_preservation {
         .await?
         .unwrap_committed();
 
+        // === Stage file removal and optionally acknowledge preservation ===
         let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
         let scan = snapshot.clone().scan_builder().build()?;
         let scan_files = scan
@@ -245,6 +247,7 @@ mod row_tracking_preservation {
             txn.ack_row_tracking_preservation();
         }
 
+        // === Commit and verify the result ===
         if let Some(expected_error) = test_case.expected_error() {
             assert_result_error_with_message(txn.commit(engine.as_ref()), expected_error);
         } else {
@@ -262,6 +265,7 @@ mod row_tracking_preservation {
     #[tokio::test]
     async fn deletion_vector_update_requires_preservation_acknowledgment(
     ) -> Result<(), Box<dyn std::error::Error>> {
+        // === Create a Row Tracking table with deletion vectors and insert data ===
         let tmp_dir = tempfile::tempdir()?;
         let (_schema, table_url, engine, store) = setup_number_table_with_features(
             &tmp_dir,
@@ -279,6 +283,7 @@ mod row_tracking_preservation {
         .await?
         .unwrap_post_commit_snapshot();
 
+        // === Stage a deletion-vector update without preservation acknowledgment ===
         let mut txn = create_dv_update_transaction(&table_url, engine.as_ref())?;
         let write_context = txn.write_state()?.write_context_builder().build()?;
         let mut deletion_vector = KernelDeletionVector::new();
@@ -295,6 +300,7 @@ mod row_tracking_preservation {
                 .map(Ok),
         )?;
 
+        // === Verify the commit is rejected ===
         assert_result_error_with_message(
             txn.commit(engine.as_ref()),
             "Transaction::ack_row_tracking_preservation()",


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3252/files) to review incremental changes.
- [stack/read-stable-ver](https://github.com/delta-io/delta-kernel-rs/pull/3224) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3224/files)] [MERGED]
  - [stack/builder-ctx](https://github.com/delta-io/delta-kernel-rs/pull/3226) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3226/files)] [MERGED]
    - [stack/rc-metadata-write](https://github.com/delta-io/delta-kernel-rs/pull/3229) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3229/files)] [MERGED]
      - [**stack/ack-rc-preserve**](https://github.com/delta-io/delta-kernel-rs/pull/3252) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3252/files)] ← _this PR_
        - stack/emit-preserve-flag

---------
## What changes are proposed in this pull request?

add `ack_row_tracking_preservation`. connector will be able to do `removeFile` on row tracking table with the acknowledgement

## How was this change tested?
unit tests for fns
integration tests for
- `OPTIMIZE` on row tracking table with minimum/maximum feature set
- dv update + `OPTIMIZE` on row tracking table
- negative tests for error cases(no acknowledgement, `icebergCompatV3`, etc...)