### PR TITLE
fix!: normalize empty partition values to null

### DIFF
--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -21,8 +21,7 @@ use delta_kernel::expressions::{
     VariadicExpression, VariadicExpressionOp,
 };
 use delta_kernel::schema::{
-    DataType as KernelDataType, PrimitiveType, SchemaRef as KernelSchemaRef, StructField,
-    StructType,
+    DataType as KernelDataType, SchemaRef as KernelSchemaRef, StructField, StructType,
 };
 use delta_kernel::{DeltaResult, EngineData, Error};
 
@@ -390,13 +389,10 @@ fn struct_columns_from_patch(
 /// types come from `output_type`, which must be a struct holding only primitive fields (matching
 /// the kernel evaluator, which supports only primitive targets).
 ///
-/// Each field extracts its value with `cast(get_field(map, name), T)`. For a numeric or temporal
-/// type the raw value is first wrapped in `nullif(.., '')`, mapping an empty string to null before
-/// the cast, so an empty string becomes null (kernel's `empty_string_partition_cast`) while an
-/// unparseable value fails the cast (kernel's hard parse error). String and Binary keep the raw
-/// value (empty is a valid empty string / empty bytes). A missing key or null value is already null
-/// via [`get_field`]. The whole struct is nulled where the input map row is null, via `<map> IS NOT
-/// NULL`.
+/// Each field extracts its value with `cast(nullif(get_field(map, name), ''), T)`. This maps an
+/// empty string to null for every primitive target before the cast. A missing key or null value is
+/// already null via [`get_field`]. The whole struct is nulled where the input map row is null, via
+/// `<map> IS NOT NULL`.
 ///
 /// KNOWN DIVERGENCES from the kernel parser, confined to malformed or non-spec-compliant values
 /// (spec-compliant writers never emit them):
@@ -420,7 +416,7 @@ fn map_to_struct_to_df_expr(
 
     let mut args = Vec::with_capacity(target.num_fields() * 2);
     for field in target.fields() {
-        let KernelDataType::Primitive(prim) = field.data_type() else {
+        let KernelDataType::Primitive(_) = field.data_type() else {
             return Err(Error::unsupported(format!(
                 "MapToStruct only supports primitive target types, but field '{}' is {:?}",
                 field.name(),
@@ -428,12 +424,7 @@ fn map_to_struct_to_df_expr(
             )));
         };
         let raw = get_field(map.clone(), field.name().to_string());
-        let value = match prim {
-            // An empty string is a value for these two (the empty string / empty bytes) and null
-            // for every other type based on kernel.
-            PrimitiveType::String | PrimitiveType::Binary => raw,
-            _ => nullif(raw, lit("")),
-        };
+        let value = nullif(raw, lit(""));
         let arrow_type = field
             .data_type()
             .try_into_arrow()
@@ -1023,18 +1014,22 @@ mod tests {
             rendered,
             concat!(
                 r#"CASE WHEN pv IS NOT NULL THEN named_struct("#,
-                r#"Utf8("region"), CAST(get_field(pv, Utf8("region")) AS Utf8), "#,
+                r#"Utf8("region"), CAST(nullif(get_field(pv, Utf8("region")), Utf8("")) AS Utf8), "#,
                 r#"Utf8("id"), CAST(nullif(get_field(pv, Utf8("id")), Utf8("")) AS Int32)) "#,
                 r#"ELSE NULL END"#,
             )
         );
     }
 
-    /// String and Binary targets keep the raw value (empty string is a valid value), so they lower
-    /// to a bare `cast`; every other primitive first maps an empty string to null via `nullif`.
     #[rstest]
-    #[case::string_bare_cast(DataType::STRING, "CAST(get_field(pv, Utf8(\"f\")) AS Utf8)")]
-    #[case::binary_bare_cast(DataType::BINARY, "CAST(get_field(pv, Utf8(\"f\")) AS Binary)")]
+    #[case::string(
+        DataType::STRING,
+        "CAST(nullif(get_field(pv, Utf8(\"f\")), Utf8(\"\")) AS Utf8)"
+    )]
+    #[case::binary(
+        DataType::BINARY,
+        "CAST(nullif(get_field(pv, Utf8(\"f\")), Utf8(\"\")) AS Binary)"
+    )]
     #[case::integer_wraps_nullif(
         DataType::INTEGER,
         "CAST(nullif(get_field(pv, Utf8(\"f\")), Utf8(\"\")) AS Int32)"

--- a/docs/user-guide/src/reading/scan_metadata.md
+++ b/docs/user-guide/src/reading/scan_metadata.md
@@ -282,8 +282,8 @@ of parsing the string map per file. The raw string map is still present, so this
 adds the typed column.
 
 > [!TIP]
-> When the checkpoint already stores typed partition values, Kernel reads that column directly
-> and skips parsing entirely.
+> Kernel reads compatible typed checkpoint values directly. String and Binary partition schemas
+> are reconstructed from the raw map so empty strings become null.
 
 ## Cancelling a scan
 

--- a/docs/user-guide/src/reading/scan_metadata.md
+++ b/docs/user-guide/src/reading/scan_metadata.md
@@ -282,8 +282,9 @@ of parsing the string map per file. The raw string map is still present, so this
 adds the typed column.
 
 > [!TIP]
-> Kernel reads compatible typed checkpoint values directly. String and Binary partition schemas
-> are reconstructed from the raw map so empty strings become null.
+> Kernel preserves each compatible typed checkpoint field independently. String and Binary fields
+> are reconstructed from the raw map so empty strings become null, while other compatible fields
+> retain their checkpoint-native values.
 
 ## Cancelling a scan
 

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -52,7 +52,7 @@ impl StatsTransformConfig {
 /// - When `writeStatsAsStruct=false`: drop `stats_parsed` field
 ///
 /// For partitioned tables when `writeStatsAsStruct=true`, it also populates:
-/// - `partitionValues_parsed = COALESCE(partitionValues_parsed, MAP_TO_STRUCT(partitionValues))`
+/// - `partitionValues_parsed = MAP_TO_STRUCT(partitionValues)`
 ///
 /// Returns a top-level transform that wraps the nested Add transform, ensuring the
 /// full checkpoint batch is produced with the modified Add action.
@@ -193,24 +193,21 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
     ]))
 }
 
-/// Builds expression: `partitionValues_parsed = COALESCE(partitionValues_parsed,
-///     MAP_TO_STRUCT(partitionValues))`
+/// Builds expression: `partitionValues_parsed = MAP_TO_STRUCT(partitionValues)`
 ///
-/// This expression prefers existing `partitionValues_parsed`, falling back to converting
-/// the string-valued `partitionValues` map into a native typed struct. The target struct
-/// type (field names and data types) is determined by the output schema — `MAP_TO_STRUCT`
-/// itself carries no schema, so the expression evaluator uses the expected output type to
-/// parse each string value into the correct native type.
+/// The target struct type (field names and data types) is determined by the output schema --
+/// `MAP_TO_STRUCT` itself carries no schema, so the expression evaluator uses the expected output
+/// type to parse each string value into the correct native type.
 ///
-/// The fallback uses the same `MAP_TO_STRUCT` the scan applies, so an empty-string partition value
-/// reconstructs as null in both a checkpoint and a scan of its source commit.
+/// Rebuilding from the serialized map applies the same normalization as scans and avoids preserving
+/// incompatible native values from an earlier checkpoint.
 ///
 /// Column paths are relative to the full batch, not the nested Add struct.
 fn build_partition_values_parsed_expr() -> ExpressionRef {
-    Arc::new(Expression::coalesce([
-        col!(ADD_NAME, PARTITION_VALUES_PARSED_FIELD),
-        Expression::map_to_struct(col!(ADD_NAME, PARTITION_VALUES_FIELD)),
-    ]))
+    Arc::new(Expression::map_to_struct(col!(
+        ADD_NAME,
+        PARTITION_VALUES_FIELD
+    )))
 }
 
 /// Static expression: `stats = COALESCE(stats, ToJson(stats_parsed))`
@@ -434,21 +431,13 @@ mod tests {
         );
     }
 
-    /// The checkpoint falls back to `MAP_TO_STRUCT` over `partitionValues` when no native
-    /// `partitionValues_parsed` column is present, so a checkpoint reconstructs the same typed
-    /// struct the scan reads and the two can never disagree on a value.
+    /// Checkpoints rebuild `partitionValues_parsed` from the serialized map so native values from
+    /// an earlier checkpoint cannot bypass partition-value normalization.
     #[test]
-    fn build_partition_values_parsed_expr_falls_back_to_map_to_struct() {
+    fn build_partition_values_parsed_expr_uses_map_to_struct() {
         let expr = build_partition_values_parsed_expr();
-        let Expression::Variadic(coalesce) = expr.as_ref() else {
-            panic!("expected a COALESCE expression");
-        };
-        let has_map_to_struct_fallback = coalesce
-            .exprs
-            .iter()
-            .any(|e| matches!(e, Expression::MapToStruct(_)));
         assert!(
-            has_map_to_struct_fallback,
+            matches!(expr.as_ref(), Expression::MapToStruct(_)),
             "checkpoint partitionValues_parsed must reconstruct via MAP_TO_STRUCT"
         );
     }

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -203,9 +203,7 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
 /// parse each string value into the correct native type.
 ///
 /// The fallback uses the same `MAP_TO_STRUCT` the scan applies, so an empty-string partition value
-/// (only ever a foreign `""`, since kernel serializes its own empty and null partition values to
-/// JSON null on write) reconstructs into the checkpoint identically to how the scan reconstructs it
-/// from a commit.
+/// reconstructs as null in both a checkpoint and a scan of its source commit.
 ///
 /// Column paths are relative to the full batch, not the nested Add struct.
 fn build_partition_values_parsed_expr() -> ExpressionRef {

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -16,7 +16,7 @@
 use std::sync::{Arc, LazyLock};
 
 use crate::actions::{ADD_NAME, STATS_PARSED as STATS_PARSED_FIELD};
-use crate::expressions::{col, Expression, ExpressionRef, UnaryExpressionOp};
+use crate::expressions::{col, Expression, ExpressionRef, Predicate, UnaryExpressionOp};
 use crate::schema::{DataType, SchemaRef, SchemaStructPatchBuilder, StructField, StructType};
 use crate::struct_patch::ProjectionStructPatchBuilder;
 use crate::table_properties::TableProperties;
@@ -28,6 +28,94 @@ pub(crate) const PARTITION_VALUES_FIELD: &str = "partitionValues";
 pub(crate) const PARTITION_VALUES_PARSED_FIELD: &str = "partitionValues_parsed";
 const RAW_PARTITION_VALUES_PARSED: &str = "__raw_partition_values_parsed";
 const NATIVE_PARTITION_VALUES_PARSED: &str = "__native_partition_values_parsed";
+
+/// Selects raw, native, or field-level mixed sourcing for parsed partition values.
+pub(crate) enum PartitionValuesSource {
+    Raw,
+    Native(SchemaRef),
+    Mixed(PartitionValuesStaging),
+}
+
+pub(crate) struct PartitionValuesStaging {
+    partition_schema: SchemaRef,
+    raw_schema: SchemaRef,
+    native_schema: SchemaRef,
+}
+
+impl PartitionValuesSource {
+    pub(crate) fn for_schemas(
+        partition_schema: &SchemaRef,
+        native_schema: Option<&SchemaRef>,
+    ) -> Self {
+        let Some(native_schema) = native_schema else {
+            return Self::Raw;
+        };
+        let raw_fields = partition_schema
+            .fields()
+            .filter(|field| native_schema.field(field.name()).is_none())
+            .cloned()
+            .collect::<Vec<_>>();
+        if raw_fields.is_empty() {
+            Self::Native(partition_schema.clone())
+        } else {
+            Self::Mixed(PartitionValuesStaging {
+                partition_schema: partition_schema.clone(),
+                raw_schema: Arc::new(StructType::new_unchecked(raw_fields)),
+                native_schema: native_schema.clone(),
+            })
+        }
+    }
+}
+
+impl PartitionValuesStaging {
+    pub(crate) fn partition_schema(&self) -> &SchemaRef {
+        &self.partition_schema
+    }
+
+    pub(crate) fn scan_columns(&self) -> [(StructField, ExpressionRef); 2] {
+        self.columns(col!(ADD_NAME, PARTITION_VALUES_PARSED_FIELD))
+    }
+
+    fn checkpoint_columns(&self) -> [(StructField, ExpressionRef); 2] {
+        self.columns(native_partition_values_with_raw_fallback(
+            self.native_schema.as_ref(),
+        ))
+    }
+
+    fn columns(&self, native_expr: Expression) -> [(StructField, ExpressionRef); 2] {
+        [
+            (
+                StructField::nullable(
+                    RAW_PARTITION_VALUES_PARSED,
+                    self.raw_schema.as_ref().clone(),
+                ),
+                Arc::new(raw_partition_values_expr()),
+            ),
+            (
+                StructField::nullable(
+                    NATIVE_PARTITION_VALUES_PARSED,
+                    self.native_schema.as_ref().clone(),
+                ),
+                Arc::new(native_expr),
+            ),
+        ]
+    }
+
+    pub(crate) fn merge_expr(&self) -> Expression {
+        let fields = self.partition_schema.fields().map(|field| {
+            let source = if self.native_schema.field(field.name()).is_some() {
+                NATIVE_PARTITION_VALUES_PARSED
+            } else {
+                RAW_PARTITION_VALUES_PARSED
+            };
+            Expression::column([source, field.name()])
+        });
+        Expression::struct_with_nullability_from(
+            fields,
+            Expression::from_pred(col!(RAW_PARTITION_VALUES_PARSED).is_not_null()),
+        )
+    }
+}
 
 pub(crate) struct CheckpointTransform {
     pub first_output_schema: SchemaRef,
@@ -60,8 +148,9 @@ impl StatsTransformConfig {
 /// - When `writeStatsAsStruct=true`: `stats_parsed = COALESCE(stats_parsed, ParseJson(stats))`
 /// - When `writeStatsAsStruct=false`: drop `stats_parsed` field
 ///
-/// For partitioned tables when `writeStatsAsStruct=true`, it also populates:
-/// - `partitionValues_parsed = MAP_TO_STRUCT(partitionValues)`
+/// For partitioned tables when `writeStatsAsStruct=true`, it also populates
+/// `partitionValues_parsed`, preserving compatible native fields and reconstructing the remaining
+/// fields from `partitionValues`.
 ///
 /// Returns a top-level transform that wraps the nested Add transform, ensuring the
 /// full checkpoint batch is produced with the modified Add action.
@@ -121,34 +210,37 @@ pub(crate) fn build_checkpoint_transform(
         patch_builder = patch_builder.drop_at([ADD_NAME], STATS_PARSED_FIELD);
     }
 
+    let partition_values_source = partition_schema
+        .map(|schema| PartitionValuesSource::for_schemas(schema, native_partition_schema));
+
     // Handle partitionValues_parsed field (only for partitioned tables)
-    if let Some(partition_schema) = partition_schema {
+    if partition_schema.is_some() {
         if config.write_stats_as_struct {
-            if let Some(native_schema) = native_partition_schema {
-                patch_builder = patch_builder
-                    .append(
-                        StructField::nullable(
-                            RAW_PARTITION_VALUES_PARSED,
-                            partition_schema.as_ref().clone(),
-                        ),
-                        build_partition_values_parsed_expr(),
-                    )
-                    .append(
-                        StructField::nullable(
-                            NATIVE_PARTITION_VALUES_PARSED,
-                            native_schema.as_ref().clone(),
-                        ),
-                        Expression::coalesce([
-                            col!(ADD_NAME, PARTITION_VALUES_PARSED_FIELD),
-                            Expression::map_to_struct(col!(ADD_NAME, PARTITION_VALUES_FIELD)),
-                        ]),
+            match partition_values_source.as_ref() {
+                Some(PartitionValuesSource::Raw) => {
+                    patch_builder = patch_builder.replace_expr_at(
+                        [ADD_NAME],
+                        PARTITION_VALUES_PARSED_FIELD,
+                        raw_partition_values_expr(),
                     );
-            } else {
-                patch_builder = patch_builder.replace_expr_at(
-                    [ADD_NAME],
-                    PARTITION_VALUES_PARSED_FIELD,
-                    build_partition_values_parsed_expr(),
-                );
+                }
+                Some(PartitionValuesSource::Native(native_schema)) => {
+                    patch_builder = patch_builder.replace_expr_at(
+                        [ADD_NAME],
+                        PARTITION_VALUES_PARSED_FIELD,
+                        native_partition_values_with_raw_fallback(native_schema.as_ref()),
+                    );
+                }
+                Some(PartitionValuesSource::Mixed(staging)) => {
+                    for (field, expr) in staging.checkpoint_columns() {
+                        patch_builder = patch_builder.append(field, expr);
+                    }
+                }
+                None => {
+                    return Err(Error::internal_error(
+                        "partition values source missing for partitioned table",
+                    ));
+                }
             }
         } else {
             // Drop partitionValues_parsed since it was added to read schema
@@ -157,8 +249,8 @@ pub(crate) fn build_checkpoint_transform(
     }
 
     let (first_output_schema, first_expr) = patch_builder.build()?;
-    let Some((partition_schema, native_schema)) = partition_schema
-        .zip(native_partition_schema)
+    let Some(PartitionValuesSource::Mixed(staging)) = partition_values_source
+        .as_ref()
         .filter(|_| config.write_stats_as_struct)
     else {
         return Ok(CheckpointTransform {
@@ -168,16 +260,15 @@ pub(crate) fn build_checkpoint_transform(
             output_expr: None,
         });
     };
-    let mixed_expr = mixed_partition_values_expr(partition_schema, native_schema);
     let (output_schema, output_expr) = ProjectionStructPatchBuilder::new(&first_output_schema)
         .replace_at(
             [ADD_NAME],
             PARTITION_VALUES_PARSED_FIELD,
             StructField::nullable(
                 PARTITION_VALUES_PARSED_FIELD,
-                partition_schema.as_ref().clone(),
+                staging.partition_schema.as_ref().clone(),
             ),
-            mixed_expr,
+            staging.merge_expr(),
         )
         .drop(RAW_PARTITION_VALUES_PARSED)
         .drop(NATIVE_PARTITION_VALUES_PARSED)
@@ -254,39 +345,23 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
     ]))
 }
 
-/// Builds expression: `partitionValues_parsed = MAP_TO_STRUCT(partitionValues)`
-///
-/// The target struct type (field names and data types) is determined by the output schema --
-/// `MAP_TO_STRUCT` itself carries no schema, so the expression evaluator uses the expected output
-/// type to parse each string value into the correct native type.
-///
-/// Rebuilding from the serialized map applies the same normalization as scans. When compatible
-/// native fields exist, the caller combines this raw struct with those fields independently.
-///
-/// Column paths are relative to the full batch, not the nested Add struct.
-fn build_partition_values_parsed_expr() -> ExpressionRef {
-    Arc::new(Expression::map_to_struct(col!(
-        ADD_NAME,
-        PARTITION_VALUES_FIELD
-    )))
+pub(crate) fn raw_partition_values_expr() -> Expression {
+    Expression::map_to_struct(col!(ADD_NAME, PARTITION_VALUES_FIELD))
 }
 
-fn mixed_partition_values_expr(
-    partition_schema: &StructType,
-    native_partition_schema: &StructType,
-) -> Expression {
-    let fields = partition_schema.fields().map(|field| {
-        let source = if native_partition_schema.field(field.name()).is_some() {
-            NATIVE_PARTITION_VALUES_PARSED
-        } else {
-            RAW_PARTITION_VALUES_PARSED
-        };
-        Expression::column([source, field.name()])
-    });
-    Expression::struct_with_nullability_from(
-        fields,
-        Expression::from_pred(col!(RAW_PARTITION_VALUES_PARSED).is_not_null()),
-    )
+fn native_partition_values_with_raw_fallback(native_schema: &StructType) -> Expression {
+    let native_fields = native_schema
+        .fields()
+        .map(|field| Expression::column([ADD_NAME, PARTITION_VALUES_PARSED_FIELD, field.name()]));
+    let native_is_present_or_not_add = Predicate::or(
+        col!(ADD_NAME, PARTITION_VALUES_PARSED_FIELD).is_not_null(),
+        col!(ADD_NAME, PARTITION_VALUES_FIELD).is_null(),
+    );
+    let native_candidate = Expression::struct_with_nullability_from(
+        native_fields,
+        Expression::from_pred(native_is_present_or_not_add),
+    );
+    Expression::coalesce([native_candidate, raw_partition_values_expr()])
 }
 
 /// Static expression: `stats = COALESCE(stats, ToJson(stats_parsed))`
@@ -525,9 +600,9 @@ mod tests {
     /// Raw fallback fields use `MAP_TO_STRUCT`; compatible native fields are merged separately.
     #[test]
     fn build_partition_values_parsed_expr_uses_map_to_struct() {
-        let expr = build_partition_values_parsed_expr();
+        let expr = raw_partition_values_expr();
         assert!(
-            matches!(expr.as_ref(), Expression::MapToStruct(_)),
+            matches!(expr, Expression::MapToStruct(_)),
             "checkpoint partitionValues_parsed must reconstruct via MAP_TO_STRUCT"
         );
     }
@@ -561,7 +636,8 @@ mod tests {
         .unwrap();
         let handler = SyncJsonHandler::new(None);
         let input_json: StringArray = vec![
-            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"1970-01-01 00:00:00"},"partitionValues_parsed":{"event_time":"1970-01-01T08:00:00Z"},"stats":"{\"numRecords\":1}"}}"#,
+            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"invalid-timestamp"},"partitionValues_parsed":{"event_time":"1970-01-01T08:00:00Z"},"stats":"{\"numRecords\":1}"}}"#,
+            r#"{}"#,
         ]
         .into();
         let input = handler
@@ -589,7 +665,8 @@ mod tests {
             .evaluate(first.as_ref())
             .unwrap();
         let expected_json: StringArray = vec![
-            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"1970-01-01 00:00:00"},"partitionValues_parsed":{"name":null,"event_time":"1970-01-01T08:00:00Z"},"stats":"{\"numRecords\":1}","stats_parsed":{"numRecords":1}}}"#,
+            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"invalid-timestamp"},"partitionValues_parsed":{"name":null,"event_time":"1970-01-01T08:00:00Z"},"stats":"{\"numRecords\":1}","stats_parsed":{"numRecords":1}}}"#,
+            r#"{}"#,
         ]
         .into();
         let expected = handler

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -26,6 +26,15 @@ use crate::{DeltaResult, Error};
 pub(crate) const STATS_FIELD: &str = "stats";
 pub(crate) const PARTITION_VALUES_FIELD: &str = "partitionValues";
 pub(crate) const PARTITION_VALUES_PARSED_FIELD: &str = "partitionValues_parsed";
+const RAW_PARTITION_VALUES_PARSED: &str = "__raw_partition_values_parsed";
+const NATIVE_PARTITION_VALUES_PARSED: &str = "__native_partition_values_parsed";
+
+pub(crate) struct CheckpointTransform {
+    pub first_output_schema: SchemaRef,
+    pub first_expr: ExpressionRef,
+    pub output_schema: SchemaRef,
+    pub output_expr: Option<ExpressionRef>,
+}
 
 /// Configuration for stats transformation based on table properties.
 #[derive(Debug, Clone, Copy)]
@@ -84,7 +93,8 @@ pub(crate) fn build_checkpoint_transform(
     read_schema: &StructType,
     stats_schema: &SchemaRef,
     partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<(SchemaRef, ExpressionRef)> {
+    native_partition_schema: Option<&SchemaRef>,
+) -> DeltaResult<CheckpointTransform> {
     let mut patch_builder = ProjectionStructPatchBuilder::new(read_schema);
 
     // Handle stats field
@@ -112,21 +122,72 @@ pub(crate) fn build_checkpoint_transform(
     }
 
     // Handle partitionValues_parsed field (only for partitioned tables)
-    if partition_schema.is_some() {
+    if let Some(partition_schema) = partition_schema {
         if config.write_stats_as_struct {
-            let pv_parsed_expr = build_partition_values_parsed_expr();
-            patch_builder = patch_builder.replace_expr_at(
-                [ADD_NAME],
-                PARTITION_VALUES_PARSED_FIELD,
-                pv_parsed_expr,
-            );
+            if let Some(native_schema) = native_partition_schema {
+                patch_builder = patch_builder
+                    .append(
+                        StructField::nullable(
+                            RAW_PARTITION_VALUES_PARSED,
+                            partition_schema.as_ref().clone(),
+                        ),
+                        build_partition_values_parsed_expr(),
+                    )
+                    .append(
+                        StructField::nullable(
+                            NATIVE_PARTITION_VALUES_PARSED,
+                            native_schema.as_ref().clone(),
+                        ),
+                        Expression::coalesce([
+                            col!(ADD_NAME, PARTITION_VALUES_PARSED_FIELD),
+                            Expression::map_to_struct(col!(ADD_NAME, PARTITION_VALUES_FIELD)),
+                        ]),
+                    );
+            } else {
+                patch_builder = patch_builder.replace_expr_at(
+                    [ADD_NAME],
+                    PARTITION_VALUES_PARSED_FIELD,
+                    build_partition_values_parsed_expr(),
+                );
+            }
         } else {
             // Drop partitionValues_parsed since it was added to read schema
             patch_builder = patch_builder.drop_at([ADD_NAME], PARTITION_VALUES_PARSED_FIELD);
         }
     }
 
-    patch_builder.build()
+    let (first_output_schema, first_expr) = patch_builder.build()?;
+    let Some((partition_schema, native_schema)) = partition_schema
+        .zip(native_partition_schema)
+        .filter(|_| config.write_stats_as_struct)
+    else {
+        return Ok(CheckpointTransform {
+            output_schema: first_output_schema.clone(),
+            first_output_schema,
+            first_expr,
+            output_expr: None,
+        });
+    };
+    let mixed_expr = mixed_partition_values_expr(partition_schema, native_schema);
+    let (output_schema, output_expr) = ProjectionStructPatchBuilder::new(&first_output_schema)
+        .replace_at(
+            [ADD_NAME],
+            PARTITION_VALUES_PARSED_FIELD,
+            StructField::nullable(
+                PARTITION_VALUES_PARSED_FIELD,
+                partition_schema.as_ref().clone(),
+            ),
+            mixed_expr,
+        )
+        .drop(RAW_PARTITION_VALUES_PARSED)
+        .drop(NATIVE_PARTITION_VALUES_PARSED)
+        .build()?;
+    Ok(CheckpointTransform {
+        first_output_schema,
+        first_expr,
+        output_schema,
+        output_expr: Some(output_expr),
+    })
 }
 
 /// Builds a read schema that includes `stats_parsed` and optionally `partitionValues_parsed`
@@ -199,8 +260,8 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
 /// `MAP_TO_STRUCT` itself carries no schema, so the expression evaluator uses the expected output
 /// type to parse each string value into the correct native type.
 ///
-/// Rebuilding from the serialized map applies the same normalization as scans and avoids preserving
-/// incompatible native values from an earlier checkpoint.
+/// Rebuilding from the serialized map applies the same normalization as scans. When compatible
+/// native fields exist, the caller combines this raw struct with those fields independently.
 ///
 /// Column paths are relative to the full batch, not the nested Add struct.
 fn build_partition_values_parsed_expr() -> ExpressionRef {
@@ -208,6 +269,24 @@ fn build_partition_values_parsed_expr() -> ExpressionRef {
         ADD_NAME,
         PARTITION_VALUES_FIELD
     )))
+}
+
+fn mixed_partition_values_expr(
+    partition_schema: &StructType,
+    native_partition_schema: &StructType,
+) -> Expression {
+    let fields = partition_schema.fields().map(|field| {
+        let source = if native_partition_schema.field(field.name()).is_some() {
+            NATIVE_PARTITION_VALUES_PARSED
+        } else {
+            RAW_PARTITION_VALUES_PARSED
+        };
+        Expression::column([source, field.name()])
+    });
+    Expression::struct_with_nullability_from(
+        fields,
+        Expression::from_pred(col!(RAW_PARTITION_VALUES_PARSED).is_not_null()),
+    )
 }
 
 /// Static expression: `stats = COALESCE(stats, ToJson(stats_parsed))`
@@ -266,8 +345,13 @@ mod tests {
 
     use super::*;
     use crate::actions::NUM_RECORDS;
+    use crate::arrow::array::StringArray;
+    use crate::engine::sync::json::SyncJsonHandler;
+    use crate::engine::sync::SyncEngine;
     use crate::expressions::ExpressionStructPatch;
     use crate::schema::{schema, schema_ref, MapType};
+    use crate::unit_test_utils::{assert_batch_matches, string_array_to_engine_data};
+    use crate::{Engine as _, JsonHandler as _};
 
     #[test]
     fn test_config_defaults() {
@@ -357,8 +441,15 @@ mod tests {
             partition_schema.map(AsRef::as_ref),
         )
         .expect("build checkpoint read schema should produce a valid schema");
-        super::build_checkpoint_transform(config, &read_schema, stats_schema, partition_schema)
-            .expect("build checkpoint transform should produce a valid schema and expression")
+        let transform = super::build_checkpoint_transform(
+            config,
+            &read_schema,
+            stats_schema,
+            partition_schema,
+            None,
+        )
+        .expect("build checkpoint transform should produce a valid schema and expression");
+        (transform.output_schema, transform.first_expr)
     }
 
     fn add_schema(with_partition_schema: bool) -> StructType {
@@ -431,8 +522,7 @@ mod tests {
         );
     }
 
-    /// Checkpoints rebuild `partitionValues_parsed` from the serialized map so native values from
-    /// an earlier checkpoint cannot bypass partition-value normalization.
+    /// Raw fallback fields use `MAP_TO_STRUCT`; compatible native fields are merged separately.
     #[test]
     fn build_partition_values_parsed_expr_uses_map_to_struct() {
         let expr = build_partition_values_parsed_expr();
@@ -440,6 +530,75 @@ mod tests {
             matches!(expr.as_ref(), Expression::MapToStruct(_)),
             "checkpoint partitionValues_parsed must reconstruct via MAP_TO_STRUCT"
         );
+    }
+
+    #[test]
+    fn mixed_partition_schema_preserves_native_timestamp_and_normalizes_string() {
+        let config = StatsTransformConfig {
+            write_stats_as_json: true,
+            write_stats_as_struct: true,
+        };
+        let stats_schema = schema_ref! { nullable NUM_RECORDS: LONG };
+        let partition_schema = schema_ref! {
+            nullable "name": STRING,
+            nullable "event_time": TIMESTAMP,
+        };
+        let native_schema = schema_ref! { nullable "event_time": TIMESTAMP };
+        let base_schema = schema! { nullable ADD_NAME: (add_schema(true)) };
+        let read_schema = build_checkpoint_read_schema(
+            &base_schema,
+            stats_schema.as_ref(),
+            Some(native_schema.as_ref()),
+        )
+        .unwrap();
+        let transform = super::build_checkpoint_transform(
+            &config,
+            &read_schema,
+            &stats_schema,
+            Some(&partition_schema),
+            Some(&native_schema),
+        )
+        .unwrap();
+        let handler = SyncJsonHandler::new(None);
+        let input_json: StringArray = vec![
+            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"1970-01-01 00:00:00"},"partitionValues_parsed":{"event_time":"1970-01-01T08:00:00Z"},"stats":"{\"numRecords\":1}"}}"#,
+        ]
+        .into();
+        let input = handler
+            .parse_json(string_array_to_engine_data(input_json), read_schema.clone())
+            .unwrap();
+        let engine = SyncEngine::new();
+        let first = engine
+            .evaluation_handler()
+            .new_expression_evaluator(
+                read_schema,
+                transform.first_expr,
+                transform.first_output_schema.clone().into(),
+            )
+            .unwrap()
+            .evaluate(input.as_ref())
+            .unwrap();
+        let actual = engine
+            .evaluation_handler()
+            .new_expression_evaluator(
+                transform.first_output_schema,
+                transform.output_expr.unwrap(),
+                transform.output_schema.clone().into(),
+            )
+            .unwrap()
+            .evaluate(first.as_ref())
+            .unwrap();
+        let expected_json: StringArray = vec![
+            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"1970-01-01 00:00:00"},"partitionValues_parsed":{"name":null,"event_time":"1970-01-01T08:00:00Z"},"stats":"{\"numRecords\":1}","stats_parsed":{"numRecords":1}}}"#,
+        ]
+        .into();
+        let expected = handler
+            .parse_json(
+                string_array_to_engine_data(expected_json),
+                transform.output_schema,
+            )
+            .unwrap();
+        assert_batch_matches(actual, expected);
     }
 
     #[rstest]

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -141,6 +141,7 @@ pub(crate) use checkpoint_shape::{CheckpointShape, CheckpointType};
 use checkpoint_transform::{
     build_checkpoint_read_schema, build_checkpoint_transform, StatsTransformConfig,
 };
+pub(crate) use checkpoint_transform::{raw_partition_values_expr, PartitionValuesSource};
 use sidecar::{create_sidecar_action_batch, SidecarSplitter, SingleSidecarDataIterator};
 #[cfg(test)]
 mod tests;

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -367,8 +367,10 @@ pub struct CheckpointWriter {
 
     is_v2: bool,
     read_schema: SchemaRef,
+    first_output_schema: SchemaRef,
     output_schema: SchemaRef,
     transform_expr: ExpressionRef,
+    output_transform_expr: Option<ExpressionRef>,
 }
 
 impl RetentionCalculator for CheckpointWriter {
@@ -389,16 +391,30 @@ impl CheckpointWriter {
         snapshot.log_segment().validate_published()?;
 
         let schema_context = Self::checkpoint_schema_context(&snapshot, engine)?;
+        let native_partition_schema = schema_context
+            .partition_schema
+            .as_ref()
+            .map(|schema| {
+                snapshot
+                    .log_segment()
+                    .native_partition_values_schema(engine, schema)
+            })
+            .transpose()?
+            .flatten();
+        let partition_read_schema = native_partition_schema
+            .as_ref()
+            .or(schema_context.partition_schema.as_ref());
         let read_schema = build_checkpoint_read_schema(
             &schema_context.checkpoint_base_schema,
             &schema_context.stats_schema,
-            schema_context.partition_schema.as_deref(),
+            partition_read_schema.map(AsRef::as_ref),
         )?;
-        let (output_schema, transform_expr) = build_checkpoint_transform(
+        let transform = build_checkpoint_transform(
             &schema_context.stats_config,
             &read_schema,
             &schema_context.stats_schema,
             schema_context.partition_schema.as_ref(),
+            native_partition_schema.as_ref(),
         )?;
 
         Ok(Self {
@@ -406,8 +422,10 @@ impl CheckpointWriter {
             snapshot,
             is_v2: schema_context.is_v2,
             read_schema,
-            output_schema,
-            transform_expr,
+            first_output_schema: transform.first_output_schema,
+            output_schema: transform.output_schema,
+            transform_expr: transform.first_expr,
+            output_transform_expr: transform.output_expr,
         })
     }
 
@@ -484,14 +502,29 @@ impl CheckpointWriter {
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
             self.read_schema.clone(),
             self.transform_expr.clone(),
-            self.output_schema.clone().into(),
+            self.first_output_schema.clone().into(),
         )?;
+        let output_evaluator = self
+            .output_transform_expr
+            .as_ref()
+            .map(|expr| {
+                engine.evaluation_handler().new_expression_evaluator(
+                    self.first_output_schema.clone(),
+                    expr.clone(),
+                    self.output_schema.clone().into(),
+                )
+            })
+            .transpose()?;
 
         // Apply stats transform to each reconciled batch
         let transformed = checkpoint_data.map(move |batch_result| {
             let batch = batch_result?;
             let (data, sv) = batch.filtered_data.into_parts();
             let transformed = evaluator.evaluate(data.as_ref())?;
+            let transformed = match output_evaluator.as_ref() {
+                Some(evaluator) => evaluator.evaluate(transformed.as_ref())?,
+                None => transformed,
+            };
             Ok(ActionReconciliationBatch {
                 filtered_data: FilteredEngineData::try_new(transformed, sv)?,
                 actions_count: batch.actions_count,

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -949,6 +949,10 @@ pub fn coalesce_arrays(
 /// `parse_scalar`; spec-compliant writers only emit canonical values, so the extra leniency is
 /// harmless on the read path. All other types go through `parse_scalar`.
 fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option<Scalar>> {
+    if raw.is_empty() {
+        return Ok(None);
+    }
+
     match prim {
         PrimitiveType::Date => {
             let days = Date32Type::parse(raw).ok_or_else(|| {

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -942,8 +942,6 @@ pub fn coalesce_arrays(
 
 /// Parses one raw partition-value string into its target [`Scalar`], or `None` for a null value.
 ///
-/// An empty string casts via [`PrimitiveType::empty_string_partition_cast`].
-///
 /// Date and timestamp use arrow's `Date32Type::parse` / `string_to_datetime`, which are much
 /// faster than `parse_scalar`'s chrono path and yield the same value for valid Delta partition
 /// values. These arrow parsers accept a superset of the canonical formats (e.g. `20240115`, or a
@@ -951,9 +949,6 @@ pub fn coalesce_arrays(
 /// `parse_scalar`; spec-compliant writers only emit canonical values, so the extra leniency is
 /// harmless on the read path. All other types go through `parse_scalar`.
 fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option<Scalar>> {
-    if raw.is_empty() {
-        return Ok(prim.empty_string_partition_cast());
-    }
     match prim {
         PrimitiveType::Date => {
             let days = Date32Type::parse(raw).ok_or_else(|| {
@@ -980,8 +975,8 @@ fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option
 }
 
 /// Evaluates `MAP_TO_STRUCT(map_col, output_schema)`: extracts keys from a `Map<String, String>`
-/// and parses each value into its target type, producing a `StructArray`. An empty-string value
-/// casts via [`PrimitiveType::empty_string_partition_cast`].
+/// and parses each value into its target type using Delta's partition value serialization rules,
+/// producing a `StructArray`.
 ///
 /// - Missing keys produce null values
 /// - Parse errors are propagated (indicating a broken table)
@@ -2963,10 +2958,8 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// An empty-string map value casts via `empty_string_partition_cast`: `""` for string, empty
-    /// bytes for binary, and null for every other type.
     #[test]
-    fn test_map_to_struct_empty_string_cast_semantics() {
+    fn test_map_to_struct_empty_strings_are_null() {
         let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
         builder.keys().append_value("region");
         builder.values().append_value("");
@@ -2999,16 +2992,14 @@ mod tests {
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
-        assert!(!regions.is_null(0));
-        assert_eq!(regions.value(0), "");
+        assert!(regions.is_null(0));
 
         let blobs = structs
             .column(1)
             .as_any()
             .downcast_ref::<crate::arrow::array::BinaryArray>()
             .unwrap();
-        assert!(!blobs.is_null(0));
-        assert_eq!(blobs.value(0), b"");
+        assert!(blobs.is_null(0));
 
         let counts = structs
             .column(2)

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -703,19 +703,15 @@ impl ParseJsonExpression {
 ///   round or rescale.
 /// - BOOLEAN: accept case-insensitive `true` or `false`, with no numeric or yes/no aliases.
 /// - DATE: parse `{year}-{month}-{day}`.
-/// - TIMESTAMP: parse either 1) an ISO 8601 timestamp with an explicit offset, normalized to UTC;
-///   or 2) a space-separated timestamp without a zone. Currently, kernel expects case 2 to be
-///   interpreted as UTC, however the protocol specifies that it should be interpreted in the
-///   writer's time zone. TODO: MapToStruct needs to be updated to take in a timezone as a
-///   parameter.
+/// - TIMESTAMP: parse an ISO 8601 timestamp with an explicit offset and normalize it to UTC, or
+///   interpret a space-separated timestamp without a zone as UTC. The protocol assigns the latter
+///   form the writer's time zone, but this expression does not carry that zone.
 /// - TIMESTAMP_NTZ: parse a space-separated timestamp without an offset and preserve the local
 ///   wall-clock value.
 /// - Interval types: parse an ANSI interval literal accepted by [`PrimitiveType::parse_scalar`].
 /// - VOID: reject every non-empty value.
 ///
-/// Kernel's UTC interpretation of a zone-less TIMESTAMP is explicit here: the Delta protocol says
-/// that form is interpreted in the writer's time zone, but that time zone is not carried by this
-/// expression. Modern writers should use the protocol's UTC-adjusted ISO 8601 form.
+/// Writers should use the protocol's UTC-adjusted ISO 8601 timestamp form.
 ///
 /// Non-empty geometry and geography values are unsupported. Struct, array, map, and variant target
 /// fields are not primitive partition types and are rejected. Any other unparseable non-empty value

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -688,10 +688,8 @@ impl ParseJsonExpression {
 ///
 /// # Value parsing
 ///
-/// A literal empty string has special read compatibility behavior: it stays empty for STRING,
-/// becomes empty bytes for BINARY, and becomes null for every other primitive type. Delta writers
-/// normally encode an empty partition value as JSON null, but readers must preserve this behavior
-/// for existing tables that contain a literal empty string.
+/// A literal empty string becomes null for every primitive type, as required by the Delta
+/// [protocol].
 ///
 /// Non-empty strings must follow the Delta [protocol] partition value serialization rules. Kernel's
 /// reference evaluator implements these rules with [`PrimitiveType::parse_scalar`] and equivalent
@@ -728,7 +726,7 @@ impl ParseJsonExpression {
 /// A connector generally cannot implement this contract as `CAST(map[key] AS target_type)`.
 /// Generic casts may accept additional boolean spellings, round or rescale decimals, use a session
 /// time zone, or turn malformed values into null. Implement a dedicated parser (or validate before
-/// casting), handle the empty-string cases before parsing, and preserve the input map's row-level
+/// casting), normalize empty strings before parsing, and preserve the input map's row-level
 /// nulls on the output struct.
 ///
 /// [protocol]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization
@@ -933,8 +931,8 @@ impl Expression {
 
     /// Parses an Add action's `partitionValues` map into a typed struct whose schema comes from the
     /// evaluator's result type. A null map produces a null struct; missing and null values produce
-    /// null fields; literal empty strings stay empty only for STRING and BINARY. Duplicate-key
-    /// behavior is undefined. See [`MapToStructExpression`] for the complete contract.
+    /// null fields; literal empty strings also produce null fields. Duplicate-key behavior is
+    /// undefined. See [`MapToStructExpression`] for the complete contract.
     pub fn map_to_struct(map_expr: impl Into<Expression>) -> Self {
         Self::MapToStruct(MapToStructExpression::new(map_expr))
     }

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -922,10 +922,6 @@ impl PrimitiveType {
     /// protocol's [partition value serialization] rules. An empty string parses as
     /// [`Scalar::Null`].
     ///
-    /// Note: the scan read path does not use this empty-string handling for partition values; it
-    /// applies a type-dependent cast instead (empty string on a string or binary column surfaces as
-    /// an empty value rather than null).
-    ///
     /// Timestamp and TimestampNtz accept the space-separated form `{year}-{month}-{day}
     /// {hour}:{minute}:{second}[.{fraction}]`. Timestamp (only) also accepts ISO 8601 / RFC 3339
     /// strings such as `1970-01-01T00:00:00.123456Z`; an explicit offset is honored and the value
@@ -1009,26 +1005,6 @@ impl PrimitiveType {
             Geometry(_) | Geography(_) => Err(Error::Unsupported(format!(
                 "parse_scalar is not supported for {self:?}"
             ))),
-        }
-    }
-
-    /// Casts an empty partition-value string to its target [`Scalar`], or `None` for a null value.
-    ///
-    /// An empty string is a value for a string or binary column (the empty string / empty bytes)
-    /// but has no representation for any other type, so it casts to null there. This aligns with
-    /// Spark, which reads the partition-value map as a non-ANSI SQL cast, and is the empty-string
-    /// rule the scan read path applies, in place of [`parse_scalar`]'s null-for-every-type
-    /// handling.
-    ///
-    /// A literal empty string only reaches this path from a foreign writer, since kernel
-    /// serializes its own empty and null partition values to JSON null on write.
-    ///
-    /// [`parse_scalar`]: PrimitiveType::parse_scalar
-    pub(crate) fn empty_string_partition_cast(&self) -> Option<Scalar> {
-        match self {
-            PrimitiveType::String => Some(Scalar::String(String::new())),
-            PrimitiveType::Binary => Some(Scalar::Binary(Vec::new())),
-            _ => None,
         }
     }
 

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -28,7 +28,9 @@ use crate::path::{LogPathFileType, ParsedLogPath};
 #[cfg(feature = "declarative-plans")]
 use crate::plans::ir::nodes::{FileType, ScanFile};
 use crate::schema::compare::SchemaComparison;
-use crate::schema::{lazy_schema_ref, DataType, SchemaRef, StructField, StructType, ToSchema as _};
+use crate::schema::{
+    lazy_schema_ref, DataType, PrimitiveType, SchemaRef, StructField, StructType, ToSchema as _,
+};
 use crate::utils::require;
 #[cfg(feature = "declarative-plans")]
 use crate::Scalar;
@@ -1490,7 +1492,9 @@ impl LogSegment {
     ///
     /// Validates that:
     /// 1. The `add.partitionValues_parsed` field exists in the checkpoint schema
-    /// 2. The types for partition columns present in both schemas are compatible
+    /// 2. The partition schema has no string or binary columns, whose empty values require
+    ///    normalization from the serialized map
+    /// 3. The types for partition columns present in both schemas are compatible
     ///
     /// Missing partition columns in the checkpoint are OK (they simply won't contribute
     /// to row group skipping). Returns `false` if `partitionValues_parsed` doesn't exist
@@ -1499,6 +1503,20 @@ impl LogSegment {
         checkpoint_schema: &StructType,
         partition_schema: &StructType,
     ) -> bool {
+        if partition_schema.fields().any(|field| {
+            matches!(
+                field.data_type(),
+                DataType::Primitive(PrimitiveType::String)
+                    | DataType::Primitive(PrimitiveType::Binary)
+            )
+        }) {
+            debug!(
+                "partitionValues_parsed not compatible: string and binary partition values must \
+                 be normalized from add.partitionValues"
+            );
+            return false;
+        }
+
         let Some(partition_parsed) =
             Self::get_field_from_add(checkpoint_schema, "partitionValues_parsed")
         else {

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1494,11 +1494,10 @@ impl LogSegment {
     /// 1. The `add.partitionValues_parsed` field exists in the checkpoint schema
     /// 2. The partition schema has no string or binary columns, whose empty values require
     ///    normalization from the serialized map
-    /// 3. The types for partition columns present in both schemas are compatible
+    /// 3. Every requested partition column is present with a compatible type
     ///
-    /// Missing partition columns in the checkpoint are OK (they simply won't contribute
-    /// to row group skipping). Returns `false` if `partitionValues_parsed` doesn't exist
-    /// or has incompatible types for any shared column.
+    /// Returns `false` if `partitionValues_parsed` doesn't exist, omits a requested field, or has
+    /// an incompatible type.
     pub(crate) fn schema_has_compatible_partition_values_parsed(
         checkpoint_schema: &StructType,
         partition_schema: &StructType,
@@ -1531,6 +1530,17 @@ impl LogSegment {
             );
             return false;
         };
+
+        if partition_schema
+            .fields()
+            .any(|field| partition_struct.field(field.name()).is_none())
+        {
+            debug!(
+                "partitionValues_parsed not compatible: checkpoint schema omits a requested \
+                 partition field"
+            );
+            return false;
+        }
 
         // Flat struct: reuse the recursive type checker (trivial case with no nesting)
         if !Self::structs_have_compatible_types(

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -62,12 +62,12 @@ pub(crate) struct CheckpointReadInfo {
     /// When `true`, checkpoint batches can use stats_parsed directly instead of parsing JSON.
     #[allow(unused)]
     pub has_stats_parsed: bool,
-    /// Whether the checkpoint has compatible pre-parsed partition values.
-    /// When `true`, checkpoint batches can read typed partition values directly from
-    /// `partitionValues_parsed` instead of parsing strings from `partitionValues`.
+    /// Compatible checkpoint-native partition fields that can be trusted as typed values.
+    /// String and binary fields are excluded because their empty values must be normalized from
+    /// `partitionValues`. Missing or incompatible fields are likewise omitted.
     #[serde(default)]
     #[allow(unused)]
-    pub has_partition_values_parsed: bool,
+    pub native_partition_values_schema: Option<SchemaRef>,
     /// The schema used to read checkpoint files, potentially including stats_parsed.
     #[allow(unused)]
     pub checkpoint_read_schema: SchemaRef,
@@ -80,7 +80,7 @@ impl CheckpointReadInfo {
     pub(crate) fn without_stats_parsed() -> Self {
         Self {
             has_stats_parsed: false,
-            has_partition_values_parsed: false,
+            native_partition_values_schema: None,
             checkpoint_read_schema: LOG_ADD_SCHEMA.clone(),
         }
     }
@@ -998,6 +998,18 @@ impl LogSegment {
         }
     }
 
+    /// Returns checkpoint-native partition fields that can be preserved during checkpoint writes.
+    pub(crate) fn native_partition_values_schema(
+        &self,
+        engine: &dyn Engine,
+        partition_schema: &StructType,
+    ) -> DeltaResult<Option<SchemaRef>> {
+        let (file_actions_schema, _) = self.get_file_actions_schema_and_sidecars(engine, None)?;
+        Ok(file_actions_schema.as_ref().and_then(|schema| {
+            Self::compatible_partition_values_parsed_schema(schema, partition_schema)
+        }))
+    }
+
     /// Reads a parquet footer schema, threading the cancellation token so a cancelled request can
     /// stop before or during the read (the read itself fails fast on an already-cancelled token).
     fn read_footer_schema(
@@ -1077,9 +1089,9 @@ impl LogSegment {
                     Self::schema_has_compatible_stats_parsed(file_schema, stats)
                 });
 
-        let has_partition_values_parsed = partition_schema
+        let native_partition_values_schema = partition_schema
             .zip(file_actions_schema.as_ref())
-            .is_some_and(|(ps, fs)| Self::schema_has_compatible_partition_values_parsed(fs, ps));
+            .and_then(|(ps, fs)| Self::compatible_partition_values_parsed_schema(fs, ps));
 
         // JSON checkpoint stats are required when structured stats cannot satisfy the scan schema.
         let needs_json_stats_fallback = stats_schema.is_some()
@@ -1092,8 +1104,9 @@ impl LogSegment {
             });
 
         let needs_sidecar = need_file_actions && !sidecar_files.is_empty();
-        let needs_add_augmentation =
-            needs_json_stats_fallback || has_stats_parsed || has_partition_values_parsed;
+        let needs_add_augmentation = needs_json_stats_fallback
+            || has_stats_parsed
+            || native_partition_values_schema.is_some();
         let augmented_checkpoint_read_schema = if needs_add_augmentation || needs_sidecar {
             let mut new_fields: Vec<StructField> = if let (true, Some(add_field)) =
                 (needs_add_augmentation, action_schema.field("add"))
@@ -1113,8 +1126,11 @@ impl LogSegment {
                     add_fields.push(StructField::nullable("stats_parsed", ss.clone()));
                 }
 
-                if let (true, Some(ps)) = (has_partition_values_parsed, partition_schema) {
-                    add_fields.push(StructField::nullable("partitionValues_parsed", ps.clone()));
+                if let Some(ps) = native_partition_values_schema.as_ref() {
+                    add_fields.push(StructField::nullable(
+                        "partitionValues_parsed",
+                        ps.as_ref().clone(),
+                    ));
                 }
 
                 // Rebuild schema with modified add field
@@ -1213,7 +1229,7 @@ impl LogSegment {
 
         let checkpoint_info = CheckpointReadInfo {
             has_stats_parsed,
-            has_partition_values_parsed,
+            native_partition_values_schema,
             checkpoint_read_schema: augmented_checkpoint_read_schema,
         };
         Ok(ActionsWithCheckpointInfo {
@@ -1488,39 +1504,24 @@ impl LogSegment {
         true
     }
 
-    /// Checks if a checkpoint schema contains a usable `add.partitionValues_parsed` field.
+    /// Returns the usable fields from a checkpoint's `add.partitionValues_parsed` struct.
     ///
-    /// Validates that:
-    /// 1. The `add.partitionValues_parsed` field exists in the checkpoint schema
-    /// 2. The partition schema has no string or binary columns, whose empty values require
-    ///    normalization from the serialized map
-    /// 3. Every requested partition column is present with a compatible type
+    /// The `add.partitionValues_parsed` field must exist in the checkpoint schema.
     ///
-    /// Returns `false` if `partitionValues_parsed` doesn't exist, omits a requested field, or has
-    /// an incompatible type.
-    pub(crate) fn schema_has_compatible_partition_values_parsed(
+    /// String and binary fields are excluded because their empty values require normalization from
+    /// the serialized map. Missing and incompatible fields are also excluded so callers can fall
+    /// back to the raw map for those fields.
+    ///
+    /// Returns `None` when no checkpoint-native field can be used.
+    pub(crate) fn compatible_partition_values_parsed_schema(
         checkpoint_schema: &StructType,
         partition_schema: &StructType,
-    ) -> bool {
-        if partition_schema.fields().any(|field| {
-            matches!(
-                field.data_type(),
-                DataType::Primitive(PrimitiveType::String)
-                    | DataType::Primitive(PrimitiveType::Binary)
-            )
-        }) {
-            debug!(
-                "partitionValues_parsed not compatible: string and binary partition values must \
-                 be normalized from add.partitionValues"
-            );
-            return false;
-        }
-
+    ) -> Option<SchemaRef> {
         let Some(partition_parsed) =
             Self::get_field_from_add(checkpoint_schema, "partitionValues_parsed")
         else {
             debug!("partitionValues_parsed not compatible: checkpoint schema does not contain add.partitionValues_parsed field");
-            return false;
+            return None;
         };
 
         let DataType::Struct(partition_struct) = partition_parsed.data_type() else {
@@ -1528,31 +1529,29 @@ impl LogSegment {
                 "partitionValues_parsed not compatible: add.partitionValues_parsed is not a Struct, got {:?}",
                 partition_parsed.data_type()
             );
-            return false;
+            return None;
         };
 
-        if partition_schema
-            .fields()
-            .any(|field| partition_struct.field(field.name()).is_none())
-        {
-            debug!(
-                "partitionValues_parsed not compatible: checkpoint schema omits a requested \
-                 partition field"
-            );
-            return false;
-        }
-
-        // Flat struct: reuse the recursive type checker (trivial case with no nesting)
-        if !Self::structs_have_compatible_types(
-            partition_struct,
-            partition_schema,
-            "partitionValues_parsed",
-        ) {
-            return false;
-        }
-
-        debug!("Checkpoint schema has compatible partitionValues_parsed for partition pruning");
-        true
+        let fields = partition_schema.fields().filter_map(|needed| {
+            if matches!(
+                needed.data_type(),
+                DataType::Primitive(PrimitiveType::String)
+                    | DataType::Primitive(PrimitiveType::Binary)
+            ) {
+                return None;
+            }
+            let available = partition_struct.field(needed.name())?;
+            let single_available = StructType::new_unchecked([available.clone()]);
+            let single_needed = StructType::new_unchecked([needed.clone()]);
+            Self::structs_have_compatible_types(
+                &single_available,
+                &single_needed,
+                "partitionValues_parsed",
+            )
+            .then(|| needed.clone())
+        });
+        let fields = fields.collect::<Vec<_>>();
+        (!fields.is_empty()).then(|| Arc::new(StructType::new_unchecked(fields)))
     }
 }
 

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -970,9 +970,14 @@ impl LogSegment {
                 Ok((Some(schema), vec![]))
             }
             UuidCheckpoint if checkpoint.extension.as_str() == "json" => {
-                // JSON checkpoint is always V2. No checkpoint schema is available since JSON
-                // checkpoints don't have a parquet footer to read.
-                self.read_sidecar_schema_and_files(engine, checkpoint, None, cancellation_token)
+                // JSON checkpoints are always V2 and have no parquet footer, so an applicable
+                // hint is the only schema available for inline file actions.
+                self.read_sidecar_schema_and_files(
+                    engine,
+                    checkpoint,
+                    hint_schema.as_ref(),
+                    cancellation_token,
+                )
             }
             ClassicCheckpoint | UuidCheckpoint if checkpoint.extension.as_str() == "parquet" => {
                 // Parquet checkpoint (classic-named or UUID-named): either can be V1 or V2.

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -4364,11 +4364,11 @@ fn create_checkpoint_schema_without_partition_parsed() -> StructType {
 fn test_partition_values_parsed_compatible_basic() {
     let checkpoint_schema = create_checkpoint_schema_with_partition_parsed(vec![
         StructField::nullable("date", DataType::DATE),
-        StructField::nullable("region", DataType::STRING),
+        StructField::nullable("count", DataType::INTEGER),
     ]);
     let partition_schema = schema! {
         nullable "date": DATE,
-        nullable "region": STRING,
+        nullable "count": INTEGER,
     };
     assert!(LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
@@ -4383,11 +4383,11 @@ fn test_partition_values_parsed_missing_field() {
             "date",
             DataType::DATE,
         )]);
-    // Partition schema expects both date and region, but checkpoint only has date.
+    // Partition schema expects both date and count, but checkpoint only has date.
     // Missing fields are OK — they just won't contribute to row group skipping.
     let partition_schema = schema! {
         nullable "date": DATE,
-        nullable "region": STRING,
+        nullable "count": INTEGER,
     };
     assert!(LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
@@ -4400,11 +4400,28 @@ fn test_partition_values_parsed_extra_field() {
     // Checkpoint has extra fields beyond what partition schema needs — fine
     let checkpoint_schema = create_checkpoint_schema_with_partition_parsed(vec![
         StructField::nullable("date", DataType::DATE),
-        StructField::nullable("region", DataType::STRING),
+        StructField::nullable("count", DataType::INTEGER),
         StructField::nullable("extra", DataType::INTEGER),
     ]);
     let partition_schema = schema! { nullable "date": DATE };
     assert!(LogSegment::schema_has_compatible_partition_values_parsed(
+        &checkpoint_schema,
+        &partition_schema,
+    ));
+}
+
+#[rstest::rstest]
+#[case::string(DataType::STRING)]
+#[case::binary(DataType::BINARY)]
+fn test_partition_values_parsed_empty_string_types_are_incompatible(#[case] data_type: DataType) {
+    let checkpoint_schema =
+        create_checkpoint_schema_with_partition_parsed(vec![StructField::nullable(
+            "part",
+            data_type.clone(),
+        )]);
+    let partition_schema =
+        StructType::new_unchecked(vec![StructField::nullable("part", data_type)]);
+    assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
     ));

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -4377,19 +4377,17 @@ fn test_partition_values_parsed_compatible_basic() {
 }
 
 #[test]
-fn test_partition_values_parsed_missing_field() {
+fn test_partition_values_parsed_missing_field_is_incompatible() {
     let checkpoint_schema =
         create_checkpoint_schema_with_partition_parsed(vec![StructField::nullable(
             "date",
             DataType::DATE,
         )]);
-    // Partition schema expects both date and count, but checkpoint only has date.
-    // Missing fields are OK — they just won't contribute to row group skipping.
     let partition_schema = schema! {
         nullable "date": DATE,
         nullable "count": INTEGER,
     };
-    assert!(LogSegment::schema_has_compatible_partition_values_parsed(
+    assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
     ));

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1779,6 +1779,91 @@ async fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidec
     Ok(())
 }
 
+#[tokio::test]
+async fn test_json_v2_leaf_uses_hint_schema_for_native_partition_values() -> DeltaResult<()> {
+    let (store, log_root) = new_in_memory_store();
+    let engine = SyncEngine::new_with_store(store.clone());
+    let filename = "00000000000000000010.checkpoint.80a083e8-7026-4e79-81be-64bd76c43a11.json";
+    let checkpoint_json = r#"{"add":{"path":"file.parquet","partitionValues":{"event_time":"invalid-timestamp"},"partitionValues_parsed":{"event_time":"1970-01-01T08:00:00Z"},"size":1,"modificationTime":2,"dataChange":true}}"#;
+    store
+        .put(
+            &Path::from(format!("_delta_log/{filename}")),
+            checkpoint_json.to_string().into(),
+        )
+        .await?;
+
+    let action_schema = schema_ref! {
+        nullable "add": {
+            nullable "path": STRING,
+            nullable "partitionValues": { STRING => nullable STRING },
+            nullable "size": LONG,
+            nullable "modificationTime": LONG,
+            nullable "dataChange": BOOLEAN,
+        },
+    };
+    let hint_schema = schema_ref! {
+        nullable "add": {
+            nullable "path": STRING,
+            nullable "partitionValues": { STRING => nullable STRING },
+            nullable "partitionValues_parsed": { nullable "event_time": TIMESTAMP },
+            nullable "size": LONG,
+            nullable "modificationTime": LONG,
+            nullable "dataChange": BOOLEAN,
+        },
+    };
+    let partition_schema = schema_ref! { nullable "event_time": TIMESTAMP };
+    let checkpoint_file = log_root.join(filename)?.to_string();
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path(&checkpoint_file)],
+            ..Default::default()
+        },
+        log_root,
+        None,
+        Some(LastCheckpointHint {
+            version: 10,
+            checkpoint_schema: Some(hint_schema),
+            v2_checkpoint: Some(LastCheckpointV2 {
+                path: filename.to_string(),
+                sidecar_files: Some(vec![]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+    )?;
+
+    let checkpoint_result = log_segment.create_checkpoint_stream(
+        &engine,
+        action_schema,
+        None,
+        None,
+        Some(partition_schema.as_ref()),
+        None,
+    )?;
+    assert_eq!(
+        checkpoint_result
+            .checkpoint_info
+            .native_partition_values_schema
+            .as_ref(),
+        Some(&partition_schema)
+    );
+    let read_schema = checkpoint_result.checkpoint_info.checkpoint_read_schema;
+    let mut actions = checkpoint_result.actions;
+    let ActionsBatch {
+        actions: actual,
+        is_log_batch,
+    } = actions.next().expect("JSON checkpoint batch")?;
+    assert!(!is_log_batch);
+    let expected_json: StringArray = vec![checkpoint_json].into();
+    let expected = SyncJsonHandler::new(None)
+        .parse_json(string_array_to_engine_data(expected_json), read_schema)
+        .unwrap();
+    assert_batch_matches(actual, expected);
+    assert!(actions.next().is_none());
+
+    Ok(())
+}
+
 // Tests the end-to-end process of creating a checkpoint stream.
 // Verifies that:
 // - The checkpoint file is read and produces batches containing references to sidecar files.

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -4253,7 +4253,8 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
     assert!(
         checkpoint_result
             .checkpoint_info
-            .has_partition_values_parsed,
+            .native_partition_values_schema
+            .is_some(),
         "Expected has_partition_values_parsed to be true"
     );
 
@@ -4316,9 +4317,10 @@ async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -
 
     // Verify it's false
     assert!(
-        !checkpoint_result
+        checkpoint_result
             .checkpoint_info
-            .has_partition_values_parsed,
+            .native_partition_values_schema
+            .is_none(),
         "Expected has_partition_values_parsed to be false"
     );
 
@@ -4370,14 +4372,16 @@ fn test_partition_values_parsed_compatible_basic() {
         nullable "date": DATE,
         nullable "count": INTEGER,
     };
-    assert!(LogSegment::schema_has_compatible_partition_values_parsed(
+    let compatible = LogSegment::compatible_partition_values_parsed_schema(
         &checkpoint_schema,
         &partition_schema,
-    ));
+    )
+    .expect("both native fields should be compatible");
+    assert_eq!(compatible.as_ref(), &partition_schema);
 }
 
 #[test]
-fn test_partition_values_parsed_missing_field_is_incompatible() {
+fn test_partition_values_parsed_missing_field_uses_available_subset() {
     let checkpoint_schema =
         create_checkpoint_schema_with_partition_parsed(vec![StructField::nullable(
             "date",
@@ -4387,10 +4391,12 @@ fn test_partition_values_parsed_missing_field_is_incompatible() {
         nullable "date": DATE,
         nullable "count": INTEGER,
     };
-    assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
+    let compatible = LogSegment::compatible_partition_values_parsed_schema(
         &checkpoint_schema,
         &partition_schema,
-    ));
+    )
+    .expect("the date field should remain usable");
+    assert_eq!(compatible.as_ref(), &schema! { nullable "date": DATE });
 }
 
 #[test]
@@ -4402,10 +4408,12 @@ fn test_partition_values_parsed_extra_field() {
         StructField::nullable("extra", DataType::INTEGER),
     ]);
     let partition_schema = schema! { nullable "date": DATE };
-    assert!(LogSegment::schema_has_compatible_partition_values_parsed(
+    let compatible = LogSegment::compatible_partition_values_parsed_schema(
         &checkpoint_schema,
         &partition_schema,
-    ));
+    )
+    .expect("the requested native field should be compatible");
+    assert_eq!(compatible.as_ref(), &partition_schema);
 }
 
 #[rstest::rstest]
@@ -4419,10 +4427,11 @@ fn test_partition_values_parsed_empty_string_types_are_incompatible(#[case] data
         )]);
     let partition_schema =
         StructType::new_unchecked(vec![StructField::nullable("part", data_type)]);
-    assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
+    assert!(LogSegment::compatible_partition_values_parsed_schema(
         &checkpoint_schema,
         &partition_schema,
-    ));
+    )
+    .is_none());
 }
 
 #[test]
@@ -4433,20 +4442,22 @@ fn test_partition_values_parsed_type_mismatch() {
             DataType::STRING,
         )]);
     let partition_schema = schema! { nullable "date": DATE };
-    assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
+    assert!(LogSegment::compatible_partition_values_parsed_schema(
         &checkpoint_schema,
         &partition_schema,
-    ));
+    )
+    .is_none());
 }
 
 #[test]
 fn test_partition_values_parsed_not_present() {
     let checkpoint_schema = create_checkpoint_schema_without_partition_parsed();
     let partition_schema = schema! { nullable "date": DATE };
-    assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
+    assert!(LogSegment::compatible_partition_values_parsed_schema(
         &checkpoint_schema,
         &partition_schema,
-    ));
+    )
+    .is_none());
 }
 
 #[test]
@@ -4459,10 +4470,11 @@ fn test_partition_values_parsed_not_a_struct() {
         },
     };
     let partition_schema = schema! { nullable "date": DATE };
-    assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
+    assert!(LogSegment::compatible_partition_values_parsed_schema(
         &checkpoint_schema,
         &partition_schema,
-    ));
+    )
+    .is_none());
 }
 
 #[test]
@@ -4472,12 +4484,34 @@ fn test_partition_values_parsed_empty_partition_schema() {
             "date",
             DataType::DATE,
         )]);
-    // Empty partition schema — any partitionValues_parsed is compatible
+    // An empty target has no native field to preserve.
     let partition_schema = schema! {};
-    assert!(LogSegment::schema_has_compatible_partition_values_parsed(
+    assert!(LogSegment::compatible_partition_values_parsed_schema(
         &checkpoint_schema,
         &partition_schema,
-    ));
+    )
+    .is_none());
+}
+
+#[test]
+fn test_partition_values_parsed_mixed_schema_preserves_only_trusted_native_fields() {
+    let checkpoint_schema = create_checkpoint_schema_with_partition_parsed(vec![
+        StructField::nullable("name", DataType::STRING),
+        StructField::nullable("event_time", DataType::TIMESTAMP),
+    ]);
+    let partition_schema = schema! {
+        nullable "name": STRING,
+        nullable "event_time": TIMESTAMP,
+    };
+    let compatible = LogSegment::compatible_partition_values_parsed_schema(
+        &checkpoint_schema,
+        &partition_schema,
+    )
+    .expect("timestamp should remain checkpoint-native");
+    assert_eq!(
+        compatible.as_ref(),
+        &schema! { nullable "event_time": TIMESTAMP }
+    );
 }
 
 // ============================================================================

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -10,6 +10,7 @@ use super::metrics::ScanMetrics;
 use super::state_info::StateInfo;
 use super::{PhysicalPredicate, ScanMetadata, COMMIT_READ_SCHEMA};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
+use crate::checkpoint::{raw_partition_values_expr, PartitionValuesSource};
 use crate::engine_data::{EngineData, GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{
     col, column_expr_ref, column_name, null_lit, ColumnName, Expression, ExpressionRef, Predicate,
@@ -828,9 +829,6 @@ fn scan_row_schema_with_parsed_columns(
     Ok(Arc::new(patch.build(&SCAN_ROW_SCHEMA)?))
 }
 
-const RAW_PARTITION_VALUES_PARSED: &str = "__raw_partition_values_parsed";
-const NATIVE_PARTITION_VALUES_PARSED: &str = "__native_partition_values_parsed";
-
 #[allow(clippy::too_many_arguments)]
 fn build_checkpoint_transform_evaluators(
     engine: &dyn Engine,
@@ -843,10 +841,17 @@ fn build_checkpoint_transform_evaluators(
     native_partition_schema: Option<SchemaRef>,
     output_schema: SchemaRef,
 ) -> DeltaResult<Vec<Arc<dyn ExpressionEvaluator>>> {
-    let Some((partition_schema, native_partition_schema)) = partition_schema
+    let partition_values_source = partition_schema
         .as_ref()
-        .zip(native_partition_schema.as_ref())
-    else {
+        .map(|schema| PartitionValuesSource::for_schemas(schema, native_partition_schema.as_ref()));
+    if !matches!(
+        partition_values_source,
+        Some(PartitionValuesSource::Mixed(_))
+    ) {
+        let has_native_partition_values = matches!(
+            partition_values_source,
+            Some(PartitionValuesSource::Native(_))
+        );
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
             checkpoint_read_schema,
             get_add_transform_expr(
@@ -855,24 +860,26 @@ fn build_checkpoint_transform_evaluators(
                 skip_stats,
                 synthesize_json,
                 partition_schema,
-                false,
+                has_native_partition_values,
             ),
             output_schema.into(),
         )?;
         return Ok(vec![evaluator]);
+    }
+    let Some(PartitionValuesSource::Mixed(staging)) = partition_values_source else {
+        return Err(Error::internal_error(
+            "mixed partition values source expected for staged transform",
+        ));
     };
 
     let base_schema = scan_row_schema_with_parsed_columns(physical_stats_schema.clone(), None)?;
+    let [(raw_field, raw_expr), (native_field, native_expr)] = staging.scan_columns();
+    let raw_field_name = raw_field.name().clone();
+    let native_field_name = native_field.name().clone();
     let staging_schema = Arc::new(
         SchemaStructPatchBuilder::new()
-            .append(StructField::nullable(
-                RAW_PARTITION_VALUES_PARSED,
-                partition_schema.as_ref().clone(),
-            ))
-            .append(StructField::nullable(
-                NATIVE_PARTITION_VALUES_PARSED,
-                native_partition_schema.as_ref().clone(),
-            ))
+            .append(raw_field)
+            .append(native_field)
             .build(&base_schema)?,
     );
     let mut staging_fields = get_add_transform_fields(
@@ -881,29 +888,22 @@ fn build_checkpoint_transform_evaluators(
         skip_stats,
         synthesize_json,
     );
-    staging_fields.push(Arc::new(Expression::map_to_struct(col!(
-        "add.partitionValues"
-    ))));
-    staging_fields.push(Arc::new(Expression::coalesce([
-        col!("add.partitionValues_parsed"),
-        Expression::map_to_struct(col!("add.partitionValues")),
-    ])));
+    staging_fields.extend([raw_expr, native_expr]);
     let staging_evaluator = engine.evaluation_handler().new_expression_evaluator(
         checkpoint_read_schema,
         Arc::new(Expression::struct_from(staging_fields)),
         staging_schema.clone().into(),
     )?;
 
-    let mixed_expr = mixed_partition_values_expr(partition_schema, native_partition_schema);
     let (_, output_expr) = ProjectionStructPatchBuilder::new(&staging_schema)
-        .drop(RAW_PARTITION_VALUES_PARSED)
-        .drop(NATIVE_PARTITION_VALUES_PARSED)
+        .drop(raw_field_name)
+        .drop(native_field_name)
         .append(
             StructField::nullable(
                 PARTITION_VALUES_PARSED_NAME,
-                partition_schema.as_ref().clone(),
+                staging.partition_schema().as_ref().clone(),
             ),
-            mixed_expr,
+            staging.merge_expr(),
         )
         .build()?;
     let output_evaluator = engine.evaluation_handler().new_expression_evaluator(
@@ -912,24 +912,6 @@ fn build_checkpoint_transform_evaluators(
         output_schema.into(),
     )?;
     Ok(vec![staging_evaluator, output_evaluator])
-}
-
-fn mixed_partition_values_expr(
-    partition_schema: &StructType,
-    native_partition_schema: &StructType,
-) -> Expression {
-    let fields = partition_schema.fields().map(|field| {
-        let source = if native_partition_schema.field(field.name()).is_some() {
-            NATIVE_PARTITION_VALUES_PARSED
-        } else {
-            RAW_PARTITION_VALUES_PARSED
-        };
-        Expression::column([source, field.name()])
-    });
-    Expression::struct_with_nullability_from(
-        fields,
-        Expression::from_pred(col!(RAW_PARTITION_VALUES_PARSED).is_not_null()),
-    )
 }
 
 /// Build the add transform expression with optional stats and partition value parsing.
@@ -974,7 +956,7 @@ fn get_add_transform_expr(
         let pv_parsed_expr = if has_partition_values_parsed {
             col!("add.partitionValues_parsed")
         } else {
-            Expression::map_to_struct(col!("add.partitionValues"))
+            raw_partition_values_expr()
         };
         fields.push(Arc::new(pv_parsed_expr));
     }
@@ -2323,7 +2305,8 @@ mod tests {
         .unwrap();
         let handler = SyncJsonHandler::new(None);
         let input_json: StringArray = vec![
-            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"1970-01-01 00:00:00"},"partitionValues_parsed":{"event_time":"1970-01-01T08:00:00Z"},"size":1,"modificationTime":2,"dataChange":true}}"#,
+            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"invalid-timestamp"},"partitionValues_parsed":{"event_time":"1970-01-01T08:00:00Z"},"size":1,"modificationTime":2,"dataChange":true}}"#,
+            r#"{}"#,
         ]
         .into();
         let input = handler
@@ -2334,7 +2317,8 @@ mod tests {
             actual = evaluator.evaluate(actual.as_ref()).unwrap();
         }
         let expected_json: StringArray = vec![
-            r#"{"path":"file.parquet","size":1,"modificationTime":2,"fileConstantValues":{"partitionValues":{"name":"","event_time":"1970-01-01 00:00:00"}},"partitionValues_parsed":{"name":null,"event_time":"1970-01-01T08:00:00Z"}}"#,
+            r#"{"path":"file.parquet","size":1,"modificationTime":2,"fileConstantValues":{"partitionValues":{"name":"","event_time":"invalid-timestamp"}},"partitionValues_parsed":{"name":null,"event_time":"1970-01-01T08:00:00Z"}}"#,
+            r#"{"fileConstantValues":{}}"#,
         ]
         .into();
         let expected = handler

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -841,9 +841,9 @@ fn scan_row_schema_with_parsed_columns(
 ///   the JSON stats column; JSON-only checkpoints and commits retain `add.stats` as fallback input.
 /// - `partition_schema`: Schema of typed partition columns for data skipping, or None if partition
 ///   value parsing is not needed.
-/// - `has_partition_values_parsed`: Whether the source carries a native `partitionValues_parsed`
-///   column (checkpoint). When true it is read directly; otherwise the struct is reconstructed from
-///   the `partitionValues` string map.
+/// - `has_partition_values_parsed`: Whether the source has a compatible native
+///   `partitionValues_parsed` column that can be read directly. Otherwise the struct is
+///   reconstructed from the `partitionValues` string map.
 ///
 /// The transform includes `stats_parsed` only when `physical_stats_schema` is Some,
 /// and `partitionValues_parsed` only when `partition_schema` is Some.
@@ -902,10 +902,10 @@ fn get_add_transform_expr(
     // engine-facing typed output column.
     if partition_schema.is_some() {
         let pv_parsed_expr = if has_partition_values_parsed {
-            // Checkpoint carries a native partitionValues_parsed column - read it directly.
+            // Checkpoint carries a compatible native partitionValues_parsed column.
             col!("add.partitionValues_parsed")
         } else {
-            // No native column (JSON commit): reconstruct from the string map.
+            // Reconstruct from the string map when no compatible native column is available.
             Expression::map_to_struct(col!("add.partitionValues"))
         };
         fields.push(Arc::new(pv_parsed_expr));

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -28,6 +28,7 @@ use crate::schema::{
     lazy_schema_ref, ColumnNamesAndTypes, DataType, MapType, SchemaRef, SchemaStructPatchBuilder,
     StructField, StructType, ToSchema as _,
 };
+use crate::struct_patch::ProjectionStructPatchBuilder;
 use crate::table_features::ColumnMappingMode;
 use crate::utils::{require, FoldWithOption as _};
 use crate::{DeltaResult, Engine, Error, ExpressionEvaluator};
@@ -162,9 +163,9 @@ pub struct ScanLogReplayProcessor {
     /// StructPatch for log batches (commit files) - uses ParseJson for stats and MapToStruct
     /// for partition values
     commit_transform: Arc<dyn ExpressionEvaluator>,
-    /// StructPatch for checkpoint batches - reads pre-parsed stats_parsed and
-    /// partitionValues_parsed directly when available, otherwise parses from raw columns
-    checkpoint_transform: Arc<dyn ExpressionEvaluator>,
+    /// Projections for checkpoint batches. Compatible partition fields are preserved natively,
+    /// while fields needing normalization or fallback are parsed from the raw map.
+    checkpoint_transforms: Vec<Arc<dyn ExpressionEvaluator>>,
     state_info: Arc<StateInfo>,
     /// A set of (data file path, dv_unique_id) pairs that have been seen thus
     /// far in the log. This is used to filter out files with Remove actions as
@@ -243,7 +244,7 @@ impl ScanLogReplayProcessor {
     ) -> DeltaResult<Self> {
         let CheckpointReadInfo {
             has_stats_parsed,
-            has_partition_values_parsed,
+            native_partition_values_schema,
             checkpoint_read_schema,
         } = checkpoint_info.clone();
         let ScanStatsOptions {
@@ -327,17 +328,16 @@ impl ScanLogReplayProcessor {
                 output_schema.clone().into(),
             )?,
             // Checkpoint transform: read pre-parsed columns directly when available
-            checkpoint_transform: engine.evaluation_handler().new_expression_evaluator(
+            checkpoint_transforms: build_checkpoint_transform_evaluators(
+                engine,
                 checkpoint_read_schema,
-                get_add_transform_expr(
-                    stats_schema_for_transform,
-                    has_stats_parsed,
-                    skip_stats,
-                    synthesize_json,
-                    partition_schema_for_transform,
-                    has_partition_values_parsed,
-                ),
-                output_schema.into(),
+                stats_schema_for_transform,
+                has_stats_parsed,
+                skip_stats,
+                synthesize_json,
+                partition_schema_for_transform,
+                native_partition_values_schema,
+                output_schema,
             )?,
             seen_file_keys,
             state_info,
@@ -489,12 +489,15 @@ impl ScanLogReplayProcessor {
         actions: &dyn EngineData,
         is_log_batch: bool,
     ) -> DeltaResult<(Box<dyn EngineData>, Vec<bool>)> {
-        let transform = if is_log_batch {
-            &self.commit_transform
+        let transformed = if is_log_batch {
+            self.commit_transform.evaluate(actions)?
         } else {
-            &self.checkpoint_transform
+            let mut transformed = None;
+            for evaluator in &self.checkpoint_transforms {
+                transformed = Some(evaluator.evaluate(transformed.as_deref().unwrap_or(actions))?);
+            }
+            transformed.ok_or_else(|| Error::internal_error("missing checkpoint transform"))?
         };
-        let transformed = transform.evaluate(actions)?;
         require!(
             transformed.len() == actions.len(),
             Error::internal_error(format!(
@@ -825,6 +828,110 @@ fn scan_row_schema_with_parsed_columns(
     Ok(Arc::new(patch.build(&SCAN_ROW_SCHEMA)?))
 }
 
+const RAW_PARTITION_VALUES_PARSED: &str = "__raw_partition_values_parsed";
+const NATIVE_PARTITION_VALUES_PARSED: &str = "__native_partition_values_parsed";
+
+#[allow(clippy::too_many_arguments)]
+fn build_checkpoint_transform_evaluators(
+    engine: &dyn Engine,
+    checkpoint_read_schema: SchemaRef,
+    physical_stats_schema: Option<SchemaRef>,
+    has_stats_parsed: bool,
+    skip_stats: bool,
+    synthesize_json: bool,
+    partition_schema: Option<SchemaRef>,
+    native_partition_schema: Option<SchemaRef>,
+    output_schema: SchemaRef,
+) -> DeltaResult<Vec<Arc<dyn ExpressionEvaluator>>> {
+    let Some((partition_schema, native_partition_schema)) = partition_schema
+        .as_ref()
+        .zip(native_partition_schema.as_ref())
+    else {
+        let evaluator = engine.evaluation_handler().new_expression_evaluator(
+            checkpoint_read_schema,
+            get_add_transform_expr(
+                physical_stats_schema,
+                has_stats_parsed,
+                skip_stats,
+                synthesize_json,
+                partition_schema,
+                false,
+            ),
+            output_schema.into(),
+        )?;
+        return Ok(vec![evaluator]);
+    };
+
+    let base_schema = scan_row_schema_with_parsed_columns(physical_stats_schema.clone(), None)?;
+    let staging_schema = Arc::new(
+        SchemaStructPatchBuilder::new()
+            .append(StructField::nullable(
+                RAW_PARTITION_VALUES_PARSED,
+                partition_schema.as_ref().clone(),
+            ))
+            .append(StructField::nullable(
+                NATIVE_PARTITION_VALUES_PARSED,
+                native_partition_schema.as_ref().clone(),
+            ))
+            .build(&base_schema)?,
+    );
+    let mut staging_fields = get_add_transform_fields(
+        physical_stats_schema,
+        has_stats_parsed,
+        skip_stats,
+        synthesize_json,
+    );
+    staging_fields.push(Arc::new(Expression::map_to_struct(col!(
+        "add.partitionValues"
+    ))));
+    staging_fields.push(Arc::new(Expression::coalesce([
+        col!("add.partitionValues_parsed"),
+        Expression::map_to_struct(col!("add.partitionValues")),
+    ])));
+    let staging_evaluator = engine.evaluation_handler().new_expression_evaluator(
+        checkpoint_read_schema,
+        Arc::new(Expression::struct_from(staging_fields)),
+        staging_schema.clone().into(),
+    )?;
+
+    let mixed_expr = mixed_partition_values_expr(partition_schema, native_partition_schema);
+    let (_, output_expr) = ProjectionStructPatchBuilder::new(&staging_schema)
+        .drop(RAW_PARTITION_VALUES_PARSED)
+        .drop(NATIVE_PARTITION_VALUES_PARSED)
+        .append(
+            StructField::nullable(
+                PARTITION_VALUES_PARSED_NAME,
+                partition_schema.as_ref().clone(),
+            ),
+            mixed_expr,
+        )
+        .build()?;
+    let output_evaluator = engine.evaluation_handler().new_expression_evaluator(
+        staging_schema,
+        output_expr,
+        output_schema.into(),
+    )?;
+    Ok(vec![staging_evaluator, output_evaluator])
+}
+
+fn mixed_partition_values_expr(
+    partition_schema: &StructType,
+    native_partition_schema: &StructType,
+) -> Expression {
+    let fields = partition_schema.fields().map(|field| {
+        let source = if native_partition_schema.field(field.name()).is_some() {
+            NATIVE_PARTITION_VALUES_PARSED
+        } else {
+            RAW_PARTITION_VALUES_PARSED
+        };
+        Expression::column([source, field.name()])
+    });
+    Expression::struct_with_nullability_from(
+        fields,
+        Expression::from_pred(col!(RAW_PARTITION_VALUES_PARSED).is_not_null()),
+    )
+}
+
 /// Build the add transform expression with optional stats and partition value parsing.
 ///
 /// # Parameters
@@ -841,9 +948,9 @@ fn scan_row_schema_with_parsed_columns(
 ///   the JSON stats column; JSON-only checkpoints and commits retain `add.stats` as fallback input.
 /// - `partition_schema`: Schema of typed partition columns for data skipping, or None if partition
 ///   value parsing is not needed.
-/// - `has_partition_values_parsed`: Whether the source has a compatible native
-///   `partitionValues_parsed` column that can be read directly. Otherwise the struct is
-///   reconstructed from the `partitionValues` string map.
+/// - `has_partition_values_parsed`: Whether the source's full native `partitionValues_parsed`
+///   column can be read directly. Otherwise this one-stage helper reconstructs the struct from the
+///   `partitionValues` string map.
 ///
 /// The transform includes `stats_parsed` only when `physical_stats_schema` is Some,
 /// and `partitionValues_parsed` only when `partition_schema` is Some.
@@ -856,6 +963,31 @@ fn get_add_transform_expr(
     partition_schema: Option<SchemaRef>,
     has_partition_values_parsed: bool,
 ) -> ExpressionRef {
+    let mut fields = get_add_transform_fields(
+        physical_stats_schema,
+        has_stats_parsed,
+        skip_stats,
+        synthesize_json,
+    );
+
+    if partition_schema.is_some() {
+        let pv_parsed_expr = if has_partition_values_parsed {
+            col!("add.partitionValues_parsed")
+        } else {
+            Expression::map_to_struct(col!("add.partitionValues"))
+        };
+        fields.push(Arc::new(pv_parsed_expr));
+    }
+
+    Arc::new(Expression::struct_from(fields))
+}
+
+fn get_add_transform_fields(
+    physical_stats_schema: Option<SchemaRef>,
+    has_stats_parsed: bool,
+    skip_stats: bool,
+    synthesize_json: bool,
+) -> Vec<ExpressionRef> {
     let stats_expr = if skip_stats {
         Arc::new(null_lit(DataType::STRING))
     } else if has_stats_parsed && synthesize_json {
@@ -898,20 +1030,7 @@ fn get_add_transform_expr(
         fields.push(Arc::new(stats_parsed_expr));
     }
 
-    // Add partitionValues_parsed when partition columns are needed for data skipping or for the
-    // engine-facing typed output column.
-    if partition_schema.is_some() {
-        let pv_parsed_expr = if has_partition_values_parsed {
-            // Checkpoint carries a compatible native partitionValues_parsed column.
-            col!("add.partitionValues_parsed")
-        } else {
-            // Reconstruct from the string map when no compatible native column is available.
-            Expression::map_to_struct(col!("add.partitionValues"))
-        };
-        fields.push(Arc::new(pv_parsed_expr));
-    }
-
-    Arc::new(Expression::struct_from(fields))
+    fields
 }
 
 // TODO: Move this to transaction/mod.rs once `scan_metadata_from` is pub, as this is used for
@@ -1177,10 +1296,13 @@ mod tests {
     use rstest::rstest;
 
     use super::{
-        get_add_transform_expr, scan_action_iter, InternalScanState, ScanLogReplayProcessor,
-        ScanPartitionValuesOptions, ScanStatsOptions, SerializableScanState,
+        build_checkpoint_transform_evaluators, get_add_transform_expr, scan_action_iter,
+        scan_row_schema_with_parsed_columns, InternalScanState, ScanLogReplayProcessor,
+        ScanPartitionValuesOptions, ScanStatsOptions, SerializableScanState, COMMIT_READ_SCHEMA,
     };
     use crate::actions::get_commit_schema;
+    use crate::arrow::array::StringArray;
+    use crate::engine::sync::json::SyncJsonHandler;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{
         col, column_name, lit, null_lit, BinaryExpressionOp, Expression, OpaquePredicateOp,
@@ -1203,10 +1325,14 @@ mod tests {
         add_batch_with_remove, add_batch_with_remove_and_partition, run_with_validate_callback,
     };
     use crate::scan::PhysicalPredicate;
-    use crate::schema::{schema_ref, DataType, MetadataColumnSpec, SchemaRef};
+    use crate::schema::{
+        schema_ref, DataType, MetadataColumnSpec, SchemaRef, SchemaStructPatchBuilder, StructField,
+    };
     use crate::table_features::ColumnMappingMode;
-    use crate::unit_test_utils::assert_result_error_with_message;
-    use crate::{DeltaResult, Expression as Expr, ExpressionRef};
+    use crate::unit_test_utils::{
+        assert_batch_matches, assert_result_error_with_message, string_array_to_engine_data,
+    };
+    use crate::{DeltaResult, Expression as Expr, ExpressionRef, JsonHandler as _};
 
     fn test_checkpoint_info() -> CheckpointReadInfo {
         CheckpointReadInfo::without_stats_parsed()
@@ -2151,5 +2277,69 @@ mod tests {
             &null_lit(DataType::STRING),
             "structured-only checkpoint stats output must be a typed NULL"
         );
+    }
+
+    #[test]
+    fn checkpoint_scan_transform_preserves_native_timestamp_and_normalizes_string() {
+        let partition_schema = schema_ref! {
+            nullable "name": STRING,
+            nullable "event_time": TIMESTAMP,
+        };
+        let native_schema = schema_ref! { nullable "event_time": TIMESTAMP };
+        let add_field = COMMIT_READ_SCHEMA.field("add").unwrap();
+        let DataType::Struct(add_schema) = add_field.data_type() else {
+            panic!("add must be a struct");
+        };
+        let add_schema = SchemaStructPatchBuilder::new()
+            .append(StructField::nullable(
+                "partitionValues_parsed",
+                native_schema.as_ref().clone(),
+            ))
+            .build(add_schema)
+            .unwrap();
+        let read_schema = Arc::new(
+            SchemaStructPatchBuilder::new()
+                .replace(
+                    "add",
+                    StructField::new("add", add_schema, add_field.is_nullable()),
+                )
+                .build(&COMMIT_READ_SCHEMA)
+                .unwrap(),
+        );
+        let output_schema =
+            scan_row_schema_with_parsed_columns(None, Some(partition_schema.clone())).unwrap();
+        let engine = SyncEngine::new();
+        let evaluators = build_checkpoint_transform_evaluators(
+            &engine,
+            read_schema.clone(),
+            None,
+            false,
+            true,
+            false,
+            Some(partition_schema),
+            Some(native_schema),
+            output_schema.clone(),
+        )
+        .unwrap();
+        let handler = SyncJsonHandler::new(None);
+        let input_json: StringArray = vec![
+            r#"{"add":{"path":"file.parquet","partitionValues":{"name":"","event_time":"1970-01-01 00:00:00"},"partitionValues_parsed":{"event_time":"1970-01-01T08:00:00Z"},"size":1,"modificationTime":2,"dataChange":true}}"#,
+        ]
+        .into();
+        let input = handler
+            .parse_json(string_array_to_engine_data(input_json), read_schema)
+            .unwrap();
+        let mut actual = input;
+        for evaluator in evaluators {
+            actual = evaluator.evaluate(actual.as_ref()).unwrap();
+        }
+        let expected_json: StringArray = vec![
+            r#"{"path":"file.parquet","size":1,"modificationTime":2,"fileConstantValues":{"partitionValues":{"name":"","event_time":"1970-01-01 00:00:00"}},"partitionValues_parsed":{"name":null,"event_time":"1970-01-01T08:00:00Z"}}"#,
+        ]
+        .into();
+        let expected = handler
+            .parse_json(string_array_to_engine_data(expected_json), output_schema)
+            .unwrap();
+        assert_batch_matches(actual, expected);
     }
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -978,7 +978,7 @@ impl Scan {
                 actions: existing_data.into_iter().map(apply_transform),
                 checkpoint_info: CheckpointReadInfo {
                     has_stats_parsed: false,
-                    has_partition_values_parsed: false,
+                    native_partition_values_schema: None,
                     checkpoint_read_schema: restored_add_schema().clone(),
                 },
             };
@@ -1291,7 +1291,7 @@ impl Scan {
         };
         let checkpoint_info = CheckpointReadInfo {
             has_stats_parsed: false,
-            has_partition_values_parsed: false,
+            native_partition_values_schema: None,
             checkpoint_read_schema,
         };
         let processor = ScanLogReplayProcessor::new(

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -228,8 +228,8 @@ impl StatsOptions {
 /// When the typed struct is requested, scan metadata output gains a top-level
 /// `partitionValues_parsed` struct column with one typed nullable field per partition column
 /// (physical names, table partition-column order). On non-partitioned tables the column is
-/// omitted. Values come directly from the checkpoint's native `partitionValues_parsed` column
-/// when present, otherwise from parsing the string map.
+/// omitted. Compatible checkpoint-native values are read directly. String and Binary partition
+/// values, and values without compatible native fields, are reconstructed from the string map.
 #[derive(Clone, Debug, Default)]
 pub struct PartitionValuesOptions {
     /// Whether to emit the typed `partitionValues_parsed` struct column.
@@ -1177,9 +1177,18 @@ impl Scan {
         // partition schema rather than the logical names in table metadata.
         let mut partition_columns = HashSet::new();
         let mut floating_partition_columns = HashSet::new();
+        let mut stats_columns = self.state_info.eligible_physical_stats_columns.clone();
         if let Some(schema) = self.state_info.physical_partition_schema.as_ref() {
             for field in schema.fields() {
                 let column = ColumnName::new([field.name()]);
+                if matches!(
+                    field.data_type(),
+                    DataType::Primitive(PrimitiveType::String)
+                        | DataType::Primitive(PrimitiveType::Binary)
+                ) {
+                    stats_columns.remove(&column);
+                    continue;
+                }
                 if field.data_type() == &DataType::FLOAT || field.data_type() == &DataType::DOUBLE {
                     floating_partition_columns.insert(column.clone());
                 }
@@ -1190,7 +1199,7 @@ impl Scan {
             predicate,
             &partition_columns,
             &floating_partition_columns,
-            &self.state_info.eligible_physical_stats_columns,
+            &stats_columns,
         )?;
 
         let mut prefixer = PrefixColumns {

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -495,9 +495,8 @@ impl StateInfo {
         // When the engine requested the typed struct, emit all partition columns rather than
         // the predicate-narrowed subset. The data skipping filter only references the columns
         // its predicate needs, so the superset is safe for pruning too. All fields are forced
-        // nullable: MapToStruct can yield null even for a non-nullable column (a missing key, or
-        // an empty string cast to a non-string/binary type), and a non-nullable field would then
-        // error.
+        // nullable: MapToStruct can yield null even for a non-nullable column (a missing key or an
+        // empty string), and a non-nullable field would then error.
         let physical_partition_schema = if partition_values.parsed_struct {
             table_partition_schema.map(|tps| {
                 let nullable_fields = tps

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1089,12 +1089,13 @@ fn test_build_actions_meta_predicate_static_skip_all() {
     );
 }
 
-// Partition-only scans have no stats schema, so the partition schema must enable the rewrite.
+// String partition footer values cannot distinguish an empty string from protocol null, so
+// partition-only predicates over them cannot be pushed to checkpoint row-group filtering.
 #[rstest]
 #[case::equality(Pred::eq(
     col!("modified"),
     lit("2021-02-01"),
-), None)]
+))]
 #[case::date_cast_range(Pred::and(
     Pred::ge(
         Expr::cast(col!("modified"), DataType::DATE),
@@ -1104,11 +1105,8 @@ fn test_build_actions_meta_predicate_static_skip_all() {
         Expr::cast(col!("modified"), DataType::DATE),
         Scalar::Date(20_644),
     ),
-), Some("CAST(Column(add.partitionValues_parsed.modified) AS date)"))]
-fn test_build_actions_meta_predicate_partition_only(
-    #[case] predicate: Pred,
-    #[case] expected_cast: Option<&str>,
-) {
+))]
+fn test_build_actions_meta_predicate_omits_string_partition_refs(#[case] predicate: Pred) {
     // `app-txn-checkpoint` is partitioned by `modified` (string), no column mapping.
     let path = std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint/")).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
@@ -1121,31 +1119,20 @@ fn test_build_actions_meta_predicate_partition_only(
         .build()
         .unwrap();
 
-    let meta_pred = scan
-        .build_actions_meta_predicate()
-        .expect("partition-only predicate should produce a checkpoint meta-predicate");
-    let rendered = meta_pred.to_string();
-    if let Some(expected_cast) = expected_cast {
-        assert!(rendered.contains(expected_cast), "{rendered}");
-    }
-    let refs: Vec<String> = meta_pred
-        .references()
-        .into_iter()
-        .map(|c| c.to_string())
-        .collect();
-    assert_eq!(
-        refs,
-        vec!["add.partitionValues_parsed.modified".to_string()]
+    let meta_predicate = scan.build_actions_meta_predicate();
+    assert!(
+        meta_predicate
+            .as_ref()
+            .is_none_or(|predicate| predicate.references().is_empty()),
+        "{meta_predicate:?}"
     );
 }
 
-// Under column mapping, `partitionValues_parsed` is keyed by the physical partition name, so the
-// checkpoint meta-predicate must reference that physical name (not the logical one) in both name
-// and id mapping modes.
+// String partition footer values are unsafe for null pruning under every column mapping mode.
 #[rstest]
 #[case::name_mode("name")]
 #[case::id_mode("id")]
-fn test_build_actions_meta_predicate_partition_column_mapping(
+fn test_build_actions_meta_predicate_omits_mapped_string_partition_refs(
     #[case] mode: &str,
     #[values(false, true)] casted: bool,
 ) {
@@ -1171,22 +1158,12 @@ fn test_build_actions_meta_predicate_partition_column_mapping(
         .build()
         .unwrap();
 
-    let meta_pred = scan
-        .build_actions_meta_predicate()
-        .expect("partition predicate under column mapping should produce a meta-predicate");
-    let rendered = meta_pred.to_string();
-    assert_eq!(rendered.contains("CAST("), casted, "{rendered}");
-    let refs: Vec<String> = meta_pred
-        .references()
-        .into_iter()
-        .map(|c| c.to_string())
-        .collect();
-    // The hyphenated physical name is backtick-quoted in the column display.
+    let meta_predicate = scan.build_actions_meta_predicate();
     assert!(
-        refs.iter().any(|r| r.contains("partitionValues_parsed")
-            && r.contains("col-6dc68f07-711d-4f00-8bd6-1f5bc698e8ad")),
-        "expected a reference to the PHYSICAL partition column under partitionValues_parsed, \
-         got {refs:?}"
+        meta_predicate
+            .as_ref()
+            .is_none_or(|predicate| predicate.references().is_empty()),
+        "{meta_predicate:?}"
     );
 }
 

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -237,18 +237,11 @@ fn apply_insert_after(
 }
 
 /// Parse a partition value from the raw string representation.
-///
-/// An empty string casts via [`PrimitiveType::empty_string_partition_cast`].
-///
-/// [`PrimitiveType::empty_string_partition_cast`]: crate::schema::PrimitiveType::empty_string_partition_cast
 pub(crate) fn parse_partition_value_raw(
     raw: Option<&String>,
     data_type: &DataType,
 ) -> DeltaResult<Scalar> {
     match (raw, data_type.as_primitive_opt()) {
-        (Some(v), Some(primitive)) if v.is_empty() => Ok(primitive
-            .empty_string_partition_cast()
-            .unwrap_or_else(|| Scalar::Null(data_type.clone()))),
         (Some(v), Some(primitive)) => primitive.parse_scalar(v),
         (Some(_), None) => Err(Error::generic(format!(
             "Unexpected partition column type: {data_type:?}"
@@ -370,17 +363,14 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_partition_value_raw_empty_string_cast_semantics() {
-        // An empty string casts to itself for string and to empty bytes for binary, and to null
-        // for every other type. A literal empty string only reaches this path from a foreign
-        // writer, since kernel serializes its own empty and null partition values to JSON null.
+    fn test_parse_partition_value_raw_empty_strings_are_null() {
         let empty = String::new();
 
         let string_value = parse_partition_value_raw(Some(&empty), &DataType::STRING).unwrap();
-        assert_eq!(string_value, Scalar::String(String::new()));
+        assert!(string_value.is_null());
 
         let binary_value = parse_partition_value_raw(Some(&empty), &DataType::BINARY).unwrap();
-        assert_eq!(binary_value, Scalar::Binary(Vec::new()));
+        assert!(binary_value.is_null());
 
         let int_value =
             parse_partition_value_raw(Some(&empty), &DataType::Primitive(PrimitiveType::Integer))

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -30,9 +30,8 @@ use url::Url;
 /// - `native_checkpoint = false`: no checkpoint, so the struct is synthesized from the
 ///   `partitionValues` string map via `MAP_TO_STRUCT` on a JSON commit.
 /// - `native_checkpoint = true`: a checkpoint with `writeStatsAsStruct=true`, so the read takes the
-///   checkpoint's native `partitionValues_parsed` column directly. For the non-null values this
-///   table writes, that column matches what `MAP_TO_STRUCT` would reconstruct, so both sources
-///   yield the same struct.
+///   checkpoint path. Because this table has string and binary partitions, the scan reconstructs
+///   the struct from `partitionValues` so empty strings can be normalized safely.
 ///
 /// The struct keys on physical names, so a logical-vs-physical mismatch under `Id`/`Name` mapping
 /// would surface every partition value as null. The builder writes well-defined (non-null)
@@ -150,10 +149,8 @@ fn scan_metadata_emits_partition_values_parsed_across_column_mapping(
 
 // === Foreign-writer literal empty-string partition values ===
 //
-// The kernel never persists a literal "" partition value (it serializes its own empty and null
-// partition values to JSON null on write), so these tests stand in a raw-JSON foreign writer that
-// did, then assert the kernel reconstructs `partitionValues_parsed` with the empty-string cast: ""
-// stays "" for string, becomes empty bytes for binary, and becomes null for every other type.
+// These tests stand in for a foreign writer that persists an empty string instead of null. Delta's
+// partition value serialization requires readers to normalize that representation to null.
 
 /// Writes a foreign-writer table under `table_path`: protocol + metadata declaring string, binary,
 /// and integer partition columns (with `writeStatsAsStruct` enabled so a checkpoint writes its own
@@ -221,13 +218,11 @@ fn add_action(path: &str, p_str: &str, p_bin: &str, p_int: &str) -> String {
 }
 
 /// A foreign writer can persist a literal "" in the `partitionValues` map. On read, kernel
-/// reconstructs `partitionValues_parsed` with the empty-string cast: "" stays "" for string,
-/// becomes empty bytes for binary, and becomes null for every other type.
+/// reconstructs every empty partition value as null.
 ///
-/// The result is identical whether the value is reconstructed from the `partitionValues` map (JSON
-/// commit) or read from a kernel-written checkpoint's native `partitionValues_parsed` column: the
-/// checkpoint reconstructs that column with the same cast, so a checkpoint never changes the value
-/// a scan surfaces. The `native_checkpoint` axis exercises both sources.
+/// The result is identical whether the map comes from a JSON commit or a checkpoint. Checkpoints
+/// with string or binary partitions do not use the native `partitionValues_parsed` fast path, so
+/// both sources apply the same normalization. The `native_checkpoint` axis exercises both sources.
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn parsed_partition_values_read_foreign_empty_string(
@@ -287,12 +282,10 @@ async fn parsed_partition_values_read_foreign_empty_string(
         let p_int = pv.column_by_name("p_int").unwrap();
         let p_int = p_int.as_any().downcast_ref::<Int32Array>().unwrap();
 
-        // Identical whether read from the map (JSON commit) or the checkpoint's native column.
-        assert!(!p_str.is_null(0), "string \"\" reconstructs as \"\"");
-        assert_eq!(p_str.value(0), "");
-        assert!(!p_bin.is_null(0), "binary \"\" reconstructs as empty bytes");
-        assert_eq!(p_bin.value(0), b"");
-        assert!(p_int.is_null(0), "non-string \"\" must be null");
+        // Identical whether the map is read from a JSON commit or a checkpoint.
+        assert!(p_str.is_null(0), "string \"\" must be null");
+        assert!(p_bin.is_null(0), "binary \"\" must be null");
+        assert!(p_int.is_null(0), "integer \"\" must be null");
 
         asserted_rows += batch.num_rows();
     }
@@ -306,15 +299,13 @@ fn collect_path(paths: &mut Vec<String>, scan_file: ScanFile) {
     paths.push(scan_file.path);
 }
 
-/// A file whose partition value is a foreign literal "" is a real empty value, not null, so
-/// partition skipping treats it accordingly:
-/// - `p_str = ''` keeps it and `p_str = 'other'` prunes it.
-/// - `p_str IS NULL` prunes it and `p_str IS NOT NULL` keeps it (the value is "", not null).
-/// - the same holds for the binary column (`p_bin`), whose "" reconstructs as empty bytes.
+/// A file whose partition value is a foreign literal "" has a null partition value. Partition
+/// skipping prunes it for equality with a non-null literal, keeps it for `IS NULL`, and prunes it
+/// for `IS NOT NULL`.
 ///
 /// The `native_checkpoint` axis exercises that pruning is identical before and after a kernel
-/// checkpoint: the checkpoint reconstructs the same "" into its native `partitionValues_parsed`
-/// column, so skipping keeps and prunes the same files a scan of the JSON commit would.
+/// checkpoint: both sources normalize the value to null, so skipping keeps and prunes the same
+/// files.
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn empty_string_partition_pruning(#[values(false, true)] native_checkpoint: bool) {
@@ -359,35 +350,31 @@ async fn empty_string_partition_pruning(#[values(false, true)] native_checkpoint
 
     let empty = "p_str=/empty.parquet".to_string();
     let other = "p_str=other/other.parquet".to_string();
-    let both = vec![empty.clone(), other.clone()];
 
-    // The empty-string value is a real "", so equality and null predicates treat it as such.
-    assert_eq!(
-        surviving(Predicate::eq(col!("p_str"), lit(""))),
-        vec![empty.clone()],
-        "empty-string file must be kept under p_str = ''"
+    assert!(
+        surviving(Predicate::eq(col!("p_str"), lit(""))).is_empty(),
+        "null partition file must be pruned under p_str = ''"
     );
     assert_eq!(
         surviving(Predicate::eq(col!("p_str"), lit("other"))),
         vec![other.clone()],
-        "empty-string file must be pruned under p_str = 'other'"
+        "null partition file must be pruned under p_str = 'other'"
     );
-    // Both partition values are non-null ("" and "other"), so IS NULL prunes both and IS NOT NULL
-    // keeps both.
-    assert!(
-        surviving(Predicate::is_null(col!("p_str"))).is_empty(),
-        "no file has a null p_str, so IS NULL prunes both (the empty file's value is \"\", not null)"
+    assert_eq!(
+        surviving(Predicate::is_null(col!("p_str"))),
+        vec![empty.clone()],
+        "empty-string partition must be kept under p_str IS NULL"
     );
     assert_eq!(
         surviving(Predicate::is_not_null(col!("p_str"))),
-        both,
-        "both files must be kept under p_str IS NOT NULL"
+        vec![other.clone()],
+        "empty-string partition must be pruned under p_str IS NOT NULL"
     );
 
-    // The binary column reconstructs "" as empty bytes, pruned the same way.
+    // The binary empty string follows the same null semantics.
     assert_eq!(
         surviving(Predicate::eq(col!("p_bin"), lit(b"other".as_slice()))),
-        vec![other.clone()],
-        "empty-bytes file must be pruned under p_bin = X'6f74686572'"
+        vec![other],
+        "null partition file must be pruned under p_bin = X'6f74686572'"
     );
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Normalize empty serialized partition values to null for every primitive type, matching the Delta protocol. String and Binary partition fields are reconstructed from `partitionValues`, while compatible native checkpoint fields remain authoritative. This prevents empty strings from causing incorrect `IS NULL` pruning without reinterpreting writer-resolved timestamp values.

This restores the protocol rule after #2859 adopted Spark cast semantics for foreign empty strings and makes map reconstruction consistent across the kernel and DataFusion evaluators.

Closes #2793.

## How was this change tested?

- `cargo nextest run -p delta_kernel --all-features empty_string`
- `cargo nextest run -p delta_kernel --all-features partition_values_parsed`
- `cargo nextest run -p delta_kernel --lib --all-features checkpoint_transform`
- `cargo nextest run -p delta_kernel --lib --all-features checkpoint_scan_transform_preserves_native_timestamp_and_normalizes_string`
- `cargo clippy -p delta_kernel --all-targets --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
