### PR TITLE
fix: tolerate negative file sizes in CRC replay

### DIFF
--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -396,10 +396,13 @@ impl CrcReplayAccumulator {
         if !self.delta.is_incremental_safe {
             return Ok(());
         }
+        if size < 0 {
+            warn!("CRC reverse-replay: add action has negative size {size}");
+            self.delta.is_incremental_safe = false;
+            return Ok(());
+        }
         let fs = &mut self.delta.file_stats;
         fs.gross_add_files += 1;
-        // TODO(#2676): a negative size errors here and fails the snapshot load; degrade to
-        //              Indeterminate instead, like a missing remove size.
         fs.gross_add_bytes += size_to_u64(size)?;
         if let Some(hist) = fs.net_histogram.as_mut() {
             hist.insert(size)?;
@@ -418,6 +421,10 @@ impl CrcReplayAccumulator {
             return Ok(());
         }
         match size {
+            Some(s) if s < 0 => {
+                warn!("CRC reverse-replay: remove action at {path} has negative size {s}");
+                self.delta.is_incremental_safe = false;
+            }
             Some(s) => {
                 let fs = &mut self.delta.file_stats;
                 fs.gross_remove_files += 1;
@@ -743,6 +750,14 @@ mod tests {
         assert!(acc.delta.is_incremental_safe);
     }
 
+    #[test]
+    fn on_add_negative_size_trips_is_incremental_safe() {
+        let mut acc = CrcReplayAccumulator::new(Some(FileSizeHistogram::create_default()));
+        acc.on_add(-1).unwrap();
+        assert!(!acc.delta.is_incremental_safe);
+        assert!(acc.current_commit_saw_file_action);
+    }
+
     // ===== remove =====
 
     #[test]
@@ -758,6 +773,14 @@ mod tests {
     fn on_remove_missing_size_trips_is_incremental_safe() {
         let mut acc = CrcReplayAccumulator::new(None);
         acc.on_remove("p", None).unwrap();
+        assert!(!acc.delta.is_incremental_safe);
+        assert!(acc.current_commit_saw_file_action);
+    }
+
+    #[test]
+    fn on_remove_negative_size_trips_is_incremental_safe() {
+        let mut acc = CrcReplayAccumulator::new(Some(FileSizeHistogram::create_default()));
+        acc.on_remove("p", Some(-1)).unwrap();
         assert!(!acc.delta.is_incremental_safe);
         assert!(acc.current_commit_saw_file_action);
     }

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -154,8 +154,8 @@ impl LogSegment {
         let Some(version) = self.checkpoint_version else {
             return Ok(None);
         };
-        // No commit boundaries here, so the delta stays incremental-safe. It covers the full
-        // table, which `into_complete_crc` turns into a Complete CRC.
+        // The checkpoint covers the full table, so `into_complete_crc` produces a Complete CRC.
+        // Invalid Add sizes mark replay unsafe and degrade its file stats to `Indeterminate`.
         let mut acc = CrcReplayAccumulator::new(Some(FileSizeHistogram::create_default()));
         // Read only the checkpoint parquet plus any V2 sidecars via `create_checkpoint_stream`.
         let batches = self


### PR DESCRIPTION
## What changes are proposed in this pull request?

Treat negative add/remove file sizes as unsafe for incremental CRC file-stat replay. Snapshot loading now degrades file statistics to `Indeterminate` instead of propagating a cast or histogram error.

Closes #2676.

## How was this change tested?

- `cargo nextest run -p delta_kernel --lib --all-features negative_size_trips_is_incremental_safe`
- `cargo clippy -p delta_kernel --lib --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`

The full workspace clippy command currently hits an unrelated `clippy::redundant_closure` error in `ffi/src/ffi_tracing.rs:381` on upstream `main`.