### PR TITLE
ci: default automatic AI reviews to inline

### DIFF
--- a/.github/omnigent/tests/test_inline_review.py
+++ b/.github/omnigent/tests/test_inline_review.py
@@ -103,6 +103,14 @@ class InlineReviewTest(unittest.TestCase):
 
         self.assertEqual(standalone_prompt.strip(), "\n".join(configured_lines).strip())
 
+    def test_automatic_reviews_default_to_inline(self) -> None:
+        workflow = (Path(__file__).parents[2] / "workflows" / "ai-review.yml").read_text()
+        automatic_trigger = workflow.partition("            pull_request_target)")[2].partition(
+            "            workflow_dispatch)"
+        )[0]
+
+        self.assertIn("mode=inline", automatic_trigger)
+
     def test_diff_positions_tracks_both_sides_and_context(self) -> None:
         self.assertEqual(
             self.inline_review.diff_positions(DIFF),

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -14,9 +14,9 @@
 #   vars.OMNIGENT_BOT_APP_ID + secrets.OMNIGENT_BOT_APP_KEY
 #
 # Ready PRs from authors with write-or-higher permission are reviewed
-# automatically and published to the workflow summary and a non-blocking PR
-# check. Authorized actors can also trigger a review manually with a /review
-# comment or workflow dispatch.
+# automatically and published as an inline review with a non-blocking PR check.
+# Authorized actors can also trigger a review manually with a /review comment or
+# workflow dispatch.
 # =============================================================================
 name: AI PR Review
 
@@ -139,7 +139,7 @@ jobs:
               ;;
             pull_request_target)
               n="$PR_NUMBER"
-              mode=summary
+              mode=inline
               auth_subject="$PR_AUTHOR"
               ;;
             workflow_dispatch)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Publish automatic AI reviews triggered by `pull_request_target` as inline reviews instead of
workflow summaries. Explicit `/review` options and workflow-dispatch output modes remain unchanged.

Add a source-contract unit test that keeps the automatic default pinned to inline.

## How was this change tested?

- Python inline-review unit tests
- Workflow YAML parsing
- `cargo +nightly fmt`
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`