### PR TITLE
ci: validate AI review source before runtime rewrite

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -202,7 +202,7 @@ jobs:
             -f content=eyes --silent
 
   review:
-    name: AI PR Review
+    name: "[non blocking] AI PR Review"
     runs-on: ubuntu-latest
     needs: authorize
     timeout-minutes: 30
@@ -431,9 +431,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/.github/omnigent
         run: |
           set -euo pipefail
-          python3 -m unittest discover \
-            --start-directory .github/omnigent/tests \
-            --pattern test_inline_review.py
+          # Source-format unit tests run on pristine PR-head code in build.yml's ai-review-config job.
           python3 - <<'PYEOF'
           import json
           import os


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3256/files) to review incremental changes.
- [stack/fix-ai-review-runtime-test-order](https://github.com/delta-io/delta-kernel-rs/pull/3256) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3256/files)]

---------
## What changes are proposed in this pull request?

Remove the source-format unit-test invocation from the runtime review job. The `ai-review-config` job in `build.yml` already runs those tests against pristine PR-head code, while the review job retains its semantic Omnigent validation after rewriting reviewer YAML.

Rename the advisory review job to `[non blocking] AI PR Review` so its status is clear in the checks list. The repository has no branch-protection required-status configuration or ruleset pinned to the old job name.

The failing runtime sequence ran `test_reviewer_contract_matches_configured_prompt` after the `Disable reviewer host skills` step rewrote `config.yaml` with `yaml.safe_dump`. The rewrite preserved the prompt value but removed its literal `prompt: |` source representation, so the test could not find that separator and failed at `self.assertTrue(separator)`.

## How was this change tested?

- Python inline-review unit tests
- Full branch workflow in inline mode: https://github.com/delta-io/delta-kernel-rs/actions/runs/33806451133
  - Runtime validation passed
  - Model execution completed
  - Output validation passed
  - Inline review publication completed with two inline comments
- cargo +nightly fmt
- cargo clippy --workspace --benches --tests --all-features -- -D warnings
- cargo doc --workspace --all-features --no-deps