### PR TITLE
feat: add void schema field visitor

### DIFF
--- a/docs/user-guide/src/ffi/overview.md
+++ b/docs/user-guide/src/ffi/overview.md
@@ -174,7 +174,8 @@ to pass to `scan_builder_with_schema`).
 
 | Function | Purpose |
 |----------|---------|
-| `visit_field_byte` / `visit_field_short` / `visit_field_integer` / `visit_field_void` / `visit_field_long` / `visit_field_float` / `visit_field_double` / `visit_field_boolean` | Build a numeric, boolean, or void primitive `StructField` |
+| `visit_field_byte` / `visit_field_short` / `visit_field_integer` / `visit_field_long` / `visit_field_float` / `visit_field_double` / `visit_field_boolean` | Build a numeric or boolean primitive `StructField` |
+| `visit_field_void` | Build a void primitive `StructField` |
 | `visit_field_string` / `visit_field_binary` / `visit_field_date` / `visit_field_timestamp` / `visit_field_timestamp_ntz` | Build a string, binary, or date/time primitive `StructField` |
 | `visit_field_decimal` | Build a decimal `StructField` with explicit precision and scale |
 | `visit_field_struct` / `visit_field_array` / `visit_field_map` / `visit_field_variant` | Build a complex `StructField` (struct, array, map, or variant) from previously created field or struct IDs |

--- a/docs/user-guide/src/ffi/overview.md
+++ b/docs/user-guide/src/ffi/overview.md
@@ -174,7 +174,7 @@ to pass to `scan_builder_with_schema`).
 
 | Function | Purpose |
 |----------|---------|
-| `visit_field_byte` / `visit_field_short` / `visit_field_integer` / `visit_field_long` / `visit_field_float` / `visit_field_double` / `visit_field_boolean` | Build a numeric or boolean primitive `StructField` |
+| `visit_field_byte` / `visit_field_short` / `visit_field_integer` / `visit_field_void` / `visit_field_long` / `visit_field_float` / `visit_field_double` / `visit_field_boolean` | Build a numeric, boolean, or void primitive `StructField` |
 | `visit_field_string` / `visit_field_binary` / `visit_field_date` / `visit_field_timestamp` / `visit_field_timestamp_ntz` | Build a string, binary, or date/time primitive `StructField` |
 | `visit_field_decimal` | Build a decimal `StructField` with explicit precision and scale |
 | `visit_field_struct` / `visit_field_array` / `visit_field_map` / `visit_field_variant` | Build a complex `StructField` (struct, array, map, or variant) from previously created field or struct IDs |

--- a/ffi/examples/read-table/CMakeLists.txt
+++ b/ffi/examples/read-table/CMakeLists.txt
@@ -27,7 +27,7 @@ add_test(NAME read_and_print_nested COMMAND ${TestRunner} ${DatPath}/nested_type
 add_test(NAME read_and_print_nested_cols COMMAND ${TestRunner} ${DatPath}/nested_types/delta/ ${ExpectedPath}/nested-types-cols.expected -cmap,struct,array)
 add_test(NAME read_and_print_basic_partitioned COMMAND ${TestRunner} ${DatPath}/basic_partitioned/delta/ ${ExpectedPath}/basic-partitioned.expected)
 add_test(NAME read_and_print_with_dv_small COMMAND ${TestRunner} ${KernelTestPath}/table-with-dv-small/ ${ExpectedPath}/table-with-dv-small.expected)
-add_test(NAME read_void_col_projection COMMAND read_table -cid,void_col ${KernelTestPath}/void-column/)
+add_test(NAME read_and_print_void_col COMMAND ${TestRunner} ${KernelTestPath}/void-column/ ${ExpectedPath}/void-column.expected -cid,void_col)
 add_test(NAME read_and_print_with_short_dv COMMAND ${TestRunner} ${KernelTestPath}/with-short-dv/ ${ExpectedPath}/with-short-dv.expected)
 # Exercises the Arrow batch-mode scan metadata path (scan_metadata_next_arrow). The arrow path
 # does not call read_parquet_file, so the data section is "[No data]"; this test still

--- a/ffi/examples/read-table/CMakeLists.txt
+++ b/ffi/examples/read-table/CMakeLists.txt
@@ -27,6 +27,7 @@ add_test(NAME read_and_print_nested COMMAND ${TestRunner} ${DatPath}/nested_type
 add_test(NAME read_and_print_nested_cols COMMAND ${TestRunner} ${DatPath}/nested_types/delta/ ${ExpectedPath}/nested-types-cols.expected -cmap,struct,array)
 add_test(NAME read_and_print_basic_partitioned COMMAND ${TestRunner} ${DatPath}/basic_partitioned/delta/ ${ExpectedPath}/basic-partitioned.expected)
 add_test(NAME read_and_print_with_dv_small COMMAND ${TestRunner} ${KernelTestPath}/table-with-dv-small/ ${ExpectedPath}/table-with-dv-small.expected)
+add_test(NAME read_void_col_projection COMMAND read_table -cid,void_col ${KernelTestPath}/void-column/)
 add_test(NAME read_and_print_with_short_dv COMMAND ${TestRunner} ${KernelTestPath}/with-short-dv/ ${ExpectedPath}/with-short-dv.expected)
 # Exercises the Arrow batch-mode scan metadata path (scan_metadata_next_arrow). The arrow path
 # does not call read_parquet_file, so the data section is "[No data]"; this test still

--- a/ffi/examples/read-table/kernel_schema_visitor.h
+++ b/ffi/examples/read-table/kernel_schema_visitor.h
@@ -14,6 +14,8 @@ uintptr_t visit_schema_item(SchemaItem* item, KernelSchemaVisitorState *state, C
   ExternResultusize visit_res;
   if (strcmp(item->type, "string") == 0) {
     visit_res = visit_field_string(state, name, item->is_nullable, allocate_error);
+  } else if (strcmp(item->type, "void") == 0) {
+    visit_res = visit_field_void(state, name, item->is_nullable, allocate_error);
   } else if (strcmp(item->type, "integer") == 0) {
     visit_res = visit_field_integer(state, name, item->is_nullable, allocate_error);
   } else if (strcmp(item->type, "short") == 0) {

--- a/ffi/src/schema_visitor.rs
+++ b/ffi/src/schema_visitor.rs
@@ -344,7 +344,7 @@ pub unsafe extern "C" fn visit_field_interval_day_time(
         .into_extern_result(&allocate_error)
 }
 
-/// Visit a void field. Void fields contain no values.
+/// Visit a void field. Void fields are not materialized in data files and read as all-null columns.
 ///
 /// # Safety
 ///

--- a/ffi/src/schema_visitor.rs
+++ b/ffi/src/schema_visitor.rs
@@ -344,6 +344,24 @@ pub unsafe extern "C" fn visit_field_interval_day_time(
         .into_extern_result(&allocate_error)
 }
 
+/// Visit a void field. Void fields contain no values.
+///
+/// # Safety
+///
+/// Caller is responsible for providing a valid `state`, `name` slice with valid UTF-8 data,
+/// and `allocate_error` function pointer.
+#[no_mangle]
+pub unsafe extern "C" fn visit_field_void(
+    state: &mut KernelSchemaVisitorState,
+    name: KernelStringSlice,
+    nullable: bool,
+    allocate_error: AllocateErrorFn,
+) -> ExternResult<usize> {
+    let name_str = unsafe { TryFromStringSlice::try_from_slice(&name) };
+    visit_field_primitive_impl(state, name_str, PrimitiveType::Void, nullable)
+        .into_extern_result(&allocate_error)
+}
+
 /// Visit a decimal field. Decimal fields store fixed-precision decimal numbers with specified
 /// precision and scale.
 ///
@@ -793,6 +811,7 @@ mod tests {
         //   col_timestamp_ntz: timestamp_ntz,
         //   col_interval_year_month: interval year to month,
         //   col_interval_day_time: interval day to second,
+        //   col_void: void,
         //   col_decimal: decimal(10,2),
         //   col_array: array<string>,
         //   col_map: map<string, long>,
@@ -819,6 +838,7 @@ mod tests {
             visit_field!(interval_year_month, state, "col_interval_year_month", false);
         let col_interval_day_time =
             visit_field!(interval_day_time, state, "col_interval_day_time", false);
+        let col_void = visit_field!(void, state, "col_void", false);
         let col_decimal = visit_field!(decimal, state, "col_decimal", 10, 2, false);
 
         // Create array<string>
@@ -865,6 +885,7 @@ mod tests {
             col_timestamp_ntz,
             col_interval_year_month,
             col_interval_day_time,
+            col_void,
             col_decimal,
             col_array,
             col_map,
@@ -885,7 +906,7 @@ mod tests {
         // Verify the schema
         let schema = extract_kernel_schema(&mut state, schema_id).unwrap();
         let fields: Vec<_> = schema.fields().collect();
-        assert_eq!(fields.len(), 19);
+        assert_eq!(fields.len(), 20);
 
         // Validate the primitive fields
         let primitive_field_expectations = [
@@ -903,6 +924,7 @@ mod tests {
             ("col_timestamp_ntz", PrimitiveType::TimestampNtz),
             ("col_interval_year_month", PrimitiveType::IntervalYearMonth),
             ("col_interval_day_time", PrimitiveType::IntervalDayTime),
+            ("col_void", PrimitiveType::Void),
         ];
 
         for (index, (expected_name, expected_type)) in
@@ -916,25 +938,25 @@ mod tests {
             assert!(!fields[index].is_nullable());
         }
 
-        assert_eq!(fields[14].name(), "col_decimal");
-        let DataType::Primitive(PrimitiveType::Decimal(decimal_type)) = fields[14].data_type()
+        assert_eq!(fields[15].name(), "col_decimal");
+        let DataType::Primitive(PrimitiveType::Decimal(decimal_type)) = fields[15].data_type()
         else {
             panic!("Field col_decimal is not a decimal type");
         };
         assert_eq!(decimal_type.precision(), 10);
         assert_eq!(decimal_type.scale(), 2);
 
-        assert_eq!(fields[15].name(), "col_array");
-        assert_array(fields[15], DataType::STRING, false);
+        assert_eq!(fields[16].name(), "col_array");
+        assert_array(fields[16], DataType::STRING, false);
 
-        assert_eq!(fields[16].name(), "col_map");
-        assert_map(fields[16], DataType::STRING, DataType::LONG, false);
+        assert_eq!(fields[17].name(), "col_map");
+        assert_map(fields[17], DataType::STRING, DataType::LONG, false);
 
-        assert_eq!(fields[17].name(), "col_struct");
-        assert_struct(fields[17], DataType::STRING, false);
+        assert_eq!(fields[18].name(), "col_struct");
+        assert_struct(fields[18], DataType::STRING, false);
 
-        assert_eq!(fields[18].name(), "col_variant");
-        let DataType::Variant(variant_type) = fields[18].data_type() else {
+        assert_eq!(fields[19].name(), "col_variant");
+        let DataType::Variant(variant_type) = fields[19].data_type() else {
             panic!("Expected variant type for col_variant");
         };
         let variant_fields: Vec<_> = variant_type.fields().collect();

--- a/ffi/tests/read-table-testing/expected-data/void-column.expected
+++ b/ffi/tests/read-table-testing/expected-data/void-column.expected
@@ -1,0 +1,13 @@
+Reading table at ../../../../kernel/tests/data/void-column/
+version: 0
+
+Schema:
+├─ id: long
+└─ void_col: void
+
+id:  [
+  1,
+  2,
+  3
+]
+void_col:  3 nulls


### PR DESCRIPTION
## What changes are proposed in this pull request?

The C FFI schema visitor could not construct a kernel schema containing a `void` field because it
had no outbound `visit_field_void` entry point. This prevented FFI-based engines from round-tripping
an existing VOID-bearing schema, including using that schema as a read projection.

This PR adds `visit_field_void`, backed by the existing primitive-field visitor implementation, so
engines can add `PrimitiveType::Void` fields through the C boundary. The read-table C example now
dispatches VOID fields as well, and its CTest projects `id,void_col` from the existing VOID fixture
and compares the generated Arrow output against a checked-in golden file.

## How was this change tested?

```bash
cargo +nightly fmt
cargo clippy -p delta_kernel_ffi --all-features -- -D warnings
cargo nextest run -p delta_kernel_ffi --all-features test_schema_all_types

cargo build -p delta_kernel_ffi --features tracing
cmake -S ffi/examples/read-table -B ffi/examples/read-table/build
cmake --build ffi/examples/read-table/build
(cd ffi/examples/read-table/build && ctest -R '^read_and_print_void_col$' --output-on-failure)
(cd ffi/examples/read-table/build && ctest --output-on-failure)
```
