### PR TITLE
feat!: emit row tracking preservation tag in commitInfo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,9 +99,6 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
   in development). Gates `KernelSupport` for the `geospatial` reader+writer feature: with the
   cargo feature off, any table listing it is rejected; with it on, scans and CDF are supported
   but writes are still blocked.
-- `row-tracking-preservation-in-dev`: enables `Transaction::ack_row_tracking_preservation()` and
-  acknowledged file removals and deletion-vector updates on Row Tracking tables. This remains
-  experimental until Kernel emits `delta.rowTracking.preserved` in CommitInfo tags.
 - `internal-api`: unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
 - `declarative-plans`: experimental declarative-plan IR (`kernel/src/plans/`) and the prost

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -132,11 +132,6 @@ adaptive-metadata-in-dev = []
 # Experimental, temporary, test-only feature flag guarding the in-progress geospatial
 # (geometry/geography) type work. TODO(#2949): remove once full geo support ships.
 geo-type-in-dev = []
-# Experimental feature flag guarding Row Tracking preservation for file removals and
-# deletion-vector updates. TODO(#3227): remove the flag and emit `delta.rowTracking.preserved` in
-# CommitInfo tags when preservation support is ready.
-row-tracking-preservation-in-dev = []
-
 # Enables shared Arrow-based engine support modules (arrow_data, arrow_expression,
 # ensure_data_types, parquet_row_group_skipping). Used by the delta_kernel_default_engine crate
 # and the SyncEngine. Keeps `reqwest` only for the gated `Error::Reqwest` variant.

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -37,6 +37,7 @@ use crate::{
 const KERNEL_VERSION: &str = env!("CARGO_PKG_VERSION");
 const SERDE_JSON_RECURSION_LIMIT_ERROR_PREFIX: &str = "recursion limit exceeded";
 const UNKNOWN_OPERATION: &str = "UNKNOWN";
+pub(crate) const ROW_TRACKING_PRESERVED_TAG: &str = "delta.rowTracking.preserved";
 
 pub mod deletion_vector;
 pub mod deletion_vector_writer;
@@ -896,6 +897,8 @@ pub(crate) struct CommitInfo {
     pub(crate) engine_info: Option<String>,
     /// A unique transaction identifier for this commit.
     pub(crate) txn_id: Option<String>,
+    /// Map of tags associated with this commit.
+    pub(crate) tags: Option<HashMap<String, Option<String>>>,
 }
 
 impl CommitInfo {
@@ -916,6 +919,24 @@ impl CommitInfo {
             is_blind_append: is_blind_append.then_some(true),
             engine_info,
             txn_id: Some(uuid::Uuid::new_v4().to_string()),
+            tags: None,
+        }
+    }
+
+    pub(crate) fn set_row_tracking_preserved(&mut self) {
+        self.tags.get_or_insert_default().insert(
+            ROW_TRACKING_PRESERVED_TAG.to_string(),
+            Some("true".to_string()),
+        );
+    }
+
+    pub(crate) fn merge_tags(&mut self, connector_tags: Option<HashMap<String, Option<String>>>) {
+        let Some(connector_tags) = connector_tags else {
+            return;
+        };
+        let kernel_tags = self.tags.get_or_insert_default();
+        for (key, value) in connector_tags {
+            kernel_tags.entry(key).or_insert(value);
         }
     }
 }
@@ -1959,6 +1980,7 @@ mod tests {
                 nullable "isBlindAppend": BOOLEAN,
                 nullable "engineInfo": STRING,
                 nullable "txnId": STRING,
+                nullable "tags": { STRING => nullable STRING },
             },
         };
         assert_eq!(schema, expected);
@@ -2274,6 +2296,9 @@ mod tests {
         let mut map_builder = create_string_map_builder(true);
         map_builder.append(false).unwrap();
         let operation_metrics = Arc::new(map_builder.finish());
+        let mut map_builder = create_string_map_builder(true);
+        map_builder.append(false).unwrap();
+        let tags = Arc::new(map_builder.finish());
 
         let expected = RecordBatch::try_new(
             record_batch.schema(),
@@ -2287,6 +2312,7 @@ mod tests {
                 Arc::new(BooleanArray::from(vec![None::<bool>])),
                 Arc::new(StringArray::from(vec![None::<String>])),
                 Arc::new(StringArray::from(vec![commit_info_txn_id])),
+                tags,
             ],
         )
         .unwrap();

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -930,13 +930,16 @@ impl CommitInfo {
         );
     }
 
-    pub(crate) fn merge_tags(&mut self, connector_tags: Option<HashMap<String, Option<String>>>) {
-        let Some(connector_tags) = connector_tags else {
+    /// Merges the supplied tags into this CommitInfo's tags.
+    ///
+    /// Existing values take precedence when both maps contain the same key.
+    pub(crate) fn merge_tags(&mut self, tags: Option<HashMap<String, Option<String>>>) {
+        let Some(tags) = tags else {
             return;
         };
-        let kernel_tags = self.tags.get_or_insert_default();
-        for (key, value) in connector_tags {
-            kernel_tags.entry(key).or_insert(value);
+        let current_tags = self.tags.get_or_insert_default();
+        for (key, value) in tags {
+            current_tags.entry(key).or_insert(value);
         }
     }
 }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -923,14 +923,6 @@ impl TableConfiguration {
     }
 
     pub(crate) fn validate_feature_support_for_remove(&self) -> DeltaResult<()> {
-        #[cfg(not(feature = "row-tracking-preservation-in-dev"))]
-        require!(
-            !self.should_write_row_tracking(),
-            Error::unsupported(
-                "Remove actions are not yet supported on tables with rowTracking supported \
-                 and not suspended",
-            )
-        );
         if self.is_feature_enabled(&TableFeature::IcebergCompatV3) {
             return Err(Error::unsupported(
                 "Remove actions are not yet supported on tables with icebergCompatV3 enabled",
@@ -956,8 +948,6 @@ mod test {
         ColumnMappingMode, FeatureType, Operation, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
         TABLE_FEATURES_MIN_WRITER_VERSION,
     };
-    #[cfg(not(feature = "row-tracking-preservation-in-dev"))]
-    use crate::table_properties::ROW_TRACKING_SUSPENDED;
     use crate::table_properties::{
         TableProperties, ENABLE_DELETION_VECTORS, ENABLE_ICEBERG_COMPAT_V1,
         ENABLE_ICEBERG_COMPAT_V2, ENABLE_ICEBERG_COMPAT_V3, ENABLE_IN_COMMIT_TIMESTAMPS,
@@ -2875,7 +2865,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "row-tracking-preservation-in-dev")]
     #[rstest]
     #[case::iceberg_compat_v3_supported(&[], None)]
     #[case::iceberg_compat_v3_enabled(
@@ -2902,32 +2891,6 @@ mod test {
             assert_result_error_with_message(result, expected_error);
         } else {
             assert!(result.is_ok(), "expected Ok, got {result:?}");
-        }
-    }
-
-    #[cfg(not(feature = "row-tracking-preservation-in-dev"))]
-    /// `validate_feature_support_for_remove` must fire whenever row tracking is _supported_
-    /// and not _suspended_, which is broader than _enabled_.
-    #[rstest]
-    #[case::supported_only(&[], Some("rowTracking"))]
-    #[case::supported_and_enabled(&[(ENABLE_ROW_TRACKING, "true")], Some("rowTracking"))]
-    #[case::supported_and_suspended(&[(ROW_TRACKING_SUSPENDED, "true")], None /*expected_error_substring */)]
-    fn test_validate_feature_support_for_remove_row_tracking(
-        #[case] props: &[(&str, &str)],
-        #[case] expected_error_substring: Option<&str>,
-    ) {
-        let config = MockTableConfigurationBuilder::new()
-            .with_properties(props)
-            .with_protocol(
-                MockProtocolBuilder::new()
-                    .with_features([TableFeature::RowTracking])
-                    .build(),
-            )
-            .build();
-        let result = config.validate_feature_support_for_remove();
-        match expected_error_substring {
-            Some(msg) => assert_result_error_with_message(result, msg),
-            None => assert!(result.is_ok(), "expected Ok, got {result:?}"),
         }
     }
 }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -819,15 +819,13 @@ impl TableConfiguration {
             .unwrap_or(false)
     }
 
-    /// Returns `true` if row tracking information should be written for this table.
+    /// Returns `true` if fresh Row IDs and fresh Row Commit Versions should be assigned for
+    /// this table.
     ///
-    /// Row tracking information should be written when:
+    /// Fresh Row IDs and fresh Row Commit Versions should be assigned when:
     /// - Row tracking is supported
     /// - Row tracking is not suspended
-    ///
-    /// Note: We ignore [`is_row_tracking_enabled`] at this point because Kernel does not
-    /// preserve row IDs and row commit versions yet.
-    pub(crate) fn should_write_row_tracking(&self) -> bool {
+    pub(crate) fn should_assign_fresh_row_tracking_metadata(&self) -> bool {
         self.is_feature_supported(&TableFeature::RowTracking) && !self.is_row_tracking_suspended()
     }
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -372,7 +372,7 @@ static IN_COMMIT_TIMESTAMP_INFO: FeatureInfo = FeatureInfo {
 };
 
 // Row Tracking rewrites require connectors to preserve stable row metadata. Kernel records the
-// feature-gated acknowledgment but does not validate materialized values. IcebergCompatV3 removals
+// connector acknowledgment but does not validate materialized values. IcebergCompatV3 removals
 // remain unsupported.
 //
 // TODO: When kernel writes the materialized `row_id` / `row_commit_version` columns, they must

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -68,7 +68,6 @@ impl AlterTableTransaction {
             user_domain_removals: vec![],
             data_change: false,
             column_defaults_acknowledged: false,
-            #[cfg(feature = "row-tracking-preservation-in-dev")]
             row_tracking_preservation_acknowledged: false,
             engine_commit_info: None,
             // TODO(#2446): match delta-spark's per-op isBlindAppend policy

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -1,10 +1,13 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
 
 use super::Transaction;
 use crate::actions::{CommitInfo, COMMIT_INFO_NAME, LOG_COMMIT_INFO_SCHEMA};
+use crate::engine_data::{GetData, MapItem, RowVisitor, TypedGetData as _};
 use crate::expressions::{lit, null_lit, MapData, Scalar};
-use crate::schema::{schema_ref, MapType, ToSchema};
+use crate::schema::{column_name, schema_ref, ColumnName, MapType, ToSchema};
 use crate::struct_patch::ProjectionStructPatchBuilder;
+use crate::utils::require;
 use crate::{DataType, Engine, EngineData, Error, Expression, ExpressionRef, IntoEngineData};
 
 /// Builds a list of `(field_name, literal_expression)` pairs covering every [`CommitInfo`]
@@ -36,16 +39,26 @@ fn commit_info_literal_exprs(
             "operationMetrics",
             Arc::new(match commit_info.operation_metrics {
                 Some(map) => lit(MapData::try_new(
-                    string_map_type,
+                    string_map_type.clone(),
                     map.into_iter().map(|(k, v)| (Scalar::String(k), v)),
                 )?),
-                None => null_lit(string_map_type),
+                None => null_lit(string_map_type.clone()),
             }),
         ),
         ("kernelVersion", Arc::new(lit(commit_info.kernel_version))),
         ("isBlindAppend", Arc::new(lit(commit_info.is_blind_append))),
         ("engineInfo", Arc::new(lit(commit_info.engine_info))),
         ("txnId", Arc::new(lit(commit_info.txn_id))),
+        (
+            "tags",
+            Arc::new(match commit_info.tags {
+                Some(map) => lit(MapData::try_new(
+                    string_map_type,
+                    map.into_iter().map(|(k, v)| (Scalar::String(k), v)),
+                )?),
+                None => null_lit(string_map_type),
+            }),
+        ),
     ];
     let expected_expr_len = CommitInfo::to_schema().fields().len();
     if literal_exprs.len() != expected_expr_len {
@@ -64,9 +77,15 @@ impl<S> Transaction<S> {
         match &self.engine_commit_info {
             Some((engine_commit_info, engine_commit_info_schema)) => {
                 let kernel_schema = CommitInfo::to_schema();
+                let mut commit_info = kernel_commit_info;
+                if engine_commit_info_schema.contains("tags") {
+                    let mut visitor = CommitInfoTagsVisitor::default();
+                    visitor.visit_rows_of(engine_commit_info.as_ref())?;
+                    commit_info.merge_tags(visitor.tags);
+                }
 
                 // Step 1: Build literal expressions for each CommitInfo field.
-                let literal_exprs = commit_info_literal_exprs(kernel_commit_info)?;
+                let literal_exprs = commit_info_literal_exprs(commit_info)?;
 
                 // Step 2: Build the output schema and expression patch together. Engine fields
                 // pass through first, overlapping kernel fields are replaced in place, and
@@ -111,13 +130,56 @@ impl<S> Transaction<S> {
     }
 }
 
+#[derive(Default)]
+struct CommitInfoTagsVisitor {
+    tags: Option<HashMap<String, Option<String>>>,
+}
+
+impl RowVisitor for CommitInfoTagsVisitor {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES: LazyLock<[ColumnName; 1]> = LazyLock::new(|| [column_name!("tags")]);
+        static TYPES: LazyLock<[DataType; 1]> = LazyLock::new(|| {
+            [DataType::from(MapType::new(
+                DataType::STRING,
+                DataType::STRING,
+                true,
+            ))]
+        });
+        (NAMES.as_slice(), TYPES.as_slice())
+    }
+
+    fn visit<'a>(
+        &mut self,
+        row_count: usize,
+        getters: &[&'a dyn GetData<'a>],
+    ) -> Result<(), Error> {
+        require!(
+            row_count == 1,
+            Error::generic("Connector commit info must contain exactly one row")
+        );
+        let [tags_getter] = getters else {
+            return Err(Error::internal_error(format!(
+                "CommitInfoTagsVisitor received {} getters instead of one",
+                getters.len()
+            )));
+        };
+        let tags: Option<MapItem<'_>> = tags_getter.get_opt(0, "tags")?;
+        self.tags = tags.map(|tags| {
+            tags.keys()
+                .map(|key| (key.to_string(), tags.get(key).map(str::to_string)))
+                .collect()
+        });
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use crate::actions::CommitInfo;
     use crate::arrow::array::{
-        Array, ArrayRef, BooleanArray, Int64Array, MapArray, MapBuilder, StringArray,
+        Array, ArrayRef, AsArray, BooleanArray, Int64Array, MapArray, MapBuilder, StringArray,
         StringBuilder, StructArray,
     };
     use crate::arrow::datatypes::{
@@ -306,6 +368,7 @@ mod tests {
         map_builder.values().append_value("stale_value");
         map_builder.append(true).unwrap();
         let stale_op_params = Arc::new(map_builder.finish()) as ArrayRef;
+        let connector_tags = stale_op_params.clone();
         let mut metrics_map_builder =
             MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
         metrics_map_builder.keys().append_value("stale_metric");
@@ -332,6 +395,7 @@ mod tests {
                 ArrowField::new("isBlindAppend", ArrowDataType::Boolean, true),
                 ArrowField::new("engineInfo", ArrowDataType::Utf8, true),
                 ArrowField::new("txnId", ArrowDataType::Utf8, true),
+                ArrowField::new("tags", connector_tags.data_type().clone(), true),
             ],
             vec![
                 Arc::new(Int64Array::from(vec![Some(0i64)])) as ArrayRef,
@@ -343,6 +407,7 @@ mod tests {
                 Arc::new(BooleanArray::from(vec![None::<bool>])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["stale_engine"])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["stale_txn"])) as ArrayRef,
+                connector_tags,
             ],
         );
         let (engine, txn) = make_txn(Some((data, schema)))?;
@@ -367,6 +432,11 @@ mod tests {
         assert_eq!(get_i64(commit_info, "inCommitTimestamp"), 134_000_000);
         assert_eq!(get_str(commit_info, "engineInfo"), "test_engine/1.0");
         assert!(!get_bool(commit_info, "isBlindAppend"));
+        let tags = get_map(commit_info, "tags");
+        let tag_keys = tags.column(0).as_string::<i32>();
+        let tag_values = tags.column(1).as_string::<i32>();
+        assert_eq!(tag_keys.value(0), "stale_key");
+        assert_eq!(tag_values.value(0), "stale_value");
 
         Ok(())
     }

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -177,6 +177,7 @@ impl RowVisitor for CommitInfoTagsVisitor {
 mod tests {
     use std::sync::Arc;
 
+    use super::CommitInfoTagsVisitor;
     use crate::actions::CommitInfo;
     use crate::arrow::array::{
         Array, ArrayRef, AsArray, BooleanArray, Int64Array, MapArray, MapBuilder, StringArray,
@@ -191,9 +192,9 @@ mod tests {
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::schema::{schema_ref, Schema, SchemaRef, ToSchema};
     use crate::transaction::Transaction;
-    use crate::unit_test_utils::load_test_table;
+    use crate::unit_test_utils::{assert_result_error_with_message, load_test_table};
     use crate::utils::FoldWithOption as _;
-    use crate::{DeltaResult, Engine, EngineData};
+    use crate::{DeltaResult, Engine, EngineData, RowVisitor};
 
     // ── build_commit_info tests ────────────────────────────────────────────────
 
@@ -293,6 +294,19 @@ mod tests {
                 txn.with_commit_info(data, schema)
             });
         Ok((engine, txn))
+    }
+
+    #[test]
+    fn commit_info_tags_visitor_rejects_invalid_callback_shape() {
+        let mut visitor = CommitInfoTagsVisitor::default();
+        assert_result_error_with_message(
+            visitor.visit(0, &[]),
+            "Connector commit info must contain exactly one row",
+        );
+        assert_result_error_with_message(
+            visitor.visit(1, &[]),
+            "CommitInfoTagsVisitor received 0 getters instead of one",
+        );
     }
 
     /// no engine_commit_info -- output is the kernel CommitInfo wrapped in a "commitInfo"

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -27,23 +27,11 @@ fn commit_info_literal_exprs(
         ("operation", Arc::new(lit(commit_info.operation))),
         (
             "operationParameters",
-            Arc::new(match commit_info.operation_parameters {
-                Some(map) => lit(MapData::try_new(
-                    string_map_type.clone(),
-                    map.into_iter().map(|(k, v)| (Scalar::String(k), v)),
-                )?),
-                None => null_lit(string_map_type.clone()),
-            }),
+            string_map_literal_expr(commit_info.operation_parameters, &string_map_type)?,
         ),
         (
             "operationMetrics",
-            Arc::new(match commit_info.operation_metrics {
-                Some(map) => lit(MapData::try_new(
-                    string_map_type.clone(),
-                    map.into_iter().map(|(k, v)| (Scalar::String(k), v)),
-                )?),
-                None => null_lit(string_map_type.clone()),
-            }),
+            string_map_literal_expr(commit_info.operation_metrics, &string_map_type)?,
         ),
         ("kernelVersion", Arc::new(lit(commit_info.kernel_version))),
         ("isBlindAppend", Arc::new(lit(commit_info.is_blind_append))),
@@ -51,13 +39,7 @@ fn commit_info_literal_exprs(
         ("txnId", Arc::new(lit(commit_info.txn_id))),
         (
             "tags",
-            Arc::new(match commit_info.tags {
-                Some(map) => lit(MapData::try_new(
-                    string_map_type,
-                    map.into_iter().map(|(k, v)| (Scalar::String(k), v)),
-                )?),
-                None => null_lit(string_map_type),
-            }),
+            string_map_literal_expr(commit_info.tags, &string_map_type)?,
         ),
     ];
     let expected_expr_len = CommitInfo::to_schema().fields().len();
@@ -66,6 +48,21 @@ fn commit_info_literal_exprs(
             If CommitInfo field was added/removed, please update Expression::Literal in this function and update the with_commit_info doc comment", literal_exprs.len())));
     }
     Ok(literal_exprs)
+}
+
+fn string_map_literal_expr(
+    map: Option<HashMap<String, Option<String>>>,
+    map_type: &MapType,
+) -> Result<ExpressionRef, Error> {
+    let expression = match map {
+        Some(map) => lit(MapData::try_new(
+            map_type.clone(),
+            map.into_iter()
+                .map(|(key, value)| (Scalar::String(key), value)),
+        )?),
+        None => null_lit(map_type.clone()),
+    };
+    Ok(Arc::new(expression))
 }
 
 impl<S> Transaction<S> {

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -171,7 +171,6 @@ impl CreateTableTransaction {
             user_domain_removals: vec![],
             data_change: true,
             column_defaults_acknowledged: false,
-            #[cfg(feature = "row-tracking-preservation-in-dev")]
             row_tracking_preservation_acknowledged: false,
             engine_commit_info: None,
             is_blind_append: false,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -455,8 +455,9 @@ impl<S> Transaction<S> {
             self.is_blind_append,
         );
 
-        // Kernel always requires stable row tracking id/commitVersion preservation,
-        // so the flag is always true(except for CREATE TABLE).
+        // Kernel requires every commit on an existing Row Tracking-enabled table to preserve
+        // Stable Row IDs and Stable Row Commit Versions, so it always emits true. CREATE TABLE has
+        // no existing Row Tracking state to preserve and therefore omits the flag.
         if !self.is_create_table()
             && self
                 .effective_table_config

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -456,10 +456,11 @@ impl<S> Transaction<S> {
         );
 
         // Kernel always requires stable row tracking id/commitVersion preservation,
-        // so the flag is always true.
-        if self
-            .effective_table_config
-            .is_feature_enabled(&TableFeature::RowTracking)
+        // so the flag is always true(except for CREATE TABLE).
+        if !self.is_create_table()
+            && self
+                .effective_table_config
+                .is_feature_enabled(&TableFeature::RowTracking)
         {
             kernel_commit_info.set_row_tracking_preserved();
         }
@@ -639,21 +640,23 @@ impl<S> Transaction<S> {
 
     /// Set the content of the commitInfo action for this transaction. Note that kernel will
     /// _always_ write a commitInfo, this function simply allows engines to add their own data
-    /// into that action if they wish. Note that the following fields in `engine_commit_info`
-    /// will be overridden or merged by kernel if they are set:
-    /// - timestamp
-    /// - inCommitTimestamp
-    /// - operation
-    /// - operationParameters
-    /// - operationMetrics
-    /// - kernelVersion
-    /// - isBlindAppend
-    /// - engineInfo
-    /// - txnId
-    /// - tags
+    /// into that action if they wish. Kernel overrides the following fields if they are set in
+    /// `engine_commit_info`, so connectors should not set them:
     ///
-    /// When a connector tag has the same key as a Kernel-provided tag, Kernel's value takes
-    /// precedence. Otherwise, the connector-provided tag is preserved.
+    /// - `timestamp`
+    /// - `inCommitTimestamp`
+    /// - `operation`
+    /// - `operationParameters`
+    /// - `operationMetrics`
+    /// - `kernelVersion`
+    /// - `isBlindAppend`
+    /// - `engineInfo`
+    /// - `txnId`
+    ///
+    /// Kernel merges the following field if it is set:
+    ///
+    /// - `tags`: When a connector tag has the same key as a Kernel-provided tag, Kernel's value
+    ///   takes precedence. Otherwise, the connector-provided tag is preserved.
     pub fn with_commit_info(
         mut self,
         engine_commit_info: Box<dyn EngineData>,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -246,7 +246,6 @@ pub struct Transaction<S = ExistingTable> {
     column_defaults_acknowledged: bool,
     // Whether the connector acknowledged responsibility for preserving Row IDs and Row Commit
     // Versions.
-    #[cfg(feature = "row-tracking-preservation-in-dev")]
     row_tracking_preservation_acknowledged: bool,
     // Whether this transaction should be marked as a blind append.
     is_blind_append: bool,
@@ -360,19 +359,12 @@ impl<S> Transaction<S> {
     pub fn commit(self, engine: &dyn Engine) -> DeltaResult<CommitResult<S>> {
         let commit_start = Instant::now();
 
-        #[cfg(feature = "row-tracking-preservation-in-dev")]
         // Kernel cannot distinguish Remove actions and DV updates that only delete rows from those
         // that accompany copied or updated rows, so both require the preservation acknowledgment.
         if !self.remove_files_metadata.is_empty() || self.num_dv_updates > 0 {
             self.effective_table_config
                 .validate_feature_support_for_remove()?;
             self.ensure_row_tracking_preservation_acknowledged()?;
-        }
-
-        #[cfg(not(feature = "row-tracking-preservation-in-dev"))]
-        if !self.remove_files_metadata.is_empty() {
-            self.effective_table_config
-                .validate_feature_support_for_remove()?;
         }
 
         // Step 1: Check for duplicate app_ids and generate set transactions (`txn`)
@@ -455,13 +447,22 @@ impl<S> Transaction<S> {
 
         // Step 2: Construct commit info with ICT if enabled
         let in_commit_timestamp = self.get_in_commit_timestamp(engine)?;
-        let kernel_commit_info = CommitInfo::new(
+        let mut kernel_commit_info = CommitInfo::new(
             self.commit_timestamp,
             in_commit_timestamp,
             self.operation.clone(),
             self.engine_info.clone(),
             self.is_blind_append,
         );
+
+        // Kernel always requires stable row tracking id/commitVersion preservation,
+        // so the flag is always true.
+        if self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::RowTracking)
+        {
+            kernel_commit_info.set_row_tracking_preserved();
+        }
         let commit_info_action = self.generate_commit_info(engine, kernel_commit_info);
 
         // Step 3: Generate Protocol and Metadata actions based on emit flags
@@ -639,7 +640,7 @@ impl<S> Transaction<S> {
     /// Set the content of the commitInfo action for this transaction. Note that kernel will
     /// _always_ write a commitInfo, this function simply allows engines to add their own data
     /// into that action if they wish. Note that the following fields in `engine_commit_info`
-    /// will be overridden by kernel if they are set (meaning you should not set them):
+    /// will be overridden or merged by kernel if they are set:
     /// - timestamp
     /// - inCommitTimestamp
     /// - operation
@@ -649,6 +650,10 @@ impl<S> Transaction<S> {
     /// - isBlindAppend
     /// - engineInfo
     /// - txnId
+    /// - tags
+    ///
+    /// When a connector tag has the same key as a Kernel-provided tag, Kernel's value takes
+    /// precedence. Otherwise, the connector-provided tag is preserved.
     pub fn with_commit_info(
         mut self,
         engine_commit_info: Box<dyn EngineData>,
@@ -870,7 +875,6 @@ impl<S> Transaction<S> {
         Ok(())
     }
 
-    #[cfg(feature = "row-tracking-preservation-in-dev")]
     fn ensure_row_tracking_preservation_acknowledged(&self) -> DeltaResult<()> {
         if !self
             .effective_table_config

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1214,21 +1214,23 @@ impl<S> Transaction<S> {
     )> {
         // Note: this does not require delta.enableRowTracking=true. "supported" is sufficient
         // for writers to assign row IDs.
-        let row_tracking_supported = self.effective_table_config.should_write_row_tracking();
+        let assign_fresh_row_tracking_metadata = self
+            .effective_table_config
+            .should_assign_fresh_row_tracking_metadata();
 
         if self.add_files_metadata.is_empty() {
             // No files to add. For an empty CREATE TABLE with row tracking, emit the initial
             // high water mark domain metadata (rowIdHighWaterMark = -1) so subsequent writes
             // have a valid starting point. For all other empty commits (metadata-only, etc.),
             // nothing row-tracking-related needs to be written.
-            let row_tracking_dm = (row_tracking_supported && self.is_create_table())
+            let row_tracking_dm = (assign_fresh_row_tracking_metadata && self.is_create_table())
                 .then(RowTrackingDomainMetadata::initial);
             return Ok((Box::new(iter::empty()), row_tracking_dm));
         }
 
         let commit_version = version_as_i64(commit_version)?;
 
-        if row_tracking_supported {
+        if assign_fresh_row_tracking_metadata {
             self.generate_adds_with_row_tracking(engine, commit_version)
         } else {
             let add_actions = build_add_actions(

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -105,7 +105,6 @@ impl Transaction {
             user_domain_removals: vec![],
             data_change: true,
             column_defaults_acknowledged: false,
-            #[cfg(feature = "row-tracking-preservation-in-dev")]
             row_tracking_preservation_acknowledged: false,
             engine_commit_info: None,
             is_blind_append: false,
@@ -171,7 +170,6 @@ impl Transaction {
     /// on tables with Row Tracking enabled.
     ///
     /// [Row Tracking]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#row-tracking
-    #[cfg(feature = "row-tracking-preservation-in-dev")]
     pub fn ack_row_tracking_preservation(&mut self) {
         self.row_tracking_preservation_acknowledged = true;
     }

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -1246,7 +1246,6 @@ async fn test_read_row_tracking_metadata_stable_across_deletion_vector_update(
             .into_iter()
             .map(Ok),
     )?;
-    #[cfg(feature = "row-tracking-preservation-in-dev")]
     txn.ack_row_tracking_preservation();
     txn.commit(engine.as_ref())?.unwrap_committed();
 

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -1454,7 +1454,6 @@ async fn test_v2_sidecar_preserves_dv_and_row_tracking_on_add(
         HashMap::from([(path, dv.clone())]),
         scan_files.into_iter().map(Ok),
     )?;
-    #[cfg(feature = "row-tracking-preservation-in-dev")]
     txn.ack_row_tracking_preservation();
     let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
 

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -10,122 +10,20 @@ use delta_kernel::schema::{schema_ref, MetadataColumnSpec};
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
 use delta_kernel::transaction::RowTrackingMetadataColumns;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
-#[cfg(feature = "row-tracking-preservation-in-dev")]
-use test_utils::read_scan;
 use test_utils::{
-    assert_result_error_with_message, insert_data, into_record_batch, test_table_setup,
+    assert_result_error_with_message, insert_data, into_record_batch, read_scan, test_table_setup,
     test_table_setup_mt,
 };
-#[cfg(not(feature = "row-tracking-preservation-in-dev"))]
-use url::Url;
 
 use crate::common::read_utils::read_row_tracking_scan;
-#[cfg(not(feature = "row-tracking-preservation-in-dev"))]
-use crate::common::write_utils::set_table_properties;
-
-#[cfg(not(feature = "row-tracking-preservation-in-dev"))]
-/// `Transaction::commit` is rejected when it contains staged removeFiles and row
-/// tracking is _supported_ and not _suspended_, which is broader than _enabled_.
-#[rstest::rstest]
-#[case::enabled(
-    &[("delta.enableRowTracking", "true")],
-    false, /* suspend_after_create */
-    true,  /* expect_err */
-)]
-#[case::supported_only(
-    &[("delta.feature.rowTracking", "supported")],
-    false, /* suspend_after_create */
-    true,  /* expect_err */
-)]
-#[case::supported_and_suspended(
-    &[("delta.feature.rowTracking", "supported")],
-    true,  /* suspend_after_create */
-    false, /* expect_err */
-)]
-#[case::iceberg_compat_v3(
-    // V3 auto-enables row tracking, so the gate fires.
-    &[("delta.enableIcebergCompatV3", "true")],
-    false, /* suspend_after_create */
-    true,  /* expect_err */
-)]
-#[tokio::test(flavor = "multi_thread")]
-async fn test_row_tracking_remove_gate(
-    #[case] create_properties: &[(&str, &str)],
-    #[case] suspend_after_create: bool,
-    #[case] expect_err: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
-    let schema = schema_ref! { nullable "number": INTEGER };
-    let table_url = Url::from_directory_path(&table_path).unwrap();
-
-    // v0: create table with the requested initial properties.
-    kernel_create_table(table_path.as_str(), schema.clone(), "Test/1.0")
-        .with_table_properties(create_properties.iter().copied())
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
-        .unwrap_committed();
-
-    // Optional v1: inject a metadata-only commit that sets `delta.rowTrackingSuspended=true`.
-    // kernel's create_table rejects this property at create time, so we set it via
-    // the integration test hack here.
-    let initial_snapshot = if suspend_after_create {
-        set_table_properties(
-            &table_path,
-            &table_url,
-            engine.as_ref(),
-            0, /* current_version */
-            &[("delta.rowTrackingSuspended", "true")],
-        )?
-    } else {
-        Snapshot::builder_for(&table_path).build(engine.as_ref())?
-    };
-
-    // Insert a file.
-    insert_data(
-        initial_snapshot,
-        &engine,
-        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
-    )
-    .await?
-    .unwrap_committed();
-
-    // Remove the inserted file.
-    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    let scan = snapshot.clone().scan_builder().build()?;
-    let scan_files = scan
-        .scan_metadata(engine.as_ref())?
-        .next()
-        .unwrap()?
-        .scan_files;
-    let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
-        .with_data_change(true);
-    txn.remove_files(scan_files);
-
-    if expect_err {
-        let err = txn
-            .commit(engine.as_ref())
-            .expect_err("commit must fail when rowTracking is supported and not suspended");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("Remove actions are not yet supported") && msg.contains("rowTracking"),
-            "expected remove-block error mentioning rowTracking, got: {msg}",
-        );
-    } else {
-        txn.commit(engine.as_ref())?.unwrap_committed();
-    }
-    Ok(())
-}
-
-#[cfg(feature = "row-tracking-preservation-in-dev")]
 mod row_tracking_preservation {
     use std::collections::HashMap;
 
     use delta_kernel::actions::deletion_vector_writer::KernelDeletionVector;
-    use delta_kernel::arrow::array::Array;
+    use delta_kernel::arrow::array::{Array, ArrayRef, MapBuilder, StringBuilder};
     use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
     use test_utils::delta_kernel_default_engine::DefaultEngine;
-    use test_utils::read_add_infos;
+    use test_utils::{read_actions_from_commit, read_add_infos};
     use url::Url;
 
     use super::*;
@@ -135,6 +33,116 @@ mod row_tracking_preservation {
         write_deletion_vector_to_store,
     };
     use crate::features::row_tracking::setup_number_table_with_features;
+
+    const ROW_TRACKING_PRESERVED_TAG: &str = "delta.rowTracking.preserved";
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum CommitInfoTagTestCase {
+        Enabled,
+        Supported,
+        Suspended,
+    }
+
+    impl CommitInfoTagTestCase {
+        fn create_table_properties(self) -> &'static [(&'static str, &'static str)] {
+            match self {
+                Self::Enabled => &[("delta.enableRowTracking", "true")],
+                Self::Supported | Self::Suspended => &[("delta.feature.rowTracking", "supported")],
+            }
+        }
+
+        fn expected_tag(self) -> Option<&'static str> {
+            (self == Self::Enabled).then_some("true")
+        }
+    }
+
+    #[rstest::rstest]
+    #[case::enabled(CommitInfoTagTestCase::Enabled)]
+    #[case::supported(CommitInfoTagTestCase::Supported)]
+    #[case::suspended(CommitInfoTagTestCase::Suspended)]
+    fn commit_info_preservation_tag_requires_row_tracking_enabled(
+        #[case] test_case: CommitInfoTagTestCase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp_dir, table_path, engine) = test_table_setup()?;
+        let table_url = Url::from_directory_path(&table_path).unwrap();
+        let snapshot = kernel_create_table(
+            table_path.as_str(),
+            schema_ref! { nullable "number": INTEGER },
+            "Test/1.0",
+        )
+        .with_table_properties(test_case.create_table_properties().iter().copied())
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+        let snapshot = if test_case == CommitInfoTagTestCase::Suspended {
+            set_table_properties(
+                &table_path,
+                &table_url,
+                engine.as_ref(),
+                0, /* current_version */
+                &[("delta.rowTrackingSuspended", "true")],
+            )?
+        } else {
+            snapshot
+        };
+
+        let commit_version = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .commit(engine.as_ref())?
+            .unwrap_committed()
+            .commit_version();
+        let commit_infos = read_actions_from_commit(&table_url, commit_version, "commitInfo")?;
+        assert_eq!(commit_infos.len(), 1);
+        assert_eq!(
+            commit_infos[0]["tags"][ROW_TRACKING_PRESERVED_TAG].as_str(),
+            test_case.expected_tag()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn commit_info_preservation_tag_merges_connector_tags() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let (_temp_dir, table_path, engine) = test_table_setup()?;
+        let table_url = Url::from_directory_path(&table_path).unwrap();
+        let snapshot = kernel_create_table(
+            table_path.as_str(),
+            schema_ref! { nullable "number": INTEGER },
+            "Test/1.0",
+        )
+        .with_table_properties([("delta.enableRowTracking", "true")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+        let mut tags = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        tags.keys().append_value("connectorTag");
+        tags.values().append_value("connectorValue");
+        tags.keys().append_value("nullableConnectorTag");
+        tags.values().append_null();
+        tags.keys().append_value(ROW_TRACKING_PRESERVED_TAG);
+        tags.values().append_value("false");
+        tags.append(true)?;
+        let tags = Arc::new(tags.finish()) as ArrayRef;
+        let commit_info = RecordBatch::try_from_iter([("tags", tags)])?;
+        let commit_version = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_commit_info(
+                Box::new(ArrowEngineData::new(commit_info)),
+                schema_ref! { nullable "tags": { STRING => nullable STRING } },
+            )
+            .commit(engine.as_ref())?
+            .unwrap_committed()
+            .commit_version();
+
+        let commit_infos = read_actions_from_commit(&table_url, commit_version, "commitInfo")?;
+        assert_eq!(commit_infos.len(), 1);
+        let tags = &commit_infos[0]["tags"];
+        assert_eq!(tags["connectorTag"], "connectorValue");
+        assert!(tags["nullableConnectorTag"].is_null());
+        assert_eq!(tags[ROW_TRACKING_PRESERVED_TAG], "true");
+        Ok(())
+    }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum RemoveTestCase {

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -164,9 +164,9 @@ mod row_tracking_preservation {
     }
 
     #[rstest::rstest]
-    #[case::connector_commit_info_with_tags(ConnectorCommitInfoTestCase::WithTags)]
-    #[case::connector_commit_info_without_tags(ConnectorCommitInfoTestCase::WithoutTags)]
-    #[case::connector_commit_info_with_null_tags(ConnectorCommitInfoTestCase::NullTags)]
+    #[case::connector_commit_info_with_tags(ConnectorCommitInfoTestCase::PopulatedTags)]
+    #[case::connector_commit_info_without_tags(ConnectorCommitInfoTestCase::MissingTagsField)]
+    #[case::connector_commit_info_with_null_tags(ConnectorCommitInfoTestCase::NullTagsMap)]
     fn commit_info_preservation_tag_merges_connector_commit_info(
         #[case] test_case: ConnectorCommitInfoTestCase,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -205,26 +205,26 @@ mod row_tracking_preservation {
             "true"
         );
         match test_case {
-            ConnectorCommitInfoTestCase::WithTags => {
+            ConnectorCommitInfoTestCase::PopulatedTags => {
                 assert_eq!(
                     committed_commit_info["tags"]["connectorTag"],
                     "connectorValue"
                 );
                 assert!(committed_commit_info["tags"]["nullableConnectorTag"].is_null());
             }
-            ConnectorCommitInfoTestCase::WithoutTags => {
+            ConnectorCommitInfoTestCase::MissingTagsField => {
                 assert_eq!(committed_commit_info["customApp"], "connector");
             }
-            ConnectorCommitInfoTestCase::NullTags => {}
+            ConnectorCommitInfoTestCase::NullTagsMap => {}
         }
         Ok(())
     }
 
     #[derive(Clone, Copy, Debug)]
     enum ConnectorCommitInfoTestCase {
-        WithTags,
-        WithoutTags,
-        NullTags,
+        PopulatedTags,
+        MissingTagsField,
+        NullTagsMap,
     }
 
     impl ConnectorCommitInfoTestCase {
@@ -233,7 +233,7 @@ mod row_tracking_preservation {
             self,
         ) -> Result<(RecordBatch, SchemaRef), Box<dyn std::error::Error>> {
             match self {
-                Self::WithTags => {
+                Self::PopulatedTags => {
                     let mut tags =
                         MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
                     tags.keys().append_value("connectorTag");
@@ -251,14 +251,14 @@ mod row_tracking_preservation {
                         schema_ref! { nullable "tags": { STRING => nullable STRING } },
                     ))
                 }
-                Self::WithoutTags => Ok((
+                Self::MissingTagsField => Ok((
                     RecordBatch::try_from_iter([(
                         "customApp",
                         Arc::new(StringArray::from(vec!["connector"])) as ArrayRef,
                     )])?,
                     schema_ref! { nullable "customApp": STRING },
                 )),
-                Self::NullTags => {
+                Self::NullTagsMap => {
                     let mut tags =
                         MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
                     tags.append(false)?;

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -21,6 +21,7 @@ mod row_tracking_preservation {
 
     use delta_kernel::actions::deletion_vector_writer::KernelDeletionVector;
     use delta_kernel::arrow::array::{Array, ArrayRef, MapBuilder, StringBuilder};
+    use delta_kernel::schema::{DataType, StructField};
     use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
     use test_utils::delta_kernel_default_engine::DefaultEngine;
     use test_utils::{read_actions_from_commit, read_add_infos};
@@ -44,6 +45,8 @@ mod row_tracking_preservation {
     }
 
     impl CommitInfoTagTestCase {
+        /// Returns the properties that create an enabled or supported-only Row Tracking table.
+        /// The suspended case starts supported-only and is suspended in a later commit.
         fn create_table_properties(self) -> &'static [(&'static str, &'static str)] {
             match self {
                 Self::Enabled => &[("delta.enableRowTracking", "true")],
@@ -56,13 +59,29 @@ mod row_tracking_preservation {
         }
     }
 
+    fn assert_row_tracking_preserved_tag(
+        table_url: &Url,
+        commit_version: u64,
+        expected: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let commit_infos = read_actions_from_commit(table_url, commit_version, "commitInfo")?;
+        assert_eq!(commit_infos.len(), 1);
+        assert_eq!(
+            commit_infos[0]["tags"][ROW_TRACKING_PRESERVED_TAG].as_str(),
+            expected
+        );
+        Ok(())
+    }
+
     #[rstest::rstest]
     #[case::enabled(CommitInfoTagTestCase::Enabled)]
     #[case::supported(CommitInfoTagTestCase::Supported)]
     #[case::suspended(CommitInfoTagTestCase::Suspended)]
-    fn commit_info_preservation_tag_requires_row_tracking_enabled(
+    #[tokio::test]
+    async fn insert_commit_info_preservation_tag_requires_row_tracking_enabled(
         #[case] test_case: CommitInfoTagTestCase,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        // === Create a table in the requested Row Tracking state ===
         let (_temp_dir, table_path, engine) = test_table_setup()?;
         let table_url = Url::from_directory_path(&table_path).unwrap();
         let snapshot = kernel_create_table(
@@ -86,23 +105,68 @@ mod row_tracking_preservation {
             snapshot
         };
 
+        // === Insert data and validate the preservation tag ===
+        let commit_version = insert_data(
+            snapshot,
+            &engine,
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .await?
+        .unwrap_committed()
+        .commit_version();
+        assert_row_tracking_preserved_tag(&table_url, commit_version, test_case.expected_tag())?;
+        Ok(())
+    }
+
+    #[test]
+    fn create_table_does_not_emit_row_tracking_preservation_tag(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp_dir, table_path, engine) = test_table_setup()?;
+        let table_url = Url::from_directory_path(&table_path).unwrap();
+        let commit_version = kernel_create_table(
+            table_path.as_str(),
+            schema_ref! { nullable "number": INTEGER },
+            "Test/1.0",
+        )
+        .with_table_properties([("delta.enableRowTracking", "true")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed()
+        .commit_version();
+
+        assert_row_tracking_preserved_tag(&table_url, commit_version, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn alter_table_emits_row_tracking_preservation_tag() -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp_dir, table_path, engine) = test_table_setup()?;
+        let table_url = Url::from_directory_path(&table_path).unwrap();
+        let snapshot = kernel_create_table(
+            table_path.as_str(),
+            schema_ref! { nullable "number": INTEGER },
+            "Test/1.0",
+        )
+        .with_table_properties([("delta.enableRowTracking", "true")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
         let commit_version = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .alter_table()
+            .add_column(StructField::nullable("added", DataType::INTEGER))
+            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
             .commit(engine.as_ref())?
             .unwrap_committed()
             .commit_version();
-        let commit_infos = read_actions_from_commit(&table_url, commit_version, "commitInfo")?;
-        assert_eq!(commit_infos.len(), 1);
-        assert_eq!(
-            commit_infos[0]["tags"][ROW_TRACKING_PRESERVED_TAG].as_str(),
-            test_case.expected_tag()
-        );
+
+        assert_row_tracking_preserved_tag(&table_url, commit_version, Some("true"))?;
         Ok(())
     }
 
     #[test]
     fn commit_info_preservation_tag_merges_connector_tags() -> Result<(), Box<dyn std::error::Error>>
     {
+        // === Create a Row Tracking table ===
         let (_temp_dir, table_path, engine) = test_table_setup()?;
         let table_url = Url::from_directory_path(&table_path).unwrap();
         let snapshot = kernel_create_table(
@@ -115,6 +179,7 @@ mod row_tracking_preservation {
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
 
+        // === Commit connector-provided tags ===
         let mut tags = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
         tags.keys().append_value("connectorTag");
         tags.values().append_value("connectorValue");
@@ -135,6 +200,7 @@ mod row_tracking_preservation {
             .unwrap_committed()
             .commit_version();
 
+        // === Validate the merged tags ===
         let commit_infos = read_actions_from_commit(&table_url, commit_version, "commitInfo")?;
         assert_eq!(commit_infos.len(), 1);
         let tags = &commit_infos[0]["tags"];

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -20,8 +20,8 @@ mod row_tracking_preservation {
     use std::collections::HashMap;
 
     use delta_kernel::actions::deletion_vector_writer::KernelDeletionVector;
-    use delta_kernel::arrow::array::{Array, ArrayRef, MapBuilder, StringBuilder};
-    use delta_kernel::schema::{DataType, StructField};
+    use delta_kernel::arrow::array::{Array, ArrayRef, MapBuilder, StringArray, StringBuilder};
+    use delta_kernel::schema::{DataType, SchemaRef, StructField};
     use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
     use test_utils::delta_kernel_default_engine::DefaultEngine;
     use test_utils::{read_actions_from_commit, read_add_infos};
@@ -163,9 +163,13 @@ mod row_tracking_preservation {
         Ok(())
     }
 
-    #[test]
-    fn commit_info_preservation_tag_merges_connector_tags() -> Result<(), Box<dyn std::error::Error>>
-    {
+    #[rstest::rstest]
+    #[case::connector_commit_info_with_tags(ConnectorCommitInfoTestCase::WithTags)]
+    #[case::connector_commit_info_without_tags(ConnectorCommitInfoTestCase::WithoutTags)]
+    #[case::connector_commit_info_with_null_tags(ConnectorCommitInfoTestCase::NullTags)]
+    fn commit_info_preservation_tag_merges_connector_commit_info(
+        #[case] test_case: ConnectorCommitInfoTestCase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         // === Create a Row Tracking table ===
         let (_temp_dir, table_path, engine) = test_table_setup()?;
         let table_url = Url::from_directory_path(&table_path).unwrap();
@@ -179,35 +183,95 @@ mod row_tracking_preservation {
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
 
-        // === Commit connector-provided tags ===
-        let mut tags = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-        tags.keys().append_value("connectorTag");
-        tags.values().append_value("connectorValue");
-        tags.keys().append_value("nullableConnectorTag");
-        tags.values().append_null();
-        tags.keys().append_value(ROW_TRACKING_PRESERVED_TAG);
-        tags.values().append_value("false");
-        tags.append(true)?;
-        let tags = Arc::new(tags.finish()) as ArrayRef;
-        let commit_info = RecordBatch::try_from_iter([("tags", tags)])?;
+        // === Commit with connector-provided CommitInfo ===
+        let (connector_commit_info, connector_commit_info_schema) =
+            test_case.connector_commit_info()?;
         let commit_version = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_commit_info(
-                Box::new(ArrowEngineData::new(commit_info)),
-                schema_ref! { nullable "tags": { STRING => nullable STRING } },
+                Box::new(ArrowEngineData::new(connector_commit_info)),
+                connector_commit_info_schema,
             )
             .commit(engine.as_ref())?
             .unwrap_committed()
             .commit_version();
 
-        // === Validate the merged tags ===
+        // === Validate the merged CommitInfo ===
         let commit_infos = read_actions_from_commit(&table_url, commit_version, "commitInfo")?;
         assert_eq!(commit_infos.len(), 1);
-        let tags = &commit_infos[0]["tags"];
-        assert_eq!(tags["connectorTag"], "connectorValue");
-        assert!(tags["nullableConnectorTag"].is_null());
-        assert_eq!(tags[ROW_TRACKING_PRESERVED_TAG], "true");
+        let committed_commit_info = &commit_infos[0];
+        assert_eq!(
+            committed_commit_info["tags"][ROW_TRACKING_PRESERVED_TAG],
+            "true"
+        );
+        match test_case {
+            ConnectorCommitInfoTestCase::WithTags => {
+                assert_eq!(
+                    committed_commit_info["tags"]["connectorTag"],
+                    "connectorValue"
+                );
+                assert!(committed_commit_info["tags"]["nullableConnectorTag"].is_null());
+            }
+            ConnectorCommitInfoTestCase::WithoutTags => {
+                assert_eq!(committed_commit_info["customApp"], "connector");
+            }
+            ConnectorCommitInfoTestCase::NullTags => {}
+        }
         Ok(())
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum ConnectorCommitInfoTestCase {
+        WithTags,
+        WithoutTags,
+        NullTags,
+    }
+
+    impl ConnectorCommitInfoTestCase {
+        /// Returns `(connector_commit_info, connector_commit_info_schema)` for this case.
+        fn connector_commit_info(
+            self,
+        ) -> Result<(RecordBatch, SchemaRef), Box<dyn std::error::Error>> {
+            match self {
+                Self::WithTags => {
+                    let mut tags =
+                        MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+                    tags.keys().append_value("connectorTag");
+                    tags.values().append_value("connectorValue");
+                    tags.keys().append_value("nullableConnectorTag");
+                    tags.values().append_null();
+                    tags.keys().append_value(ROW_TRACKING_PRESERVED_TAG);
+                    tags.values().append_value("false");
+                    tags.append(true)?;
+                    Ok((
+                        RecordBatch::try_from_iter([(
+                            "tags",
+                            Arc::new(tags.finish()) as ArrayRef,
+                        )])?,
+                        schema_ref! { nullable "tags": { STRING => nullable STRING } },
+                    ))
+                }
+                Self::WithoutTags => Ok((
+                    RecordBatch::try_from_iter([(
+                        "customApp",
+                        Arc::new(StringArray::from(vec!["connector"])) as ArrayRef,
+                    )])?,
+                    schema_ref! { nullable "customApp": STRING },
+                )),
+                Self::NullTags => {
+                    let mut tags =
+                        MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+                    tags.append(false)?;
+                    Ok((
+                        RecordBatch::try_from_iter([(
+                            "tags",
+                            Arc::new(tags.finish()) as ArrayRef,
+                        )])?,
+                        schema_ref! { nullable "tags": { STRING => nullable STRING } },
+                    ))
+                }
+            }
+        }
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3268/files) to review incremental changes.
- [stack/read-stable-ver](https://github.com/delta-io/delta-kernel-rs/pull/3224) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3224/files)] [MERGED]
  - [stack/builder-ctx](https://github.com/delta-io/delta-kernel-rs/pull/3226) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3226/files)] [MERGED]
    - [stack/rc-metadata-write](https://github.com/delta-io/delta-kernel-rs/pull/3229) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3229/files)] [MERGED]
      - [stack/ack-rc-preserve](https://github.com/delta-io/delta-kernel-rs/pull/3252) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3252/files)] [MERGED]
        - [**stack/emit-preserve-flag**](https://github.com/delta-io/delta-kernel-rs/pull/3268) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3268/files)] ← _this PR_

---------
## What changes are proposed in this pull request?
emit row tracking preservation tag in commitInfo


## How was this change tested?
integration tests include:
- create/alter table txns
- row tracking supported, suspended, enabled
- connector supply tags in commitInfo or not