### PR TITLE
ci: fix inline AI review startup

### DIFF
--- a/.github/omnigent/reviewer/config.yaml
+++ b/.github/omnigent/reviewer/config.yaml
@@ -99,6 +99,13 @@ prompt: |
   - `Suggested fix:` with a concrete change. Include a short code snippet when
     it makes the fix clearer; omit snippets for trivial one-line fixes.
 
+  When the invocation prompt requests inline output, append the exact
+  machine-readable block it specifies after the human-readable review and before
+  the final per-run marker. Select findings according to the invocation's cap and
+  priority order, using locations from the supplied unified diff. Findings not
+  selected for inline publication remain in the collapsed review. The workflow
+  validates this data and removes it before publication.
+
   ## Final writing pass
   Before returning the final comment, do one human-style polish pass over the
   consolidated review. This pass may rewrite wording only; it must not add,
@@ -133,11 +140,12 @@ prompt: |
   Failed agents: comma-separated agent names, or none
   Do not downgrade a finding to bypass a failed gate.
 
-  Your output is posted verbatim as a PR comment. Output ONLY the final
-  consolidated review -- no narration and no status updates. Include reviewer
-  attribution on findings as required above. Begin and end your response with
-  the exact per-run markers supplied in the invocation prompt. Put each marker
-  on its own line. Nothing outside those markers will be shown.
+  The human-readable part of your output is published verbatim. Output ONLY the
+  final consolidated review and any requested machine-readable block -- no
+  narration and no status updates. Include reviewer attribution on findings as
+  required above. Begin and end your response with the exact per-run markers
+  supplied in the invocation prompt. Put each marker on its own line. Nothing
+  outside those markers will be shown.
 
 async: true
 cancellable: true

--- a/.github/omnigent/tests/test_inline_review.py
+++ b/.github/omnigent/tests/test_inline_review.py
@@ -86,6 +86,23 @@ class InlineReviewTest(unittest.TestCase):
         for side in self.inline_review.INLINE_FINDING_SIDES:
             self.assertIn(side, prompt)
 
+    def test_reviewer_contract_matches_configured_prompt(self) -> None:
+        reviewer_dir = Path(__file__).parents[1] / "reviewer"
+        contract = (reviewer_dir / "REVIEW.md").read_text()
+        _, separator, standalone_prompt = contract.partition("\n---\n\n")
+        self.assertTrue(separator)
+
+        config = (reviewer_dir / "config.yaml").read_text()
+        _, separator, prompt_block = config.partition("prompt: |\n")
+        self.assertTrue(separator)
+        configured_lines = []
+        for line in prompt_block.splitlines():
+            if line and not line.startswith("  "):
+                break
+            configured_lines.append(line[2:])
+
+        self.assertEqual(standalone_prompt.strip(), "\n".join(configured_lines).strip())
+
     def test_diff_positions_tracks_both_sides_and_context(self) -> None:
         self.assertEqual(
             self.inline_review.diff_positions(DIFF),

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -89,6 +89,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     outputs:
       allowed: ${{ steps.access.outputs.allowed }}
       auth_subject: ${{ steps.trigger.outputs.auth_subject }}
@@ -186,6 +187,7 @@ jobs:
           esac
 
       - name: Acknowledge /review command
+        continue-on-error: true
         if: >-
           github.event_name == 'issue_comment' &&
           steps.trigger.outputs.skip != 'true' &&
@@ -196,8 +198,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
-            -f content=eyes --silent || true
+          gh api --method POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes --silent
 
   review:
     name: AI PR Review

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,19 @@ env:
 # are installed via taiki-e/install-action, which fetches prebuilt binaries.
 
 jobs:
+  ai-review-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Validate AI reviewer config
+        run: >-
+          python3 -m unittest discover
+          --start-directory .github/omnigent/tests
+          --pattern test_inline_review.py
+
   format:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3255/files) to review incremental changes.
- [stack/fix-inline-review-prompt-sync](https://github.com/delta-io/delta-kernel-rs/pull/3255) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3255/files)]

---------
## What changes are proposed in this pull request?

Synchronize the AI reviewer prompt copies and add CI coverage that prevents them from drifting. Grant the review authorization job permission to acknowledge accepted commands with an eyes reaction, while keeping reaction failures non-blocking and visible.

## How was this change tested?

- Python inline-review unit tests
- cargo +nightly fmt
- cargo clippy --workspace --benches --tests --all-features -- -D warnings
- cargo doc --workspace --all-features --no-deps