### PR TITLE
feat: add parallel json log reads for snapshot construction (#3246)

### DIFF
--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -24,7 +24,8 @@ use delta_kernel::{
     FileDataReadResultIterator, FileMeta, FileSize, JsonHandler, PredicateRef,
 };
 use futures::stream::{self, BoxStream};
-use futures::{ready, StreamExt, TryStreamExt};
+use futures::{ready, FutureExt, StreamExt, TryStreamExt};
+use tokio::sync::mpsc;
 use url::Url;
 
 use crate::executor::TaskExecutor;
@@ -42,6 +43,9 @@ pub struct DefaultJsonHandler<E: TaskExecutor> {
     /// Limit the number of rows per batch. That is, for batch_size = N, then each RecordBatch
     /// yielded by the stream will have at most N rows.
     batch_size: NonZero<usize>,
+    /// Number of ordered file chunks to parse concurrently. `None` means
+    /// no parallelism (default).
+    parallel_chunks: Option<NonZero<usize>>,
 }
 
 impl<E: TaskExecutor> DefaultJsonHandler<E> {
@@ -51,6 +55,7 @@ impl<E: TaskExecutor> DefaultJsonHandler<E> {
             task_executor,
             buffer_size: super::DEFAULT_READ_BUFFER_SIZE,
             batch_size: super::DEFAULT_READ_BATCH_SIZE,
+            parallel_chunks: None,
         }
     }
 
@@ -79,6 +84,13 @@ impl<E: TaskExecutor> DefaultJsonHandler<E> {
     /// [Decoder::with_buffer_size]: delta_kernel::arrow::json::reader::Decoder
     pub fn with_batch_size(mut self, batch_size: NonZero<usize>) -> Self {
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Number of ordered file chunks to parse concurrently in [`Self::read_json_files`].
+    /// `None` (the default) means no parallelism, no chunking.
+    pub fn with_parallel_chunks(mut self, parallel_chunks: Option<NonZero<usize>>) -> Self {
+        self.parallel_chunks = parallel_chunks;
         self
     }
 }
@@ -124,7 +136,102 @@ async fn read_json_files_impl(
         .try_flatten()
         .map_ok(|e| -> Box<dyn EngineData> { Box::new(e) });
 
-    Ok(Box::pin(result_stream))
+    Ok(result_stream.boxed())
+}
+
+/// Parallel JSON read by splitting the ordered file list into chunks. Each chunk
+/// uses the original [`read_json_files_impl`] pipeline. The chunk pipelines run
+/// concurrently as tokio tasks and results are concatenated in order.
+///
+/// Yield order is the same as [`read_json_files_impl`].
+async fn read_json_files_parallel_impl(
+    store: Arc<DynObjectStore>,
+    files: Vec<FileMeta>,
+    physical_schema: SchemaRef,
+    predicate: Option<PredicateRef>,
+    batch_size: usize,
+    buffer_size: usize,
+    parallel_chunks: usize,
+) -> DeltaResult<BoxStream<'static, DeltaResult<Box<dyn EngineData>>>> {
+    if files.is_empty() {
+        return Ok(Box::pin(stream::empty()));
+    }
+
+    let num_chunks = parallel_chunks.min(files.len()).max(1);
+    let chunk_size = files.len().div_ceil(num_chunks);
+    let chunks: Vec<Vec<FileMeta>> = files
+        .chunks(chunk_size)
+        .map(|chunk| chunk.to_vec())
+        .collect();
+    let num_chunks = chunks.len();
+    let per_chunk_buffer = (buffer_size / num_chunks).max(1);
+
+    // Spawn each chunk as a tokio task. Each task streams batches through a
+    // channel as they are produced. We keep the JoinHandle so a panic becomes
+    // JoinFailure instead of a silent hole in the file list.
+    let channel_cap = per_chunk_buffer.saturating_mul(4).max(1);
+    let mut receivers = Vec::new();
+    let mut handles = Vec::new();
+    for chunk in chunks {
+        let (tx, rx) = mpsc::channel::<DeltaResult<Box<dyn EngineData>>>(channel_cap);
+        receivers.push(rx);
+
+        let store = store.clone();
+        let physical_schema = physical_schema.clone();
+        let predicate = predicate.clone();
+
+        let handle = tokio::spawn(async move {
+            let result = read_json_files_impl(
+                store,
+                chunk,
+                physical_schema,
+                predicate,
+                batch_size,
+                per_chunk_buffer,
+            )
+            .await;
+            match result {
+                Ok(batch_stream) => {
+                    let mut batch_stream = std::pin::pin!(batch_stream);
+                    while let Some(batch) = batch_stream.next().await {
+                        if tx.send(batch).await.is_err() {
+                            // Consumer dropped the stream; stop this chunk.
+                            return;
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(Err(e)).await;
+                }
+            }
+        });
+        handles.push(handle);
+    }
+
+    // Drain in chunk order. After each channel closes, join the task.
+    let result_stream = stream::iter(receivers.into_iter().zip(handles))
+        .flat_map(|(rx, handle)| drain_chunk(rx, handle));
+
+    Ok(result_stream.boxed())
+}
+
+/// Drain `rx` then join `handle`. A panicked task is `Error::JoinFailure`, not EOF.
+fn drain_chunk(
+    rx: mpsc::Receiver<DeltaResult<Box<dyn EngineData>>>,
+    handle: tokio::task::JoinHandle<()>,
+) -> impl futures::Stream<Item = DeltaResult<Box<dyn EngineData>>> {
+    let batches = stream::unfold(rx, |mut rx| async {
+        rx.recv().await.map(|item| (item, rx))
+    });
+    let join = stream::once(async move { handle.await.map_err(Error::join_failure) }).filter_map(
+        |result| async move {
+            match result {
+                Ok(()) => None,
+                Err(e) => Some(Err(e)),
+            }
+        },
+    );
+    batches.chain(join)
 }
 
 /// Internal async implementation of write_json_file
@@ -176,14 +283,31 @@ impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
         predicate: Option<PredicateRef>,
         cancellation_token: Option<CancellationTokenRef>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        let future = read_json_files_impl(
-            self.store.clone(),
-            files.to_vec(),
-            physical_schema,
-            predicate,
-            self.batch_size.get(),
-            self.buffer_size.get(),
-        );
+        let store = self.store.clone();
+        let files = files.to_vec();
+        let batch_size = self.batch_size.get();
+        let buffer_size = self.buffer_size.get();
+        let future = match self.parallel_chunks {
+            Some(parallel_chunks) => read_json_files_parallel_impl(
+                store,
+                files,
+                physical_schema,
+                predicate,
+                batch_size,
+                buffer_size,
+                parallel_chunks.get(),
+            )
+            .boxed(),
+            None => read_json_files_impl(
+                store,
+                files,
+                physical_schema,
+                predicate,
+                batch_size,
+                buffer_size,
+            )
+            .boxed(),
+        };
         super::stream_future_to_cancellable_iter(
             self.task_executor.clone(),
             future,
@@ -283,6 +407,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::{mpsc, Arc, Mutex};
     use std::task::Waker;
+    use std::time::Duration;
 
     use delta_kernel::actions::get_commit_schema;
     use delta_kernel::arrow::array::{Array, AsArray, Int32Array, RecordBatch, StringArray};
@@ -304,6 +429,93 @@ mod tests {
 
     use super::*;
     use crate::executor::tokio::{TokioBackgroundExecutor, TokioMultiThreadExecutor};
+
+    /// Wraps an inner store and sleeps on every ObjectStore API before forwarding.
+    /// Completes whatever was requested; never waits for a path that was not asked for.
+    #[derive(Debug)]
+    struct LatencyStore<T: ObjectStore> {
+        inner: T,
+        delay: Duration,
+    }
+
+    impl<T: ObjectStore> LatencyStore<T> {
+        fn new(inner: T, delay: Duration) -> Self {
+            Self { inner, delay }
+        }
+
+        async fn delay(&self) {
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
+        }
+    }
+
+    impl<T: ObjectStore> std::fmt::Display for LatencyStore<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "LatencyStore(delay={:?})", self.delay)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<T: ObjectStore> delta_kernel::object_store::ObjectStore for LatencyStore<T> {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> Result<PutResult> {
+            self.delay().await;
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> Result<Box<dyn MultipartUpload>> {
+            self.delay().await;
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+            self.delay().await;
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+            self.delay().await;
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, Result<Path>>,
+        ) -> BoxStream<'static, Result<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, Result<ObjectMeta>> {
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+            self.delay().await;
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
+            self.delay().await;
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
 
     /// Store wrapper that wraps an inner store to guarantee the ordering of GET requests. Note
     /// that since the keys are resolved in order, requests to subsequent keys in the order will
@@ -831,6 +1043,89 @@ mod tests {
                 })
                 .collect();
             assert_eq!(all_values, (0..1000).collect_vec());
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_read_json_files_parallel_ordering() {
+        // Parallel impl does not issue every GET up front, so OrderedGetStore
+        // would hang. LatencyStore delays each requested GET and always completes it.
+        const N: i32 = 10_000;
+        let ordered_paths: Vec<Path> = (0..N)
+            .map(|i| Path::from(format!("test/path{i}")))
+            .collect();
+
+        let memory_store = InMemory::new();
+        for (i, path) in ordered_paths.iter().enumerate() {
+            memory_store
+                .put(path, Bytes::from(format!("{{\"val\": {i}}}")).into())
+                .await
+                .unwrap();
+        }
+
+        let store = Arc::new(LatencyStore::new(memory_store, Duration::from_millis(1)));
+        let ordered_file_meta: Vec<_> = ordered_paths
+            .iter()
+            .map(|path| {
+                let store = store.clone();
+                async move {
+                    let url = Url::parse(&format!("memory:/{path}")).unwrap();
+                    let location = Path::from(path.as_ref());
+                    let meta = store.head(&location).await.unwrap();
+                    FileMeta {
+                        location: url,
+                        last_modified: meta.last_modified.timestamp_millis(),
+                        size: meta.size,
+                    }
+                }
+            })
+            .collect();
+        let files = future::join_all(ordered_file_meta).await;
+
+        let handler = DefaultJsonHandler::new(
+            store,
+            Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )),
+        )
+        .with_buffer_size(NonZero::new(1000).expect("buffer_size is non-zero"))
+        .with_parallel_chunks(NonZero::new(100));
+        let physical_schema = schema_ref! { nullable "val": INTEGER };
+        let data: Vec<RecordBatch> = handler
+            .read_json_files(&files, physical_schema, None)
+            .unwrap()
+            .map_ok(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        let all_values: Vec<i32> = data
+            .iter()
+            .flat_map(|batch| {
+                let val_col: &Int32Array = batch.column(0).as_primitive();
+                (0..val_col.len()).map(|i| val_col.value(i)).collect_vec()
+            })
+            .collect();
+        assert_eq!(all_values, (0..N).collect_vec());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_drain_chunk_panicked_task_is_join_failure_not_eof() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<DeltaResult<Box<dyn EngineData>>>(1);
+        let handle = tokio::spawn(async {
+            panic!("chunk task panicked");
+        });
+        drop(tx);
+
+        let items: Vec<_> = drain_chunk(rx, handle).collect().await;
+        assert_eq!(
+            items.len(),
+            1,
+            "panicked chunk must yield an error, not EOF"
+        );
+        match &items[0] {
+            Err(Error::JoinFailure(_)) => {}
+            Err(_) => panic!("expected JoinFailure, got a different error"),
+            Ok(_) => panic!("expected JoinFailure, got a batch"),
         }
     }
 

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -419,13 +419,13 @@ mod tests {
         CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
         PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
     };
-    use delta_kernel::schema::schema_ref;
+    use delta_kernel::schema::{schema_ref, DataType as KernelDataType, StructField, StructType};
     use delta_kernel_default_engine_test_utils::{into_record_batch, string_array_to_engine_data};
     use futures::future;
     use itertools::Itertools;
     use serde_json::json;
     use test_utils::engine_contract::test_json_handler_file_path_contract;
-    use test_utils::TestCancellationToken;
+    use test_utils::{assert_result_error_with_message, TestCancellationToken};
     use tracing::info;
 
     use super::*;
@@ -1178,10 +1178,7 @@ mod tests {
     async fn test_read_json_files_parallel_with_cancelled_token() {
         let store = Arc::new(InMemory::new());
         store
-            .put(
-                &Path::from("test/0"),
-                Bytes::from(r#"{"val": 0}"#).into(),
-            )
+            .put(&Path::from("test/0"), Bytes::from(r#"{"val": 0}"#).into())
             .await
             .unwrap();
         let url = Url::parse("memory:///test/0").unwrap();
@@ -1193,17 +1190,100 @@ mod tests {
         let executor = Arc::new(TokioMultiThreadExecutor::new(
             tokio::runtime::Handle::current(),
         ));
-        let handler = DefaultJsonHandler::new(store, executor)
-            .with_parallel_chunks(NonZero::new(4));
+        let handler =
+            DefaultJsonHandler::new(store, executor).with_parallel_chunks(NonZero::new(4));
         let physical_schema = schema_ref! { nullable "val": INTEGER };
-        let token: CancellationTokenRef =
-            Arc::new(TestCancellationToken::cancelled());
-        let result = handler
-            .read_json_files_with_cancellation(&files, physical_schema, None, Some(token));
+        let token: CancellationTokenRef = Arc::new(TestCancellationToken::cancelled());
+        let result =
+            handler.read_json_files_with_cancellation(&files, physical_schema, None, Some(token));
         assert!(
             matches!(result, Err(Error::Cancelled)),
             "pre-cancelled token must yield Cancelled, not data"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_json_files_parallel_propagates_schema_conversion_error() {
+        let store = Arc::new(InMemory::new());
+        store
+            .put(&Path::from("test/0"), Bytes::from(r#"{"val": 0}"#).into())
+            .await
+            .unwrap();
+        let files = vec![FileMeta {
+            location: Url::parse("memory:///test/0").unwrap(),
+            last_modified: 0,
+            size: 12,
+        }];
+
+        // A shredded Variant is a valid kernel type but Arrow conversion only
+        // accepts the unshredded (metadata + value) shape. That makes
+        // json_arrow_schema fail inside each spawned chunk task.
+        let shredded_variant = KernelDataType::variant_type([
+            StructField::not_null("metadata", KernelDataType::BINARY),
+            StructField::not_null("value", KernelDataType::BINARY),
+            StructField::nullable("typed_value", KernelDataType::INTEGER),
+        ])
+        .unwrap();
+        let physical_schema =
+            Arc::new(StructType::try_new([StructField::nullable("v", shredded_variant)]).unwrap());
+
+        let handler = DefaultJsonHandler::new(
+            store,
+            Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )),
+        )
+        .with_parallel_chunks(NonZero::new(2));
+        let result: DeltaResult<Vec<_>> = handler
+            .read_json_files(&files, physical_schema, None)
+            .unwrap()
+            .try_collect();
+        assert_result_error_with_message(result, "Incorrect Variant Schema");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_json_files_parallel_stops_when_consumer_drops() {
+        // More files per chunk than the per-chunk channel can hold, so producers
+        // block on send. Dropping after the first batch then hits is_err().
+        const N: usize = 64;
+        let memory_store = InMemory::new();
+        for i in 0..N {
+            memory_store
+                .put(
+                    &Path::from(format!("test/{i}")),
+                    Bytes::from(format!("{{\"val\": {i}}}")).into(),
+                )
+                .await
+                .unwrap();
+        }
+        let store = Arc::new(LatencyStore::new(memory_store, Duration::from_millis(5)));
+        let files: Vec<FileMeta> = (0..N)
+            .map(|i| FileMeta {
+                location: Url::parse(&format!("memory:///test/{i}")).unwrap(),
+                last_modified: 0,
+                size: 12,
+            })
+            .collect();
+
+        let handler = DefaultJsonHandler::new(
+            store,
+            Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )),
+        )
+        .with_buffer_size(NonZero::new(1).unwrap())
+        .with_batch_size(NonZero::new(1).unwrap())
+        .with_parallel_chunks(NonZero::new(2));
+        let physical_schema = schema_ref! { nullable "val": INTEGER };
+        let mut iter = handler
+            .read_json_files(&files, physical_schema, None)
+            .unwrap();
+        let first = iter.next().expect("at least one batch");
+        assert!(first.is_ok(), "first batch must succeed before drop");
+        drop(iter);
+        // Let blocked chunk tasks observe the closed channel and take the
+        // consumer-dropped return before the test runtime shuts down.
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -425,6 +425,7 @@ mod tests {
     use itertools::Itertools;
     use serde_json::json;
     use test_utils::engine_contract::test_json_handler_file_path_contract;
+    use test_utils::TestCancellationToken;
     use tracing::info;
 
     use super::*;
@@ -1127,6 +1128,132 @@ mod tests {
             Err(_) => panic!("expected JoinFailure, got a different error"),
             Ok(_) => panic!("expected JoinFailure, got a batch"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_json_files_parallel_empty_files() {
+        let store = Arc::new(InMemory::new());
+        let handler = DefaultJsonHandler::new(
+            store,
+            Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )),
+        )
+        .with_parallel_chunks(NonZero::new(4));
+        let physical_schema = schema_ref! { nullable "val": INTEGER };
+        let result: Vec<_> = handler
+            .read_json_files(&[], physical_schema, None)
+            .unwrap()
+            .try_collect()
+            .unwrap();
+        assert!(result.is_empty(), "empty file list must yield no batches");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_json_files_parallel_missing_file_errors() {
+        let store = Arc::new(InMemory::new());
+        let missing_path = Path::from("test/missing");
+        let url = Url::parse(&format!("memory:/{missing_path}")).unwrap();
+        let files = vec![FileMeta {
+            location: url,
+            last_modified: 0,
+            size: 100,
+        }];
+        let handler = DefaultJsonHandler::new(
+            store,
+            Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )),
+        )
+        .with_parallel_chunks(NonZero::new(4));
+        let physical_schema = schema_ref! { nullable "val": INTEGER };
+        let result: DeltaResult<Vec<_>> = handler
+            .read_json_files(&files, physical_schema, None)
+            .unwrap()
+            .try_collect();
+        assert!(result.is_err(), "missing file must produce an error");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_json_files_parallel_with_cancelled_token() {
+        let store = Arc::new(InMemory::new());
+        store
+            .put(
+                &Path::from("test/0"),
+                Bytes::from(r#"{"val": 0}"#).into(),
+            )
+            .await
+            .unwrap();
+        let url = Url::parse("memory:///test/0").unwrap();
+        let files = vec![FileMeta {
+            location: url,
+            last_modified: 0,
+            size: 12,
+        }];
+        let executor = Arc::new(TokioMultiThreadExecutor::new(
+            tokio::runtime::Handle::current(),
+        ));
+        let handler = DefaultJsonHandler::new(store, executor)
+            .with_parallel_chunks(NonZero::new(4));
+        let physical_schema = schema_ref! { nullable "val": INTEGER };
+        let token: CancellationTokenRef =
+            Arc::new(TestCancellationToken::cancelled());
+        let result = handler
+            .read_json_files_with_cancellation(&files, physical_schema, None, Some(token));
+        assert!(
+            matches!(result, Err(Error::Cancelled)),
+            "pre-cancelled token must yield Cancelled, not data"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_json_files_parallel_via_builder() {
+        let store = Arc::new(InMemory::new());
+        for i in 0..100 {
+            store
+                .put(
+                    &Path::from(format!("test/{i}")),
+                    Bytes::from(format!("{{\"val\": {i}}}")).into(),
+                )
+                .await
+                .unwrap();
+        }
+        let files: Vec<FileMeta> = (0..100)
+            .map(|i| {
+                let url = Url::parse(&format!("memory:///test/{i}")).unwrap();
+                FileMeta {
+                    location: url,
+                    last_modified: 0,
+                    size: 12,
+                }
+            })
+            .collect();
+
+        let executor = Arc::new(TokioMultiThreadExecutor::new(
+            tokio::runtime::Handle::current(),
+        ));
+        let engine = crate::DefaultEngineBuilder::new(store)
+            .with_task_executor(executor)
+            .with_parallel_chunks(NonZero::new(10))
+            .build();
+
+        let json_handler = engine.json_handler();
+        let physical_schema = schema_ref! { nullable "val": INTEGER };
+        let data: Vec<RecordBatch> = json_handler
+            .read_json_files(&files, physical_schema, None)
+            .unwrap()
+            .map_ok(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        let all_values: Vec<i32> = data
+            .iter()
+            .flat_map(|batch| {
+                let val_col: &Int32Array = batch.column(0).as_primitive();
+                (0..val_col.len()).map(|i| val_col.value(i)).collect_vec()
+            })
+            .collect();
+        assert_eq!(all_values, (0..100).collect_vec());
     }
 
     // Helper function to create test data

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -26,6 +26,7 @@ use delta_kernel::{
 use futures::stream::{self, BoxStream};
 use futures::{ready, FutureExt, StreamExt, TryStreamExt};
 use tokio::sync::mpsc;
+use tokio::task::{JoinError, JoinHandle};
 use url::Url;
 
 use crate::executor::TaskExecutor;
@@ -166,21 +167,17 @@ async fn read_json_files_parallel_impl(
     let num_chunks = chunks.len();
     let per_chunk_buffer = (buffer_size / num_chunks).max(1);
 
-    // Spawn each chunk as a tokio task. Each task streams batches through a
-    // channel as they are produced. We keep the JoinHandle so a panic becomes
-    // JoinFailure instead of a silent hole in the file list.
-    let channel_cap = per_chunk_buffer.saturating_mul(4).max(1);
     let mut receivers = Vec::new();
     let mut handles = Vec::new();
     for chunk in chunks {
-        let (tx, rx) = mpsc::channel::<DeltaResult<Box<dyn EngineData>>>(channel_cap);
+        let (tx, rx) = mpsc::channel::<DeltaResult<Box<dyn EngineData>>>(per_chunk_buffer);
         receivers.push(rx);
 
         let store = store.clone();
         let physical_schema = physical_schema.clone();
         let predicate = predicate.clone();
 
-        let handle = tokio::spawn(async move {
+        let handle = AbortOnDropHandle::new(tokio::spawn(async move {
             let result = read_json_files_impl(
                 store,
                 chunk,
@@ -204,7 +201,7 @@ async fn read_json_files_parallel_impl(
                     let _ = tx.send(Err(e)).await;
                 }
             }
-        });
+        }));
         handles.push(handle);
     }
 
@@ -215,22 +212,51 @@ async fn read_json_files_parallel_impl(
     Ok(result_stream.boxed())
 }
 
+/// `JoinHandle` that aborts the task if dropped without being joined.
+/// Dropping a raw `JoinHandle` detaches the task; aborting stops in-flight
+/// object-store GETs when the consumer cancels or stops early.
+struct AbortOnDropHandle {
+    handle: Option<JoinHandle<()>>,
+}
+
+impl AbortOnDropHandle {
+    fn new(handle: JoinHandle<()>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+
+    async fn join(mut self) -> Result<(), JoinError> {
+        match self.handle.take() {
+            Some(handle) => handle.await,
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for AbortOnDropHandle {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
 /// Drain `rx` then join `handle`. A panicked task is `Error::JoinFailure`, not EOF.
 fn drain_chunk(
     rx: mpsc::Receiver<DeltaResult<Box<dyn EngineData>>>,
-    handle: tokio::task::JoinHandle<()>,
+    handle: AbortOnDropHandle,
 ) -> impl futures::Stream<Item = DeltaResult<Box<dyn EngineData>>> {
     let batches = stream::unfold(rx, |mut rx| async {
         rx.recv().await.map(|item| (item, rx))
     });
-    let join = stream::once(async move { handle.await.map_err(Error::join_failure) }).filter_map(
-        |result| async move {
+    let join = stream::once(async move { handle.join().await.map_err(Error::join_failure) })
+        .filter_map(|result| async move {
             match result {
                 Ok(()) => None,
                 Err(e) => Some(Err(e)),
             }
-        },
-    );
+        });
     batches.chain(join)
 }
 
@@ -1112,9 +1138,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_drain_chunk_panicked_task_is_join_failure_not_eof() {
         let (tx, rx) = tokio::sync::mpsc::channel::<DeltaResult<Box<dyn EngineData>>>(1);
-        let handle = tokio::spawn(async {
+        let handle = AbortOnDropHandle::new(tokio::spawn(async {
             panic!("chunk task panicked");
-        });
+        }));
         drop(tx);
 
         let items: Vec<_> = drain_chunk(rx, handle).collect().await;
@@ -1128,6 +1154,59 @@ mod tests {
             Err(_) => panic!("expected JoinFailure, got a different error"),
             Ok(_) => panic!("expected JoinFailure, got a batch"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_abort_on_drop_handle_aborts_unjoined_task() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = AbortOnDropHandle::new(tokio::spawn(async move {
+            let _tx = tx;
+            std::future::pending::<()>().await;
+        }));
+        drop(handle);
+        assert!(
+            rx.await.is_err(),
+            "dropping AbortOnDropHandle must abort the task"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_abort_on_drop_handle_join_completed_task() {
+        let handle = AbortOnDropHandle::new(tokio::spawn(async {}));
+        handle
+            .join()
+            .await
+            .expect("joining a completed task must succeed");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_drain_chunk_successful_task_yields_no_join_item() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<DeltaResult<Box<dyn EngineData>>>(1);
+        let handle = AbortOnDropHandle::new(tokio::spawn(async {}));
+        drop(tx);
+
+        let items: Vec<_> = drain_chunk(rx, handle).collect().await;
+        assert!(
+            items.is_empty(),
+            "successful chunk must yield no extra item after the channel closes"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_drain_chunk_drop_aborts_unjoined_task() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<DeltaResult<Box<dyn EngineData>>>(1);
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = AbortOnDropHandle::new(tokio::spawn(async move {
+            let _tx = tx;
+            let _done_tx = done_tx;
+            std::future::pending::<()>().await;
+        }));
+
+        drop(drain_chunk(rx, handle));
+        assert!(
+            done_rx.await.is_err(),
+            "dropping drain_chunk must abort the unjoined task"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -92,8 +92,9 @@ impl<E: TaskExecutor> DefaultJsonHandler<E> {
     /// `None` (the default) means no parallelism, no chunking.
     ///
     /// Chunk tasks are spawned on the current Tokio runtime. Real speedup needs a
-    /// multi-thread executor ([`TokioMultiThreadExecutor`]). The default
-    /// [`TokioBackgroundExecutor`] is single-threaded, so chunks share one thread.
+    /// multi-thread executor ([`crate::executor::tokio::TokioMultiThreadExecutor`]).
+    /// The default [`crate::executor::tokio::TokioBackgroundExecutor`] is
+    /// single-threaded, so chunks share one thread.
     pub fn with_parallel_chunks(mut self, parallel_chunks: Option<NonZero<usize>>) -> Self {
         self.parallel_chunks = parallel_chunks;
         self

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -90,6 +90,10 @@ impl<E: TaskExecutor> DefaultJsonHandler<E> {
 
     /// Number of ordered file chunks to parse concurrently in [`Self::read_json_files`].
     /// `None` (the default) means no parallelism, no chunking.
+    ///
+    /// Chunk tasks are spawned on the current Tokio runtime. Real speedup needs a
+    /// multi-thread executor ([`TokioMultiThreadExecutor`]). The default
+    /// [`TokioBackgroundExecutor`] is single-threaded, so chunks share one thread.
     pub fn with_parallel_chunks(mut self, parallel_chunks: Option<NonZero<usize>>) -> Self {
         self.parallel_chunks = parallel_chunks;
         self
@@ -1251,6 +1255,89 @@ mod tests {
             .unwrap()
             .try_collect();
         assert!(result.is_err(), "missing file must produce an error");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_json_files_parallel_later_chunk_errors_after_data() {
+        // 4 files / 2 chunks -> [0,1] then [missing, 3]. Chunk 0 yields data;
+        // chunk 1 errors. try_collect would hide that ordering.
+        let store = Arc::new(InMemory::new());
+        for i in [0, 1, 3] {
+            store
+                .put(
+                    &Path::from(format!("test/{i}")),
+                    Bytes::from(format!("{{\"val\": {i}}}")).into(),
+                )
+                .await
+                .unwrap();
+        }
+        let files: Vec<FileMeta> = (0..4)
+            .map(|i| FileMeta {
+                location: Url::parse(&format!("memory:///test/{i}")).unwrap(),
+                last_modified: 0,
+                size: 12,
+            })
+            .collect();
+        let handler = DefaultJsonHandler::new(
+            store,
+            Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )),
+        )
+        .with_parallel_chunks(NonZero::new(2));
+        let physical_schema = schema_ref! { nullable "val": INTEGER };
+        let mut iter = handler
+            .read_json_files(&files, physical_schema, None)
+            .unwrap();
+        let first = iter.next().expect("chunk 0 must yield a batch");
+        assert!(first.is_ok(), "chunk 0 must succeed before chunk 1 errors");
+        let rest: DeltaResult<Vec<_>> = iter.try_collect();
+        assert!(rest.is_err(), "missing file in a later chunk must error");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_json_files_parallel_ragged_chunk_sizes() {
+        // 7 files / 3 chunks -> sizes 3, 3, 1 (not an even split).
+        const N: i32 = 7;
+        let store = Arc::new(InMemory::new());
+        for i in 0..N {
+            store
+                .put(
+                    &Path::from(format!("test/{i}")),
+                    Bytes::from(format!("{{\"val\": {i}}}")).into(),
+                )
+                .await
+                .unwrap();
+        }
+        let files: Vec<FileMeta> = (0..N)
+            .map(|i| FileMeta {
+                location: Url::parse(&format!("memory:///test/{i}")).unwrap(),
+                last_modified: 0,
+                size: 12,
+            })
+            .collect();
+        let handler = DefaultJsonHandler::new(
+            store,
+            Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )),
+        )
+        .with_parallel_chunks(NonZero::new(3));
+        let physical_schema = schema_ref! { nullable "val": INTEGER };
+        let data: Vec<RecordBatch> = handler
+            .read_json_files(&files, physical_schema, None)
+            .unwrap()
+            .map_ok(into_record_batch)
+            .try_collect()
+            .unwrap();
+        let all_values: Vec<i32> = data
+            .iter()
+            .flat_map(|batch| {
+                let val_col: &Int32Array = batch.column(0).as_primitive();
+                (0..val_col.len()).map(|i| val_col.value(i)).collect_vec()
+            })
+            .collect();
+        assert_eq!(all_values, (0..N).collect_vec());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -230,6 +230,9 @@ struct ReadIoConfig {
     buffer_size: Option<NonZero<usize>>,
     /// Maximum number of rows per yielded batch. See [`DefaultEngineBuilder::with_batch_size`].
     batch_size: Option<NonZero<usize>>,
+    /// Number of ordered JSON file chunks to parse concurrently. `None` means no parallelism.
+    /// See [`DefaultEngineBuilder::with_parallel_chunks`].
+    parallel_chunks: Option<NonZero<usize>>,
 }
 
 /// Represents the default [`TaskExecutor`]. The executor is created lazily to avoid unnecessary
@@ -288,6 +291,16 @@ impl<E> DefaultEngineBuilder<E> {
         self.io_config.batch_size = Some(batch_size);
         self
     }
+
+    /// Set the number of ordered JSON file chunks to parse concurrently.
+    ///
+    /// `None` (the default) means no parallelism. `Some(n)` splits the
+    /// file list into `n` chunks, parses them concurrently, and concatenates
+    /// results in the proper order.
+    pub fn with_parallel_chunks(mut self, parallel_chunks: Option<NonZero<usize>>) -> Self {
+        self.io_config.parallel_chunks = parallel_chunks;
+        self
+    }
 }
 
 impl<E: TaskExecutor> DefaultEngineBuilder<Arc<E>> {
@@ -323,7 +336,8 @@ impl<E: TaskExecutor> DefaultEngine<E> {
         let batch_size = io_config.batch_size.unwrap_or(DEFAULT_READ_BATCH_SIZE);
         let json = DefaultJsonHandler::new(object_store.clone(), task_executor.clone())
             .with_buffer_size(buffer_size)
-            .with_batch_size(batch_size);
+            .with_batch_size(batch_size)
+            .with_parallel_chunks(io_config.parallel_chunks);
         let parquet = DefaultParquetHandler::new(object_store.clone(), task_executor.clone())
             .with_buffer_size(buffer_size)
             .with_batch_size(batch_size);

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -299,8 +299,9 @@ impl<E> DefaultEngineBuilder<E> {
     /// parses them concurrently, and concatenates results in the proper order.
     ///
     /// Chunk tasks are spawned on the current Tokio runtime. Real speedup needs a
-    /// multi-thread executor ([`TokioMultiThreadExecutor`]). The default
-    /// [`TokioBackgroundExecutor`] is single-threaded, so chunks share one thread.
+    /// multi-thread executor ([`executor::tokio::TokioMultiThreadExecutor`]). The
+    /// default [`executor::tokio::TokioBackgroundExecutor`] is single-threaded, so
+    /// chunks share one thread.
     pub fn with_parallel_chunks(mut self, parallel_chunks: Option<NonZero<usize>>) -> Self {
         self.io_config.parallel_chunks = parallel_chunks;
         self

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -537,6 +537,7 @@ mod tests {
             .with_task_executor(executor)
             .with_buffer_size(NonZero::new(4).unwrap())
             .with_batch_size(NonZero::new(8).unwrap())
+            .with_parallel_chunks(NonZero::new(4))
             .build();
         test_arrow_engine(&engine, &url);
     }

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -295,8 +295,12 @@ impl<E> DefaultEngineBuilder<E> {
     /// Set the number of ordered JSON file chunks to parse concurrently.
     ///
     /// `None` (the default) means no parallelism. `Some(n)` splits the
-    /// file list into `n` chunks, parses them concurrently, and concatenates
-    /// results in the proper order.
+    /// file list into up to n chunks (fewer when there are fewer files than n),
+    /// parses them concurrently, and concatenates results in the proper order.
+    ///
+    /// Chunk tasks are spawned on the current Tokio runtime. Real speedup needs a
+    /// multi-thread executor ([`TokioMultiThreadExecutor`]). The default
+    /// [`TokioBackgroundExecutor`] is single-threaded, so chunks share one thread.
     pub fn with_parallel_chunks(mut self, parallel_chunks: Option<NonZero<usize>>) -> Self {
         self.io_config.parallel_chunks = parallel_chunks;
         self

--- a/kernel/benches/metadata_bench.rs
+++ b/kernel/benches/metadata_bench.rs
@@ -17,13 +17,15 @@
 //!
 //! Follow-ups: <https://github.com/delta-io/delta-kernel-rs/issues/1185>
 
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::try_parse_uri;
 use tempfile::TempDir;
-use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
+use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
+use test_utils::delta_kernel_default_engine::storage::store_from_url;
 use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use test_utils::load_test_data;
 use url::Url;
@@ -31,34 +33,43 @@ use url::Url;
 // force scan metadata bench to use smaller sample size so test runs faster (100 -> 20)
 const SCAN_METADATA_BENCH_SAMPLE_SIZE: usize = 20;
 
-fn setup() -> (TempDir, Url, Arc<DefaultEngine<TokioBackgroundExecutor>>) {
+fn setup(
+    parallel_chunks: Option<NonZeroUsize>,
+) -> (TempDir, Url, Arc<DefaultEngine<TokioMultiThreadExecutor>>) {
     // note this table _only_ has a _delta_log, no data files (can only do metadata reads)
     let table = "300k-add-files-100-col-partitioned";
     let tempdir = load_test_data("./tests/data", table).unwrap();
     let table_path = tempdir.path().join(table);
     let url = try_parse_uri(table_path.to_str().unwrap()).expect("Failed to parse table path");
-    // TODO: use multi-threaded executor
-    use test_utils::delta_kernel_default_engine::storage::store_from_url;
     let store = store_from_url(&url).expect("Failed to create store");
-    let engine = DefaultEngineBuilder::new(store).build();
+    let executor = Arc::new(
+        TokioMultiThreadExecutor::new_owned_runtime(None, None).expect("Failed to create runtime"),
+    );
+    let engine = DefaultEngineBuilder::new(store)
+        .with_task_executor(executor)
+        .with_parallel_chunks(parallel_chunks)
+        .build();
 
     (tempdir, url, Arc::new(engine))
 }
 
 fn create_snapshot_benchmark(c: &mut Criterion) {
-    let (_tempdir, url, engine) = setup();
-
-    c.bench_function("create_snapshot", |b| {
-        b.iter(|| {
-            Snapshot::builder_for(url.clone())
-                .build(engine.as_ref())
-                .expect("Failed to create snapshot")
-        })
-    });
+    let mut group = c.benchmark_group("create_snapshot");
+    for (id, chunks) in [("serial", None), ("parallel_chunks", NonZeroUsize::new(10))] {
+        let (_tempdir, url, engine) = setup(chunks);
+        group.bench_function(id, |b| {
+            b.iter(|| {
+                Snapshot::builder_for(url.clone())
+                    .build(engine.as_ref())
+                    .expect("Failed to create snapshot")
+            })
+        });
+    }
+    group.finish();
 }
 
 fn scan_metadata_benchmark(c: &mut Criterion) {
-    let (_tempdir, url, engine) = setup();
+    let (_tempdir, url, engine) = setup(None);
 
     let snapshot = Snapshot::builder_for(url.clone())
         .build(engine.as_ref())


### PR DESCRIPTION
## What changes are proposed in this pull request?

Opt-in parallel JSON log reads for snapshot construction. `None` (default) keeps the existing serial path. `Some(n)` splits the ordered file list into `n` chunks, parses them concurrently as tokio tasks, and concatenates results in proper order.

Here are some performance results:

| Run | Serial  | Parallel | Speedup |
|-----|---------|----------|---------|
| 1 | 100.46 ms | 40.093 ms | 2.51x |
| 2 | 99.403 ms | 39.868 ms | 2.49x |
| 3 | 94.569 ms | 39.750 ms | 2.38x |
| 4 | 93.588 ms | 39.521 ms | 2.36x |
| 5 | 95.827 ms | 40.228 ms | 2.38x |
| 6 | 93.520 ms | 39.211 ms | 2.39x |
| 7 | 95.187 ms | 39.709 ms | 2.40x |

> [!IMPORTANT]
>
> This is in average **2.41x faster** (saved ~59% of time spent)!

This metrics were extracted from a similar output of `cargo bench -p delta_kernel --bench metadata_bench -- create_snapshot`:

```
create_snapshot/serial  
                        time:   [93.300 ms 93.588 ms 93.897 ms]
                        change: [-2.5782% -1.0375% +0.2986%] (p = 0.18 > 0.05)
                        No change in performance detected.
create_snapshot/parallel_chunks
                        time:   [39.272 ms 39.521 ms 39.777 ms]
                        change: [-1.3621% -0.5756% +0.0797%] (p = 0.13 > 0.05)
                        No change in performance detected.
```

## What does it fix?

Closes #3246 

## How was this change tested?

- `test_read_json_files_parallel_ordering` with 10k files, assert correct order
- `test_drain_chunk_panicked_task_is_join_failure_not_eof` checking panic yields `JoinFailure`, not EOF
- `cargo +nightly fmt --check`
- `cargo test`
- `cargo nextest run -p delta_kernel_default_engine --lib --all-features`
- `cargo bench -p delta_kernel --bench metadata_bench -- create_snapshot`
