### PR TITLE
ci: test workspace on ubuntu arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,7 @@ jobs:
       matrix:
         os:
           - macOS-latest
+          - ubuntu-24.04-arm
           - ubuntu-latest
           - windows-latest
     steps:
@@ -231,6 +232,7 @@ jobs:
       matrix:
         os:
           - macOS-latest
+          - ubuntu-24.04-arm
           - ubuntu-latest
           - windows-latest
         config:
@@ -305,6 +307,7 @@ jobs:
       matrix:
         os:
           - macOS-latest
+          - ubuntu-24.04-arm
           - ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add Linux/AArch64 to the same GitHub Actions matrices used for the existing Linux and macOS CI
surfaces:

- workspace build and Clippy
- workspace tests with both feature configurations
- FFI integration tests

The hosted ARM runner uses the versioned `ubuntu-24.04-arm` label (same version of Ubuntu that `ubuntu-latest` x86 points to) because GitHub does not provide an `ubuntu-latest-arm` alias.

## How was this change tested?

The added matrix legs run the existing build, Clippy, workspace test, and FFI integration commands
unchanged on GitHub-hosted Linux/AArch64 runners.
