### PR TITLE
ci: clarify AI review finding IDs

### DIFF
--- a/.github/omnigent/inline_review.py
+++ b/.github/omnigent/inline_review.py
@@ -14,7 +14,7 @@ from review_publish import format_review_body as _format_review_body
 MAX_INLINE_FINDINGS = 12
 INLINE_FINDING_FIELDS = ("id", "path", "line", "side", "body")
 INLINE_FINDING_SIDES = ("LEFT", "RIGHT")
-_FINDING_ID = re.compile(r"[BN][1-9][0-9]*")
+_FINDING_ID = re.compile(r"(?:Blocker|Nit)[1-9][0-9]*")
 _HUNK_HEADER = re.compile(
     r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@"
 )
@@ -58,7 +58,7 @@ def inline_prompt_instructions(marker: str) -> str:
                     zip(
                         INLINE_FINDING_FIELDS,
                         (
-                            "N1",
+                            "Nit1",
                             "kernel/src/file.rs",
                             10,
                             "RIGHT",
@@ -84,10 +84,10 @@ machine-readable block:
 {example}
 {end}
 
-Include entries for up to {MAX_INLINE_FINDINGS} B/N findings, prioritizing
+Include entries for up to {MAX_INLINE_FINDINGS} Blocker/Nit findings, prioritizing
 blockers and then the most useful notes. Findings omitted from this block remain
 in the collapsed review. Use IDs matching `{_FINDING_ID.pattern}` (for example,
-`B1` or `N1`) and do not add an entry for the Summary. Use the repository-relative
+`Blocker1` or `Nit1`) and do not add an entry for the Summary. Use the repository-relative
 path with no backticks. Use {INLINE_FINDING_SIDES[1]} and the head-file line
 number for additions or context; use {INLINE_FINDING_SIDES[0]} and the base-file
 line number only for deleted lines. The location must occur in the supplied
@@ -227,7 +227,7 @@ def _validate_finding(finding: Any) -> tuple[str, str, int, str, str]:
     side = finding["side"]
     body = finding["body"]
     if not isinstance(finding_id, str) or _FINDING_ID.fullmatch(finding_id) is None:
-        raise ValueError("inline finding ID must match B1 or N1 form")
+        raise ValueError("inline finding ID must match Blocker1 or Nit1 form")
     if (
         not isinstance(path, str)
         or not path

--- a/.github/omnigent/reviewer/REVIEW.md
+++ b/.github/omnigent/reviewer/REVIEW.md
@@ -80,7 +80,7 @@ Omit any empty section. Do NOT comment on style/formatting a linter catches,
 and do NOT restate the diff. "No blocking issues" is a fine review.
 
 Each finding must include:
-- a stable ID (`B1`, `B2`, ... for blockers; `N1`, `N2`, ... for notes);
+- a stable ID (`Blocker1`, `Blocker2`, ... for blockers; `Nit1`, `Nit2`, ... for notes);
 - the file/line or diff hunk reference;
 - the concrete failure mode or maintenance cost;
 - `Raised by: <agent names>` with all agents that flagged that issue;

--- a/.github/omnigent/reviewer/config.yaml
+++ b/.github/omnigent/reviewer/config.yaml
@@ -92,7 +92,7 @@ prompt: |
   and do NOT restate the diff. "No blocking issues" is a fine review.
 
   Each finding must include:
-  - a stable ID (`B1`, `B2`, ... for blockers; `N1`, `N2`, ... for notes);
+  - a stable ID (`Blocker1`, `Blocker2`, ... for blockers; `Nit1`, `Nit2`, ... for notes);
   - the file/line or diff hunk reference;
   - the concrete failure mode or maintenance cost;
   - `Raised by: <agent names>` with all agents that flagged that issue;

--- a/.github/omnigent/tests/test_inline_review.py
+++ b/.github/omnigent/tests/test_inline_review.py
@@ -66,13 +66,13 @@ class InlineReviewTest(unittest.TestCase):
         review, findings = self.inline_review.extract_inline_findings(
             "Summary\n"
             f"<!-- AI_REVIEW_INLINE_START_{marker} -->\n"
-            '{"findings":[{"id":"N1"}]}\n'
+            '{"findings":[{"id":"Nit1"}]}\n'
             f"<!-- AI_REVIEW_INLINE_END_{marker} -->",
             marker,
         )
 
         self.assertEqual(review, "Summary")
-        self.assertEqual(findings, [{"id": "N1"}])
+        self.assertEqual(findings, [{"id": "Nit1"}])
 
     def test_inline_prompt_uses_parser_contract(self) -> None:
         marker = "a" * 32
@@ -128,17 +128,17 @@ class InlineReviewTest(unittest.TestCase):
 
     def test_build_payload_keeps_only_locations_in_diff(self) -> None:
         payload, unmapped = self.inline_review.build_review_payload(
-            review="### N1: use the new call",
+            review="### Nit1: use the new call",
             findings=[
                 {
-                    "id": "N1",
+                    "id": "Nit1",
                     "path": "kernel/src/example.rs",
                     "line": 10,
                     "side": "RIGHT",
                     "body": "This is attached to the added line.",
                 },
                 {
-                    "id": "N2",
+                    "id": "Nit2",
                     "path": "kernel/src/example.rs",
                     "line": 100,
                     "side": "RIGHT",
@@ -159,20 +159,20 @@ class InlineReviewTest(unittest.TestCase):
                     "path": "kernel/src/example.rs",
                     "line": 10,
                     "side": "RIGHT",
-                    "body": "**N1** This is attached to the added line.",
+                    "body": "**Nit1** This is attached to the added line.",
                 }
             ],
         )
         self.assertIn("<details><summary>Show review</summary>", payload["body"])
         self.assertTrue(payload["body"].startswith("<!-- ai-review-bot -->"))
-        self.assertEqual(unmapped, ["N2"])
+        self.assertEqual(unmapped, ["Nit2"])
 
     def test_build_payload_accepts_multiline_finding_body(self) -> None:
         payload, unmapped = self.inline_review.build_review_payload(
             review="review",
             findings=[
                 {
-                    "id": "N1",
+                    "id": "Nit1",
                     "path": "kernel/src/example.rs",
                     "line": 10,
                     "side": "RIGHT",
@@ -199,7 +199,7 @@ class InlineReviewTest(unittest.TestCase):
 
     def test_build_payload_skips_duplicate_ids(self) -> None:
         finding = {
-            "id": "B1",
+            "id": "Blocker1",
             "path": "kernel/src/example.rs",
             "line": 9,
             "side": "RIGHT",
@@ -215,11 +215,11 @@ class InlineReviewTest(unittest.TestCase):
         )
 
         self.assertEqual(len(payload["comments"]), 1)
-        self.assertEqual(unmapped, ["B1"])
+        self.assertEqual(unmapped, ["Blocker1"])
 
     def test_build_payload_skips_untrusted_finding_fields(self) -> None:
         valid = {
-            "id": "N1",
+            "id": "Nit1",
             "path": "kernel/src/example.rs",
             "line": 10,
             "side": "RIGHT",
@@ -270,7 +270,7 @@ class InlineReviewTest(unittest.TestCase):
 
     def test_build_payload_rejects_untrusted_metadata(self) -> None:
         finding = {
-            "id": "N1",
+            "id": "Nit1",
             "path": "kernel/src/example.rs",
             "line": 10,
             "side": "RIGHT",


### PR DESCRIPTION
## What changes are proposed in this pull request?

This experimental follow-up makes AI review finding IDs self-describing: `Blocker1`, `Blocker2`, and so on for blocking issues; `Nit1`, `Nit2`, and so on for non-blocking notes. It updates the reviewer contract, inline-output parser, and tests together.

## How was this change tested?

- Full repository pre-commit checks: nightly rustfmt, Clippy, Rust tests and doctests, and coverage
- Omnigent Python unit tests
- Python compilation, workflow YAML parsing, and `git diff --check`