### PR TITLE
chore: git-ignore editor backup files with names like #foo.rs#

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .cache/
 .clangd
 *.*~
+**/#*.*#
 
 # Rust
 .cargo-home


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some editors keep backups of the form `#foo.rs#` when editing `foo.rs`. Such files are never meaningful for version control, so ignore them.

## How was this change tested?

git-status ignores them now.