### PR TITLE
feat(ffi): add row-tracking high-water-mark setter

### DIFF
--- a/ffi/src/ffi_test_utils.rs
+++ b/ffi/src/ffi_test_utils.rs
@@ -120,15 +120,38 @@ pub(crate) fn assert_extern_result_error_with_message<T>(
     expected_etype: KernelError,
     opt_message: Option<&str>,
 ) {
+    let error = expect_extern_result_error(res, expected_etype);
+    if let Some(expected_message) = opt_message {
+        assert_eq!(error.message, expected_message);
+    }
+}
+
+/// Check the error type and a stable message substring while recovering the error to prevent
+/// leaks.
+pub(crate) fn assert_extern_result_error_contains<T>(
+    res: ExternResult<T>,
+    expected_etype: KernelError,
+    expected_message: &str,
+) {
+    let error = expect_extern_result_error(res, expected_etype);
+    assert!(
+        error.message.contains(expected_message),
+        "expected error message to contain '{expected_message}', got '{}'",
+        error.message
+    );
+}
+
+fn expect_extern_result_error<T>(
+    res: ExternResult<T>,
+    expected_etype: KernelError,
+) -> EngineErrorWithMessage {
     match res {
         ExternResult::Err(e) => {
             let error = unsafe { recover_error(e) };
             assert_eq!(error.etype, expected_etype);
-            if let Some(expected_message) = opt_message {
-                assert_eq!(error.message, expected_message);
-            }
+            error
         }
-        _ => panic!("Expected error of type '{expected_etype:?}' and message '{opt_message:?}'"),
+        _ => panic!("Expected error of type '{expected_etype:?}'"),
     }
 }
 

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -275,6 +275,38 @@ fn with_domain_metadata_removed_impl(
     Ok(Box::new(txn.with_domain_metadata_removed(domain)).into())
 }
 
+/// Set an explicit row-tracking high-water mark for this transaction.
+///
+/// Use this when row IDs must also be coordinated with another system. Kernel still assigns
+/// row-tracking fields to files passed to [`add_files`] and rejects `high_water_mark` if it is less
+/// than the value calculated from those files. The generic [`with_domain_metadata`] API cannot
+/// modify `delta.rowTracking` or other system-controlled domains.
+///
+/// Returns the updated transaction handle, or an error if the transaction already has an explicit
+/// high-water mark. Table-feature and current-table-state validation occurs during commit.
+///
+/// # Safety
+///
+/// Caller is responsible for passing valid handles. CONSUMES the transaction handle and returns
+/// a new one.
+#[no_mangle]
+pub unsafe extern "C" fn with_row_tracking_high_water_mark(
+    txn: Handle<ExclusiveTransaction>,
+    high_water_mark: i64,
+    engine: Handle<SharedExternEngine>,
+) -> ExternResult<Handle<ExclusiveTransaction>> {
+    let txn = unsafe { txn.into_inner() };
+    let engine = unsafe { engine.as_ref() };
+    with_row_tracking_high_water_mark_impl(*txn, high_water_mark).into_extern_result(&engine)
+}
+
+fn with_row_tracking_high_water_mark_impl(
+    txn: Transaction,
+    high_water_mark: i64,
+) -> DeltaResult<Handle<ExclusiveTransaction>> {
+    Ok(Box::new(txn.with_row_tracking_high_water_mark(high_water_mark)?).into())
+}
+
 /// Add file metadata to the transaction for files that have been written. The metadata contains
 /// information about files written during the transaction that will be added to the Delta log
 /// during commit.
@@ -798,8 +830,9 @@ mod tests {
     use delta_kernel_ffi::engine_data::{get_engine_data, ArrowFFIData};
     use delta_kernel_ffi::error::KernelError;
     use delta_kernel_ffi::ffi_test_utils::{
-        allocate_err, allocate_str, assert_extern_result_error_with_message, build_snapshot,
-        engine_handle_for_store, ok_or_panic, recover_error, recover_string,
+        allocate_err, allocate_str, assert_extern_result_error_contains,
+        assert_extern_result_error_with_message, build_snapshot, engine_handle_for_store,
+        ok_or_panic, recover_error, recover_string,
     };
     use delta_kernel_ffi::tests::get_default_engine;
     use itertools::Itertools;
@@ -1542,14 +1575,19 @@ mod tests {
             .expect("commit should contain a domainMetadata action")
     }
 
-    /// Create a table with the `domainMetadata` writer feature enabled and return the table
-    /// URL, object store, and FFI engine handle.
+    /// Create a table with the requested domain-metadata features.
     async fn setup_domain_metadata_table(
         name: &str,
+        row_tracking: bool,
     ) -> Result<(Url, Arc<DynObjectStore>, Handle<SharedExternEngine>), Box<dyn std::error::Error>>
     {
         let schema = schema_ref! { nullable "id": INTEGER };
         let (store, _test_engine, table_location) = test_utils::engine_store_setup(name, None);
+        let writer_features = if row_tracking {
+            vec!["rowTracking", "domainMetadata"]
+        } else {
+            vec!["domainMetadata"]
+        };
         let table_url = test_utils::create_table(
             store.clone(),
             table_location,
@@ -1557,7 +1595,7 @@ mod tests {
             &[],
             true,
             vec![],
-            vec!["domainMetadata"],
+            writer_features,
         )
         .await?;
         let engine = engine_handle_for_store(Arc::clone(&store));
@@ -1566,7 +1604,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_domain_metadata_add_and_remove() -> Result<(), Box<dyn std::error::Error>> {
-        let (table_url, store, engine) = setup_domain_metadata_table("test_dm").await?;
+        let (table_url, store, engine) = setup_domain_metadata_table("test_dm", false).await?;
         let table_path_str = table_url.as_str();
 
         // === Transaction 1: add domain metadata ===
@@ -1621,7 +1659,7 @@ mod tests {
     #[tokio::test]
     async fn test_domain_metadata_system_domain_rejected_at_commit(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let (table_url, _store, engine) = setup_domain_metadata_table("test_dm_sys").await?;
+        let (table_url, _store, engine) = setup_domain_metadata_table("test_dm_sys", false).await?;
         let table_path_str = table_url.as_str();
 
         // with_domain_metadata succeeds (validation is lazy), but commit should fail
@@ -1653,9 +1691,181 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_row_tracking_high_water_mark_requires_row_tracking_feature(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (table_url, _store, engine) =
+            setup_domain_metadata_table("test_row_tracking_hwm_feature", false).await?;
+        let table_path = table_url.as_str();
+        let txn = ok_or_panic(unsafe {
+            transaction(kernel_string_slice!(table_path), engine.shallow_copy())
+        });
+        let txn = ok_or_panic(unsafe {
+            with_row_tracking_high_water_mark(txn, 7, engine.shallow_copy())
+        });
+
+        assert_extern_result_error_contains(
+            unsafe { commit(txn, engine.shallow_copy()) },
+            KernelError::GenericError,
+            "requires the 'rowTracking' feature",
+        );
+
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_row_tracking_high_water_mark_rejects_duplicate(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (table_url, _store, engine) =
+            setup_domain_metadata_table("test_row_tracking_hwm_duplicate", true).await?;
+        let table_path = table_url.as_str();
+        let txn = ok_or_panic(unsafe {
+            transaction(kernel_string_slice!(table_path), engine.shallow_copy())
+        });
+        let txn = ok_or_panic(unsafe {
+            with_row_tracking_high_water_mark(txn, 7, engine.shallow_copy())
+        });
+
+        assert_extern_result_error_contains(
+            unsafe { with_row_tracking_high_water_mark(txn, 8, engine.shallow_copy()) },
+            KernelError::GenericError,
+            "already specified in this transaction",
+        );
+
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_row_tracking_high_water_mark_commit() -> Result<(), Box<dyn std::error::Error>> {
+        let (table_url, store, engine) =
+            setup_domain_metadata_table("test_row_tracking_hwm", true).await?;
+        let table_path = table_url.as_str();
+        let txn = ok_or_panic(unsafe {
+            transaction(kernel_string_slice!(table_path), engine.shallow_copy())
+        });
+        let txn = ok_or_panic(unsafe {
+            with_row_tracking_high_water_mark(txn, 7, engine.shallow_copy())
+        });
+
+        let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        assert_eq!(unsafe { version_and_free(committed) }, 1);
+        let row_tracking = read_domain_metadata_action(&store, &table_url, 1).await;
+        assert_eq!(
+            row_tracking["domainMetadata"]["domain"],
+            "delta.rowTracking"
+        );
+        assert_eq!(
+            row_tracking["domainMetadata"]["configuration"],
+            r#"{"rowIdHighWaterMark":7}"#
+        );
+
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_row_tracking_high_water_mark_rejects_regression(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (table_url, _store, engine) =
+            setup_domain_metadata_table("test_row_tracking_hwm_regression", true).await?;
+        let table_path = table_url.as_str();
+
+        let txn = ok_or_panic(unsafe {
+            transaction(kernel_string_slice!(table_path), engine.shallow_copy())
+        });
+        let txn = ok_or_panic(unsafe {
+            with_row_tracking_high_water_mark(txn, 7, engine.shallow_copy())
+        });
+        let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        assert_eq!(unsafe { version_and_free(committed) }, 1);
+
+        let txn = ok_or_panic(unsafe {
+            transaction(kernel_string_slice!(table_path), engine.shallow_copy())
+        });
+        let txn = ok_or_panic(unsafe {
+            with_row_tracking_high_water_mark(txn, 6, engine.shallow_copy())
+        });
+        assert_extern_result_error_contains(
+            unsafe { commit(txn, engine.shallow_copy()) },
+            KernelError::GenericError,
+            "cannot be less than the calculated value 7",
+        );
+
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_row_tracking_high_water_mark_with_add_files(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (table_url, store, engine) =
+            setup_domain_metadata_table("test_row_tracking_hwm_with_adds", true).await?;
+        let table_path = table_url.as_str();
+        let txn = ok_or_panic(unsafe {
+            transaction(kernel_string_slice!(table_path), engine.shallow_copy())
+        });
+
+        let metadata_schema = unsafe { txn.shallow_copy().as_ref().add_files_schema() }
+            .as_ref()
+            .try_into_arrow()?;
+        let file_info = create_file_metadata("file.parquet", 1, 2, metadata_schema)?;
+        let file_info_engine_data = ok_or_panic(unsafe {
+            get_engine_data(file_info.array, &file_info.schema, allocate_err)
+        });
+        unsafe { add_files(txn.shallow_copy(), file_info_engine_data) };
+
+        let txn = ok_or_panic(unsafe {
+            with_row_tracking_high_water_mark(txn, 7, engine.shallow_copy())
+        });
+        let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        assert_eq!(unsafe { version_and_free(committed) }, 1);
+        let row_tracking = read_domain_metadata_action(&store, &table_url, 1).await;
+        assert_eq!(
+            row_tracking["domainMetadata"]["configuration"],
+            r#"{"rowIdHighWaterMark":7}"#
+        );
+
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_row_tracking_high_water_mark_rejects_value_below_added_files(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (table_url, _store, engine) =
+            setup_domain_metadata_table("test_row_tracking_hwm_below_adds", true).await?;
+        let table_path = table_url.as_str();
+        let txn = ok_or_panic(unsafe {
+            transaction(kernel_string_slice!(table_path), engine.shallow_copy())
+        });
+
+        let metadata_schema = unsafe { txn.shallow_copy().as_ref().add_files_schema() }
+            .as_ref()
+            .try_into_arrow()?;
+        let file_info = create_file_metadata("file.parquet", 1, 2, metadata_schema)?;
+        let file_info_engine_data = ok_or_panic(unsafe {
+            get_engine_data(file_info.array, &file_info.schema, allocate_err)
+        });
+        unsafe { add_files(txn.shallow_copy(), file_info_engine_data) };
+
+        let txn = ok_or_panic(unsafe {
+            with_row_tracking_high_water_mark(txn, 0, engine.shallow_copy())
+        });
+        assert_extern_result_error_contains(
+            unsafe { commit(txn, engine.shallow_copy()) },
+            KernelError::GenericError,
+            "cannot be less than the calculated value 1",
+        );
+
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_domain_metadata_duplicate_domain_rejected_at_commit(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let (table_url, _store, engine) = setup_domain_metadata_table("test_dm_dup").await?;
+        let (table_url, _store, engine) = setup_domain_metadata_table("test_dm_dup", false).await?;
         let table_path_str = table_url.as_str();
 
         // Adding the same domain twice should cause commit to fail

--- a/kernel/src/row_tracking.rs
+++ b/kernel/src/row_tracking.rs
@@ -33,6 +33,11 @@ impl RowTrackingDomainMetadata {
         }
     }
 
+    /// Returns the highest row ID represented by this metadata.
+    pub(crate) fn high_water_mark(&self) -> i64 {
+        self.row_id_high_water_mark
+    }
+
     /// Creates the initial row tracking domain metadata for a newly created table.
     ///
     /// Sets the high water mark to -1, meaning no rows have been assigned IDs yet.

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -65,6 +65,7 @@ impl AlterTableTransaction {
             commit_timestamp: current_time_ms()?,
             user_domain_metadata_additions: vec![],
             system_domain_metadata_additions: vec![],
+            provided_row_tracking_high_water_mark: None,
             user_domain_removals: vec![],
             data_change: false,
             column_defaults_acknowledged: false,

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -168,6 +168,7 @@ impl CreateTableTransaction {
             commit_timestamp: current_time_ms()?,
             user_domain_metadata_additions: vec![],
             system_domain_metadata_additions: system_domain_metadata,
+            provided_row_tracking_high_water_mark: None,
             user_domain_removals: vec![],
             data_change: true,
             column_defaults_acknowledged: false,

--- a/kernel/src/transaction/domain_metadata.rs
+++ b/kernel/src/transaction/domain_metadata.rs
@@ -12,13 +12,14 @@ impl<S> Transaction<S> {
     ///
     /// Enforces the following rules:
     /// - DomainMetadata feature must be supported if any domain operations are present
-    /// - System domains (in system_domain_metadata_additions) must correspond to a known feature
+    /// - System domains must correspond to a known feature
     /// - User domains cannot use the delta.* prefix (system-reserved)
     /// - Domain removals are not allowed in create-table transactions
-    /// - No duplicate domains within a single transaction (across both user and system)
+    /// - No duplicate domains within a single transaction (across user and system operations)
     pub(super) fn validate_domain_metadata_operations(&self) -> DeltaResult<()> {
         // Feature validation (applies to all transactions with domain operations)
         let has_domain_ops = !self.system_domain_metadata_additions.is_empty()
+            || self.provided_row_tracking_high_water_mark.is_some()
             || !self.user_domain_metadata_additions.is_empty()
             || !self.user_domain_removals.is_empty();
 
@@ -39,12 +40,12 @@ impl<S> Transaction<S> {
         let is_create = self.is_create_table();
         let mut seen_domains = HashSet::with_capacity(
             self.system_domain_metadata_additions.len()
+                + usize::from(self.provided_row_tracking_high_water_mark.is_some())
                 + self.user_domain_metadata_additions.len()
                 + self.user_domain_removals.len(),
         );
 
-        // Validate SYSTEM domain additions (from transforms, e.g., clustering)
-        // System domains are only populated during create-table
+        // Validate system-domain additions produced by create-table transforms.
         for dm in &self.system_domain_metadata_additions {
             let domain = dm.domain();
 
@@ -55,6 +56,16 @@ impl<S> Transaction<S> {
             if !seen_domains.insert(domain) {
                 return Err(Error::generic(format!(
                     "Metadata for domain {domain} already specified in this transaction"
+                )));
+            }
+        }
+
+        // Validate the dedicated existing-table row-tracking operation with the other domains.
+        if self.provided_row_tracking_high_water_mark.is_some() {
+            self.validate_system_domain_feature(ROW_TRACKING_DOMAIN_NAME)?;
+            if !seen_domains.insert(ROW_TRACKING_DOMAIN_NAME) {
+                return Err(Error::generic(format!(
+                    "Metadata for domain {ROW_TRACKING_DOMAIN_NAME} already specified in this transaction"
                 )));
             }
         }
@@ -110,8 +121,9 @@ impl<S> Transaction<S> {
     /// Validate that a system domain corresponds to a known feature and that the feature is
     /// supported.
     ///
-    /// This prevents arbitrary `delta.*` domains from being added during table creation.
-    /// Each known system domain must have its corresponding feature enabled in the protocol.
+    /// This prevents arbitrary `delta.*` domains from entering a transaction through internal
+    /// transforms or dedicated system-domain operations. Each known system domain must have its
+    /// corresponding feature enabled in the protocol.
     fn validate_system_domain_feature(&self, domain: &str) -> DeltaResult<()> {
         let table_config = &self.effective_table_config;
 
@@ -206,7 +218,28 @@ impl<S> Transaction<S> {
         // Generate removal actions (empty for create-table due to validation above)
         let removal_actions = self.generate_user_domain_removal_actions(engine)?;
 
-        // Generate row tracking domain action.
+        let row_tracking_high_watermark = if let Some(provided) =
+            self.provided_row_tracking_high_water_mark
+        {
+            let calculated = match row_tracking_high_watermark {
+                Some(metadata) => metadata.high_water_mark(),
+                None => {
+                    RowTrackingDomainMetadata::get_high_water_mark(self.read_snapshot()?, engine)?
+                        .unwrap_or(RowTrackingDomainMetadata::MISSING_ROW_ID_HIGH_WATERMARK)
+                }
+            };
+            if provided < calculated {
+                return Err(Error::generic(format!(
+                    "Provided row-tracking high-water mark {provided} cannot be less than the \
+                         calculated value {calculated}",
+                )));
+            }
+            Some(RowTrackingDomainMetadata::new(provided))
+        } else {
+            row_tracking_high_watermark
+        };
+
+        // Generate the single row-tracking domain action, if any.
         let row_tracking_domain_action = row_tracking_high_watermark
             .map(DomainMetadata::try_from)
             .transpose()?

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -230,11 +230,10 @@ pub struct Transaction<S = ExistingTable> {
     commit_timestamp: i64,
     // User-provided domain metadata additions (via with_domain_metadata API).
     user_domain_metadata_additions: Vec<DomainMetadata>,
-    // System-generated domain metadata (from transforms, e.g., clustering).
-    // TODO(#1779): Currently only populated during CREATE TABLE. For inserts, row tracking
-    // domain metadata is handled separately via `row_tracking_high_watermark` parameter in
-    // `generate_domain_metadata_actions`. Consider unifying system domain handling.
+    // System-generated domain metadata produced by create-table transforms, e.g. clustering.
     system_domain_metadata_additions: Vec<DomainMetadata>,
+    // Row-tracking high-water mark explicitly provided by the caller.
+    provided_row_tracking_high_water_mark: Option<i64>,
     // Domain names to remove in this transaction. The configuration values are fetched during
     // commit from the log to preserve the pre-image in tombstones.
     user_domain_removals: Vec<String>,

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -102,6 +102,7 @@ impl Transaction {
             commit_timestamp,
             user_domain_metadata_additions: vec![],
             system_domain_metadata_additions: vec![],
+            provided_row_tracking_high_water_mark: None,
             user_domain_removals: vec![],
             data_change: true,
             column_defaults_acknowledged: false,
@@ -174,6 +175,28 @@ impl Transaction {
     #[cfg(feature = "row-tracking-preservation-in-dev")]
     pub fn ack_row_tracking_preservation(&mut self) {
         self.row_tracking_preservation_acknowledged = true;
+    }
+
+    /// Set an explicit row-tracking high-water mark for this transaction.
+    ///
+    /// Use this when row IDs must also be coordinated with another system. Kernel still assigns
+    /// row-tracking fields to added files and rejects this value if it is less than the high-water
+    /// mark calculated from those files. Callers cannot use [`Self::with_domain_metadata`] to
+    /// modify `delta.rowTracking` or other `delta.*` domains. Table-feature and table-state
+    /// validation occurs during commit.
+    #[internal_api]
+    #[allow(dead_code)] // used in FFI
+    pub(crate) fn with_row_tracking_high_water_mark(
+        mut self,
+        high_water_mark: i64,
+    ) -> DeltaResult<Self> {
+        if self.provided_row_tracking_high_water_mark.is_some() {
+            return Err(Error::generic(
+                "Row-tracking high-water mark already specified in this transaction",
+            ));
+        }
+        self.provided_row_tracking_high_water_mark = Some(high_water_mark);
+        Ok(self)
     }
 
     /// Remove files from the table in this transaction. This API generally enables the engine to


### PR DESCRIPTION
## Stacked PR

Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3266/files) to review incremental changes.

- [**stack/feat/ffi-row-tracking-high-water-mark**](https://github.com/delta-io/delta-kernel-rs/pull/3266) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3266/files)] <- this PR
  - [stack/feat/ffi-create-table-domain-metadata](https://github.com/delta-io/delta-kernel-rs/pull/3267) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3267/files/60b70ef9dbad795e23395312025c75ba36a34b5f..232e2be3ac2364b7cbc79c6de5a7ff6506d5f774)]

---------

## What changes are proposed in this pull request?

When row IDs are coordinated with another table format, its high-water mark may be ahead of the value Kernel calculates from the current Delta add actions. This PR adds a dedicated transaction and FFI setter for that value.

Kernel still assigns `baseRowId` and `defaultRowCommitVersion` to files passed through `add_files()`. It calculates the minimum valid high-water mark from those files and rejects a provided value below it. The generic domain-metadata API continues to reject system-controlled `delta.*` domains.

### This PR affects the following public APIs

Adds the `with_row_tracking_high_water_mark` FFI entry point.

## How was this change tested?

- `cargo nextest run -p delta_kernel_ffi --all-features row_tracking_high_water_mark`
- `cargo check-no-default-kernel`
- `cargo +nightly fmt`
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`