### PR TITLE
fix: cast widened array elements during parquet reads

### DIFF
--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -173,13 +173,6 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
         ],
     ),
     (
-        "Cannot cast list to non-list data types during type widening",
-        &[
-            "tw_array_element/specs/tw_array_element_read_",
-            "tw_map_key_value_widening/specs/tw_map_key_value_widening_read_all",
-        ],
-    ),
-    (
         "Schema deserialization fails for TimestampNTZ type",
         &["ds_multi_file_time/"],
     ),

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -33,7 +33,7 @@ use crate::engine::arrow_conversion::{TryFromKernel, TryIntoArrow, LIST_ARRAY_RO
 use crate::engine::arrow_expression::opaque::{
     ArrowOpaqueExpressionOpAdaptor, ArrowOpaquePredicateOpAdaptor,
 };
-use crate::engine::arrow_utils::{parse_json_impl, prim_array_cmp};
+use crate::engine::arrow_utils::{list_type_with_element, parse_json_impl, prim_array_cmp};
 use crate::engine::ensure_data_types::{ensure_data_types, ValidationMode};
 use crate::error::{DeltaResult, Error};
 use crate::expressions::{
@@ -559,22 +559,13 @@ fn cast_list_elements(
         },
     };
     let new_field = Arc::new(field.as_ref().clone().with_data_type(to_type));
-    let container = match (vals.data_type(), dir) {
-        (ArrowDataType::List(_), _) => ArrowDataType::List(new_field),
-        (ArrowDataType::LargeList(_), _) => ArrowDataType::LargeList(new_field),
-        (ArrowDataType::ListView(_), ViewCast::ToView) => ArrowDataType::ListView(new_field),
-        (ArrowDataType::ListView(_), ViewCast::ToNonView) => ArrowDataType::List(new_field),
-        (ArrowDataType::LargeListView(_), ViewCast::ToView) => {
-            ArrowDataType::LargeListView(new_field)
+    let container = list_type_with_element(vals.data_type(), new_field)?;
+    let container = match (container, dir) {
+        (ArrowDataType::ListView(field), ViewCast::ToNonView) => ArrowDataType::List(field),
+        (ArrowDataType::LargeListView(field), ViewCast::ToNonView) => {
+            ArrowDataType::LargeList(field)
         }
-        (ArrowDataType::LargeListView(_), ViewCast::ToNonView) => {
-            ArrowDataType::LargeList(new_field)
-        }
-        (dt, _) => {
-            return Err(Error::generic(format!(
-                "cast_list_elements: expected a list type, got {dt:?}"
-            )))
-        }
+        (container, _) => container,
     };
     Ok(cast(vals, &container)?)
 }

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -335,7 +335,7 @@ pub(crate) struct ReorderIndex {
 #[derive(Debug, PartialEq)]
 #[internal_api]
 pub(crate) enum ReorderIndexTransform {
-    /// For a non-nested type, indicates that we need to cast to the contained type
+    /// Cast the input column to the contained Arrow type.
     Cast(ArrowDataType),
     /// Used for struct/list/map. Potentially transform child fields using contained reordering
     Nested(Vec<ReorderIndex>),
@@ -560,11 +560,19 @@ fn get_indices(
                             ));
                         } else {
                             // safety, checked that we have 1 element
-                            let mut children = children.swap_remove(0);
+                            let mut child = children.swap_remove(0);
+                            if matches!(&child.transform, ReorderIndexTransform::Cast(_)) {
+                                // The recursive plan targets the element type, but this reorder
+                                // entry consumes the outer list column. Cast the complete list so
+                                // Arrow applies the element conversion recursively.
+                                let target_field: ArrowField = requested_field.try_into_arrow()?;
+                                child.transform =
+                                    ReorderIndexTransform::Cast(target_field.data_type().clone());
+                            }
                             // the index is wrong, as it's the index from the inner schema.
                             // Adjust it to be our index
-                            children.index = index;
-                            reorder_indices.push(children);
+                            child.index = index;
+                            reorder_indices.push(child);
                         }
                     } else {
                         return Err(Error::unexpected_column_type(list_field.name()));

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -2968,6 +2968,33 @@ mod tests {
     }
 
     #[test]
+    fn list_element_cast_propagates_invalid_nested_ids_error() {
+        let requested_schema: SchemaRef = schema! {
+            (StructField::not_null("values", ArrayType::new(DataType::LONG, false)).with_metadata(
+                [(
+                    ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
+                    MetadataValue::String("not a json object".to_string()),
+                )],
+            )),
+        }
+        .into();
+        let parquet_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "values",
+            ArrowDataType::List(Arc::new(ArrowField::new(
+                "element",
+                ArrowDataType::Int32,
+                false,
+            ))),
+            false,
+        )]));
+
+        assert_result_error_with_message(
+            get_requested_indices(&requested_schema, &parquet_schema),
+            "must be a JSON object",
+        );
+    }
+
+    #[test]
     fn list_skip_earlier_element() {
         column_mapping_cases().into_iter().for_each(|mode| {
             let requested_schema = schema! {

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -561,13 +561,42 @@ fn get_indices(
                         } else {
                             // safety, checked that we have 1 element
                             let mut child = children.swap_remove(0);
-                            if matches!(&child.transform, ReorderIndexTransform::Cast(_)) {
+                            if let ReorderIndexTransform::Cast(element_target) = &child.transform {
                                 // The recursive plan targets the element type, but this reorder
                                 // entry consumes the outer list column. Cast the complete list so
-                                // Arrow applies the element conversion recursively.
+                                // Arrow applies the element conversion recursively while retaining
+                                // the physical list wrapper at each nesting level.
                                 let target_field: ArrowField = requested_field.try_into_arrow()?;
-                                child.transform =
-                                    ReorderIndexTransform::Cast(target_field.data_type().clone());
+                                let ArrowDataType::List(target_element_field) =
+                                    target_field.data_type()
+                                else {
+                                    return Err(Error::internal_error(
+                                        "Kernel array converted to a non-list Arrow type.",
+                                    ));
+                                };
+                                let target_element_field = Arc::new(
+                                    target_element_field
+                                        .as_ref()
+                                        .clone()
+                                        .with_data_type(element_target.clone()),
+                                );
+                                let target = match field.data_type() {
+                                    ArrowDataType::List(_) => {
+                                        ArrowDataType::List(target_element_field)
+                                    }
+                                    ArrowDataType::LargeList(_) => {
+                                        ArrowDataType::LargeList(target_element_field)
+                                    }
+                                    ArrowDataType::ListView(_) => {
+                                        ArrowDataType::ListView(target_element_field)
+                                    }
+                                    _ => {
+                                        return Err(Error::internal_error(
+                                            "List cast planned for a non-list Arrow type.",
+                                        ));
+                                    }
+                                };
+                                child.transform = ReorderIndexTransform::Cast(target);
                             }
                             // the index is wrong, as it's the index from the inner schema.
                             // Adjust it to be our index
@@ -2992,6 +3021,72 @@ mod tests {
             get_requested_indices(&requested_schema, &parquet_schema),
             "must be a JSON object",
         );
+    }
+
+    #[rstest]
+    #[case::list(
+        ArrowDataType::List(arrow_list_element(ArrowDataType::Int32)),
+        ArrowDataType::List(arrow_list_element(ArrowDataType::Int64))
+    )]
+    #[case::large_list(
+        ArrowDataType::LargeList(arrow_list_element(ArrowDataType::Int32)),
+        ArrowDataType::LargeList(arrow_list_element(ArrowDataType::Int64))
+    )]
+    #[case::list_view(
+        ArrowDataType::ListView(arrow_list_element(ArrowDataType::Int32)),
+        ArrowDataType::ListView(arrow_list_element(ArrowDataType::Int64))
+    )]
+    fn list_element_cast_preserves_physical_wrapper(
+        #[case] physical_type: ArrowDataType,
+        #[case] expected_type: ArrowDataType,
+    ) {
+        let requested_schema: SchemaRef = schema! {
+            (StructField::not_null("values", ArrayType::new(DataType::LONG, true))),
+        }
+        .into();
+        let parquet_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "values",
+            physical_type,
+            false,
+        )]));
+
+        let (mask_indices, reorder_indices) =
+            get_requested_indices(&requested_schema, &parquet_schema).unwrap();
+
+        assert_eq!(mask_indices, vec![0]);
+        assert_eq!(reorder_indices, vec![ReorderIndex::cast(0, expected_type)]);
+    }
+
+    #[test]
+    fn nested_list_element_cast_preserves_each_physical_wrapper() {
+        let requested_schema: SchemaRef = schema! {
+            (StructField::not_null(
+                "values",
+                ArrayType::new(ArrayType::new(DataType::LONG, true), true),
+            )),
+        }
+        .into();
+        let physical_type = ArrowDataType::LargeList(arrow_list_element(ArrowDataType::ListView(
+            arrow_list_element(ArrowDataType::Int32),
+        )));
+        let parquet_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "values",
+            physical_type,
+            false,
+        )]));
+        let expected_type = ArrowDataType::LargeList(arrow_list_element(ArrowDataType::ListView(
+            arrow_list_element(ArrowDataType::Int64),
+        )));
+
+        let (mask_indices, reorder_indices) =
+            get_requested_indices(&requested_schema, &parquet_schema).unwrap();
+
+        assert_eq!(mask_indices, vec![0]);
+        assert_eq!(reorder_indices, vec![ReorderIndex::cast(0, expected_type)]);
+    }
+
+    fn arrow_list_element(data_type: ArrowDataType) -> Arc<ArrowField> {
+        Arc::new(ArrowField::new("element", data_type, true))
     }
 
     #[test]

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -71,6 +71,36 @@ macro_rules! prim_array_cmp {
 
 pub(crate) use prim_array_cmp;
 
+/// Rebuilds a variable-length Arrow list type with a replacement element field while preserving
+/// its wrapper.
+///
+/// # Parameters
+///
+/// - `list_type`: The list type whose wrapper is preserved.
+/// - `element`: The replacement element field.
+///
+/// # Returns
+///
+/// The corresponding list type containing `element`.
+///
+/// # Errors
+///
+/// Returns an error if `list_type` is not `List`, `LargeList`, `ListView`, or `LargeListView`.
+pub(crate) fn list_type_with_element(
+    list_type: &ArrowDataType,
+    element: ArrowFieldRef,
+) -> DeltaResult<ArrowDataType> {
+    match list_type {
+        ArrowDataType::List(_) => Ok(ArrowDataType::List(element)),
+        ArrowDataType::LargeList(_) => Ok(ArrowDataType::LargeList(element)),
+        ArrowDataType::ListView(_) => Ok(ArrowDataType::ListView(element)),
+        ArrowDataType::LargeListView(_) => Ok(ArrowDataType::LargeListView(element)),
+        _ => Err(Error::internal_error(format!(
+            "Expected a variable-length list type, got {list_type:?}."
+        ))),
+    }
+}
+
 type FieldIndex = usize;
 type FlattenedRangeIterator<T> = std::iter::Flatten<std::vec::IntoIter<Range<T>>>;
 
@@ -527,7 +557,8 @@ fn get_indices(
                 }
                 ArrowDataType::List(list_field)
                 | ArrowDataType::LargeList(list_field)
-                | ArrowDataType::ListView(list_field) => {
+                | ArrowDataType::ListView(list_field)
+                | ArrowDataType::LargeListView(list_field) => {
                     // we just want to transparently recurse into lists, need to transform the
                     // kernel list data type into a schema
                     if let DataType::Array(array_type) = requested_field.data_type() {
@@ -580,22 +611,10 @@ fn get_indices(
                                         .clone()
                                         .with_data_type(element_target.clone()),
                                 );
-                                let target = match field.data_type() {
-                                    ArrowDataType::List(_) => {
-                                        ArrowDataType::List(target_element_field)
-                                    }
-                                    ArrowDataType::LargeList(_) => {
-                                        ArrowDataType::LargeList(target_element_field)
-                                    }
-                                    ArrowDataType::ListView(_) => {
-                                        ArrowDataType::ListView(target_element_field)
-                                    }
-                                    _ => {
-                                        return Err(Error::internal_error(
-                                            "List cast planned for a non-list Arrow type.",
-                                        ));
-                                    }
-                                };
+                                let target = list_type_with_element(
+                                    field.data_type(),
+                                    target_element_field,
+                                )?;
                                 child.transform = ReorderIndexTransform::Cast(target);
                             }
                             // the index is wrong, as it's the index from the inner schema.
@@ -3035,6 +3054,10 @@ mod tests {
     #[case::list_view(
         ArrowDataType::ListView(arrow_list_element(ArrowDataType::Int32)),
         ArrowDataType::ListView(arrow_list_element(ArrowDataType::Int64))
+    )]
+    #[case::large_list_view(
+        ArrowDataType::LargeListView(arrow_list_element(ArrowDataType::Int32)),
+        ArrowDataType::LargeListView(arrow_list_element(ArrowDataType::Int64))
     )]
     fn list_element_cast_preserves_physical_wrapper(
         #[case] physical_type: ArrowDataType,

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -1646,6 +1646,17 @@ async fn array_element_type_widening_reads_older_files() -> Result<(), Box<dyn s
     let parquet_bytes = record_batch_to_bytes(&batch);
 
     let schema = |element_type: &str| {
+        let field_metadata = if element_type == "long" {
+            serde_json::json!({
+                "delta.typeChanges": [{
+                    "fromType": "integer",
+                    "toType": "long",
+                    "fieldPath": "element",
+                }],
+            })
+        } else {
+            serde_json::json!({})
+        };
         serde_json::json!({
             "type": "struct",
             "fields": [
@@ -1658,7 +1669,7 @@ async fn array_element_type_widening_reads_older_files() -> Result<(), Box<dyn s
                         "containsNull": true,
                     },
                     "nullable": true,
-                    "metadata": {},
+                    "metadata": field_metadata,
                 },
             ],
         })
@@ -1671,7 +1682,7 @@ async fn array_element_type_widening_reads_older_files() -> Result<(), Box<dyn s
                 "format": {"provider": "parquet", "options": {}},
                 "schemaString": schema_string,
                 "partitionColumns": [],
-                "configuration": {},
+                "configuration": {"delta.enableTypeWidening": "true"},
             },
         })
         .to_string()
@@ -1685,7 +1696,14 @@ async fn array_element_type_widening_reads_older_files() -> Result<(), Box<dyn s
             "dataChange": true,
         },
     });
-    let protocol = r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#;
+    let protocol = serde_json::json!({
+        "protocol": {
+            "minReaderVersion": 3,
+            "minWriterVersion": 7,
+            "readerFeatures": ["typeWidening"],
+            "writerFeatures": ["typeWidening"],
+        },
+    });
     add_commit(
         table_root,
         storage.as_ref(),

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -7,10 +7,13 @@ use std::sync::Arc;
 use std::vec;
 
 use delta_kernel::actions::deletion_vector::split_vector;
-use delta_kernel::arrow::array::{ArrayRef, AsArray as _, RecordBatch, TimestampMicrosecondArray};
+use delta_kernel::arrow::array::{
+    ArrayRef, AsArray as _, Int64Array, ListArray, RecordBatch, TimestampMicrosecondArray,
+};
 use delta_kernel::arrow::compute::{concat_batches, filter_record_batch};
 use delta_kernel::arrow::datatypes::{
-    DataType as ArrowDataType, Field as ArrowField, Int64Type, Schema as ArrowSchema, TimeUnit,
+    DataType as ArrowDataType, Field as ArrowField, Int32Type, Int64Type, Schema as ArrowSchema,
+    TimeUnit,
 };
 use delta_kernel::engine::arrow_conversion::TryFromKernel as _;
 use delta_kernel::engine::arrow_data::EngineDataArrowExt as _;
@@ -1627,6 +1630,85 @@ fn type_widening_basic() -> Result<(), Box<dyn std::error::Error>> {
     ]);
 
     read_table_data_str("./tests/data/type-widening/", select_cols, None, expected)
+}
+
+#[tokio::test]
+async fn array_element_type_widening_reads_older_files() -> Result<(), Box<dyn std::error::Error>> {
+    let table_root = "memory:///";
+    let file_name = "part-v0.parquet";
+    let storage = Arc::new(InMemory::new());
+    let values: ListArray =
+        ListArray::from_iter_primitive::<Int32Type, _, _>([Some(vec![Some(1), Some(2), Some(3)])]);
+    let batch = RecordBatch::try_from_iter([
+        ("id", Arc::new(Int64Array::from(vec![1])) as ArrayRef),
+        ("vals", Arc::new(values) as ArrayRef),
+    ])?;
+    let parquet_bytes = record_batch_to_bytes(&batch);
+
+    let schema = |element_type: &str| {
+        serde_json::json!({
+            "type": "struct",
+            "fields": [
+                {"name": "id", "type": "long", "nullable": true, "metadata": {}},
+                {
+                    "name": "vals",
+                    "type": {
+                        "type": "array",
+                        "elementType": element_type,
+                        "containsNull": true,
+                    },
+                    "nullable": true,
+                    "metadata": {},
+                },
+            ],
+        })
+        .to_string()
+    };
+    let metadata = |schema_string: String| {
+        serde_json::json!({
+            "metaData": {
+                "id": "array-widen",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": schema_string,
+                "partitionColumns": [],
+                "configuration": {},
+            },
+        })
+        .to_string()
+    };
+    let add = serde_json::json!({
+        "add": {
+            "path": file_name,
+            "partitionValues": {},
+            "size": parquet_bytes.len(),
+            "modificationTime": 1000,
+            "dataChange": true,
+        },
+    });
+    let protocol = r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        format!("{protocol}\n{}\n{add}", metadata(schema("integer"))),
+    )
+    .await?;
+    add_commit(table_root, storage.as_ref(), 1, metadata(schema("long"))).await?;
+    storage
+        .put(&Path::from(file_name), parquet_bytes.into())
+        .await?;
+
+    let engine = Arc::new(DefaultEngineBuilder::new(storage).build());
+    let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
+    let scan = snapshot.scan_builder().build()?;
+    let batches = read_scan(&scan, engine)?;
+
+    assert_eq!(batches.len(), 1);
+    let values = batches[0].column_by_name("vals").unwrap().as_list::<i32>();
+    assert_eq!(values.value_type(), ArrowDataType::Int64);
+    let elements = values.values().as_primitive::<Int64Type>();
+    assert_eq!(elements.values().as_ref(), &[1, 2, 3]);
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Promote an element-level cast discovered while planning a Parquet list read into a cast of the complete list column. Arrow then recursively converts the values while preserving the list wrapper, instead of attempting the invalid `List<Int32> -> Int64` cast.

The regression test recreates the reported table shape in memory: a V0 Parquet file stores `array<int>`, V1 changes the table schema to `array<long>`, and the scan verifies the older values are returned as `Int64`.

Closes #2188.

## How was this change tested?

- `cargo nextest run -p delta_kernel --test integration --all-features type_widening`
- `cargo clippy -p delta_kernel --all-targets --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`