### PR TITLE
fix: use platform c_char in FFI test

### DIFF
--- a/ffi/src/ffi_test_utils.rs
+++ b/ffi/src/ffi_test_utils.rs
@@ -156,13 +156,7 @@ mod tests {
     fn test_ok_or_panic_with_error() {
         // Create a test error
         let message = "Test error message";
-        let error_ptr = allocate_err(
-            KernelError::GenericError,
-            KernelStringSlice {
-                ptr: message.as_ptr() as *const i8,
-                len: message.len(),
-            },
-        );
+        let error_ptr = allocate_err(KernelError::GenericError, kernel_string_slice!(message));
         let result = ExternResult::<i32>::Err(error_ptr);
 
         // Test that ok_or_panic panics with the expected message

--- a/ffi/src/schema_visitor.rs
+++ b/ffi/src/schema_visitor.rs
@@ -593,27 +593,8 @@ mod tests {
 
     use super::*;
     use crate::error::{EngineError, KernelError};
-    use crate::ffi_test_utils::ok_or_panic;
+    use crate::ffi_test_utils::{allocate_err, ok_or_panic};
     use crate::KernelStringSlice;
-
-    // Error allocator for tests that panics when invoked. It is used in tests where we don't expect
-    // errors.
-    #[no_mangle]
-    extern "C" fn test_allocate_error(
-        etype: KernelError,
-        msg: crate::KernelStringSlice,
-    ) -> *mut EngineError {
-        panic!(
-            "Error allocator called with type {:?}, message: {:?}",
-            etype,
-            unsafe {
-                std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                    msg.ptr as *const u8,
-                    msg.len,
-                ))
-            }
-        );
-    }
 
     macro_rules! visit_field {
         ($type:ident, $state:ident, $name:expr, $nullable:tt) => {
@@ -622,7 +603,7 @@ mod tests {
                     &mut $state,
                     KernelStringSlice::new_unsafe($name),
                     $nullable,
-                    test_allocate_error,
+                    allocate_err,
                 )
             }) }
         };
@@ -635,7 +616,7 @@ mod tests {
                     KernelStringSlice::new_unsafe($name),
                     arg1,
                     $nullable,
-                    test_allocate_error,
+                    allocate_err,
                 )
             }) }
         };
@@ -650,7 +631,7 @@ mod tests {
                     arg1,
                     arg2,
                     $nullable,
-                    test_allocate_error,
+                    allocate_err,
                 )
             }) }
         };
@@ -665,7 +646,7 @@ mod tests {
                     KernelStringSlice::new_unsafe($name),
                     ef,
                     $nullable,
-                    test_allocate_error,
+                    allocate_err,
                 )
             })
         }};
@@ -682,7 +663,7 @@ mod tests {
                     kf,
                     vf,
                     $nullable,
-                    test_allocate_error,
+                    allocate_err,
                 )
             })
         }};
@@ -699,7 +680,7 @@ mod tests {
                     fields.as_ptr(),
                     field_count,
                     $nullable,
-                    test_allocate_error,
+                    allocate_err,
                 )
             })
         }};
@@ -878,7 +859,7 @@ mod tests {
                 all_columns.as_ptr(),
                 all_columns.len(),
                 false,
-                test_allocate_error,
+                allocate_err,
             )
         });
 
@@ -1356,10 +1337,7 @@ mod tests {
             msg: crate::KernelStringSlice,
         ) -> *mut EngineError {
             let msg = unsafe {
-                std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                    msg.ptr as *const u8,
-                    msg.len,
-                ))
+                std::str::from_utf8_unchecked(std::slice::from_raw_parts(msg.ptr.cast(), msg.len))
             };
             assert_eq!(
                 msg,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use platform-aware `c_char` pointers throughout the Rust FFI tests. This constructs test strings
with `kernel_string_slice!`, reuses the shared test error allocator instead of maintaining a
duplicate callback, and uses a pointer cast in the remaining custom error callback.

Together, these changes remove the assumption that C `char` is signed and allow the FFI tests and
Clippy to compile on targets where it is unsigned, including Linux/AArch64.

Fixes #3272.

## How was this change tested?

- `cargo +nightly fmt --check`
- `cargo clippy --locked -p delta_kernel_ffi --tests --all-features -- -D warnings`
- `cargo nextest run --locked -p delta_kernel_ffi --lib --all-features 'schema_visitor::tests'`
- `cargo nextest run -p delta_kernel_ffi --lib test_ok_or_panic_with_error`
