### PR TITLE
fix: use platform c_char in FFI test

### DIFF
--- a/ffi/src/ffi_test_utils.rs
+++ b/ffi/src/ffi_test_utils.rs
@@ -156,13 +156,7 @@ mod tests {
     fn test_ok_or_panic_with_error() {
         // Create a test error
         let message = "Test error message";
-        let error_ptr = allocate_err(
-            KernelError::GenericError,
-            KernelStringSlice {
-                ptr: message.as_ptr() as *const i8,
-                len: message.len(),
-            },
-        );
+        let error_ptr = allocate_err(KernelError::GenericError, kernel_string_slice!(message));
         let result = ExternResult::<i32>::Err(error_ptr);
 
         // Test that ok_or_panic panics with the expected message


### PR DESCRIPTION
## What changes are proposed in this pull request?

Construct the FFI test string with the platform-aware `kernel_string_slice!` helper instead of hard-coding an `i8` pointer. This allows the FFI tests to compile on targets where C `char` is unsigned, including Linux/AArch64.



Fixes #3272.

## How was this change tested?

- `cargo nextest run -p delta_kernel_ffi --lib test_ok_or_panic_with_error`
- `cargo test --locked --no-run -p delta_kernel_ffi`
- `cargo +nightly fmt --check`
- `cargo clippy --locked --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --locked --workspace --all-features --no-deps`
