### PR TITLE
ci: support automatic AI review for forks (#3228)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "test-case",
  "test-log",
  "test_utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -187,6 +187,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ar_archive_writer"
@@ -667,7 +676,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -678,7 +687,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -870,7 +879,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
 ]
@@ -1024,7 +1033,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1329,6 +1338,7 @@ version = "0.28.0"
 dependencies = [
  "arrow 58.1.0",
  "arrow 59.0.0",
+ "arrow-array 58.1.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -1337,6 +1347,9 @@ dependencies = [
  "delta_kernel",
  "delta_kernel_derive",
  "futures",
+ "geo-traits",
+ "geoarrow-array",
+ "geoarrow-schema",
  "hdfs-native",
  "hdfs-native-object-store",
  "indexmap",
@@ -1361,7 +1374,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "test_utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1437,7 +1450,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rstest",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1476,7 +1489,7 @@ version = "0.28.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1547,7 +1560,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1797,7 +1810,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1844,7 +1857,7 @@ dependencies = [
  "g2poly",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1871,6 +1884,56 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geo-traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
+dependencies = [
+ "geo-types",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777d18aa0f12f8b285331cd867133ee14422b3f023f6d388034c47d43e28786a"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "geoarrow-array"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dafe7b7de3fab1a8b7099fd6a6434ca955fa65065f9c19f0f8a133693f3c2b0e"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
+ "geo-traits",
+ "geoarrow-schema",
+ "num-traits",
+ "wkb",
+ "wkt",
+]
+
+[[package]]
+name = "geoarrow-schema"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4a7edb2a1d87024a93805332a9c8184a0354836271d42c0d18cf628a5e3cd0"
+dependencies = [
+ "arrow-schema 58.1.0",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2012,7 +2075,7 @@ dependencies = [
  "regex",
  "roxmltree",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "url",
  "uuid",
@@ -2032,7 +2095,7 @@ dependencies = [
  "futures",
  "hdfs-native",
  "object_store 0.13.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -2447,7 +2510,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2802,6 +2865,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,7 +2922,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -2877,7 +2962,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -2926,7 +3011,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3197,7 +3282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3254,7 +3339,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -3268,7 +3353,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3281,7 +3366,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3410,7 +3495,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -3432,7 +3517,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3622,7 +3707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3823,7 +3908,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -3835,7 +3920,7 @@ checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
  "rand 0.8.5",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4052,7 +4137,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4237,7 +4322,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4249,7 +4334,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4263,6 +4348,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4286,7 +4382,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4367,7 +4463,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4378,7 +4474,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "test-case-core",
 ]
 
@@ -4400,7 +4496,7 @@ checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4434,11 +4530,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4449,18 +4545,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4558,7 +4654,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4734,7 +4830,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4846,7 +4942,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -4858,7 +4954,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "unity-catalog-delta-client-api",
@@ -5057,7 +5153,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5196,7 +5292,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5207,7 +5303,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5544,7 +5640,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5560,7 +5656,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5600,6 +5696,31 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wkb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a120b336c7ad17749026d50427c23d838ecb50cd64aaea6254b5030152f890a9"
+dependencies = [
+ "byteorder",
+ "geo-traits",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wkt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5654,7 +5775,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5681,7 +5802,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5701,7 +5822,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5741,7 +5862,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -588,6 +588,8 @@ fn visit_expression_scalar(
             buf.as_ptr(),
             buf.len()
         ),
+        #[cfg(feature = "geo-type-in-dev")]
+        Scalar::Geometry(_) => visit_unknown(visitor, sibling_list_id, "geometry_literal"),
         Scalar::Decimal(v) => {
             call!(
                 visitor,
@@ -771,7 +773,11 @@ fn visit_predicate_internal(predicate: &Predicate, visitor: &mut EngineExpressio
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "geo-type-in-dev")]
+    use delta_kernel::expressions::GeometryData;
     use delta_kernel::expressions::{lit, Expression, Scalar};
+    #[cfg(feature = "geo-type-in-dev")]
+    use delta_kernel::schema::GeometryType;
     use rstest::rstest;
 
     use super::*;
@@ -790,6 +796,10 @@ mod tests {
         Column {
             sibling_list_id: usize,
             parts: Vec<String>,
+        },
+        Unknown {
+            sibling_list_id: usize,
+            name: String,
         },
     }
 
@@ -844,6 +854,19 @@ mod tests {
         builder.events.push(LiteralEvent::Column {
             sibling_list_id,
             parts,
+        });
+    }
+
+    extern "C" fn visit_unknown(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+    ) {
+        let builder = unsafe { &mut *(data as *mut TestExpressionBuilder) };
+        let name = unsafe { String::try_from_slice(&name).unwrap() };
+        builder.events.push(LiteralEvent::Unknown {
+            sibling_list_id,
+            name,
         });
     }
 
@@ -925,7 +948,7 @@ mod tests {
             visit_field_patch: ignore_field_patch,
             visit_opaque_expr: ignore_opaque_expr,
             visit_opaque_pred: ignore_opaque_pred,
-            visit_unknown: ignore_string_slice,
+            visit_unknown,
         }
     }
 
@@ -991,5 +1014,33 @@ mod tests {
 
         assert_eq!(top_level_id, 0);
         assert_eq!(builder.events, vec![expected]);
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn visit_expression_geometry_literal_is_reported_as_unknown() {
+        let mut builder = TestExpressionBuilder::default();
+        let mut visitor = test_visitor(&mut builder);
+        let geometry = GeometryData::try_new(
+            GeometryType::try_new("EPSG:4326").unwrap(),
+            vec![
+                1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+        )
+        .unwrap();
+
+        let top_level_id = visit_expression_internal(
+            &Expression::Literal(Scalar::Geometry(geometry)),
+            &mut visitor,
+        );
+
+        assert_eq!(top_level_id, 0);
+        assert_eq!(
+            builder.events,
+            vec![LiteralEvent::Unknown {
+                sibling_list_id: 0,
+                name: "geometry_literal".to_string(),
+            }]
+        );
     }
 }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -58,6 +58,10 @@ tracing-subscriber = "0.3"
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1.18.0", features = ["v4", "fast-rng"] }
 z85 = "3.0.6"
+geoarrow-array = { version = "0.8.0", optional = true }
+geoarrow-schema = { version = "0.8.0", optional = true }
+geo-traits = { version = "0.3.0", optional = true }
+geoarrow_arrow_array_58 = { package = "arrow-array", version = "58", optional = true }
 
 # optional deps
 # `reqwest` is only needed for the gated `Error::Reqwest` variant; the actual HTTP client
@@ -131,7 +135,12 @@ check-constraints-in-dev = []
 adaptive-metadata-in-dev = []
 # Experimental, temporary, test-only feature flag guarding the in-progress geospatial
 # (geometry/geography) type work. TODO(#2949): remove once full geo support ships.
-geo-type-in-dev = []
+geo-type-in-dev = [
+  "dep:geoarrow-array",
+  "dep:geoarrow-schema",
+  "dep:geo-traits",
+  "dep:geoarrow_arrow_array_58",
+]
 
 # Enables shared Arrow-based engine support modules (arrow_data, arrow_expression,
 # ensure_data_types, parquet_row_group_skipping). Used by the delta_kernel_default_engine crate

--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -68,6 +68,11 @@ message DecimalData {
   delta.kernel.schema.DecimalType decimal_type = 2;
 }
 
+message GeometryData {
+  delta.kernel.schema.GeometryType geometry_type = 1;
+  bytes wkb = 2;
+}
+
 message ArrayData {
   delta.kernel.schema.ArrayType array_type = 1;
   repeated Scalar elements = 2;
@@ -112,6 +117,7 @@ message Scalar {
     MapData map = 17;
     int32 interval_year_month = 18; // year-month interval: signed month count
     int64 interval_day_time = 19;   // day-time interval: signed microsecond count
+    GeometryData geometry = 20;
   }
 }
 

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -372,11 +372,11 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                     PrimitiveType::IntervalYearMonth => Ok(ArrowDataType::Int32),
                     PrimitiveType::IntervalDayTime => Ok(ArrowDataType::Int64),
                     #[cfg(feature = "geo-type-in-dev")]
-                    PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
-                        Err(ArrowError::SchemaError(format!(
-                            "Geo types are not yet supported in the default engine: {p}"
-                        )))
-                    }
+                    PrimitiveType::Geometry(_) => Ok(ArrowDataType::Binary),
+                    #[cfg(feature = "geo-type-in-dev")]
+                    PrimitiveType::Geography(_) => Err(ArrowError::SchemaError(format!(
+                        "Geo types are not yet supported in the default engine: {p}"
+                    ))),
                 }
             }
             DataType::Struct(s) => Ok(ArrowDataType::Struct(
@@ -681,12 +681,7 @@ mod tests {
 
     #[cfg(feature = "geo-type-in-dev")]
     #[rstest]
-    #[case(geometry_type("EPSG:4326"))]
     #[case(geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical))]
-    #[case(DataType::from(schema! {
-        nullable "g": (geometry_type("EPSG:4326")),
-    }))]
-    #[case(DataType::from(ArrayType::new(geometry_type("EPSG:4326"), true)))]
     #[case(DataType::from(MapType::new(
         DataType::STRING,
         geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical),
@@ -696,6 +691,21 @@ mod tests {
         let result: Result<ArrowDataType, _> = (&dt).try_into_arrow();
         let err = result.unwrap_err();
         assert!(matches!(err, ArrowError::SchemaError(_)), "got: {err:?}");
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[rstest]
+    #[case(geometry_type("EPSG:4326"))]
+    #[case(DataType::from(schema! {
+        nullable "g": (geometry_type("EPSG:4326")),
+    }))]
+    #[case(DataType::from(ArrayType::new(geometry_type("EPSG:4326"), true)))]
+    fn test_geometry_type_arrow_conversion_supported(#[case] dt: DataType) {
+        let result: Result<ArrowDataType, _> = (&dt).try_into_arrow();
+        assert!(
+            result.is_ok(),
+            "expected Geometry to convert, got {result:?}"
+        );
     }
 
     #[test]

--- a/kernel/src/engine/arrow_conversion/scalar.rs
+++ b/kernel/src/engine/arrow_conversion/scalar.rs
@@ -20,6 +20,8 @@ use crate::arrow::array::types::{
 };
 use crate::arrow::array::Array;
 use crate::arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
+#[cfg(feature = "geo-type-in-dev")]
+use crate::expressions::GeometryData;
 use crate::expressions::Scalar;
 use crate::schema::DataType;
 use crate::{DeltaResult, Error};
@@ -119,6 +121,50 @@ pub fn extract_primitive_scalar(array: &dyn Array, row_idx: usize) -> DeltaResul
             "unsupported Arrow type for primitive scalar extraction: {other:?}"
         ))),
     }
+}
+
+/// Extracts a kernel [`Scalar`] from the given row of an Arrow array using the caller-provided
+/// logical `data_type`.
+///
+/// This supports logical geo types backed by Arrow `Binary`/`LargeBinary`, which cannot be
+/// inferred from the physical Arrow type alone.
+///
+/// # Errors
+///
+/// Returns the same errors as [`extract_primitive_scalar`], plus an error if the physical Arrow
+/// value is incompatible with `data_type`.
+pub fn extract_scalar(
+    array: &dyn Array,
+    row_idx: usize,
+    data_type: &DataType,
+) -> DeltaResult<Scalar> {
+    #[cfg(feature = "geo-type-in-dev")]
+    if let DataType::Primitive(crate::schema::PrimitiveType::Geometry(geometry_type)) = data_type {
+        if row_idx >= array.len() {
+            return Err(Error::generic(format!(
+                "row index {row_idx} out of bounds for array of length {}",
+                array.len()
+            )));
+        }
+        if array.is_null(row_idx) {
+            return Ok(Scalar::Null(data_type.clone()));
+        }
+        let bytes = match array.data_type() {
+            ArrowDataType::Binary => array.as_binary::<i32>().value(row_idx).to_vec(),
+            ArrowDataType::LargeBinary => array.as_binary::<i64>().value(row_idx).to_vec(),
+            ArrowDataType::BinaryView => array.as_binary_view().value(row_idx).to_vec(),
+            other => {
+                return Err(Error::generic(format!(
+                    "unsupported Arrow type for geometry scalar extraction: {other:?}"
+                )))
+            }
+        };
+        return Ok(Scalar::Geometry(GeometryData::try_new(
+            geometry_type.as_ref().clone(),
+            bytes,
+        )?));
+    }
+    extract_primitive_scalar(array, row_idx)
 }
 
 /// Maps an Arrow data type to a kernel [`DataType`] for primitive types only.
@@ -596,5 +642,34 @@ mod tests {
             Scalar::Double(v) => assert!(v.is_nan(), "expected NaN double"),
             other => panic!("expected float/double NaN, got {other:?}"),
         }
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn test_extract_scalar_geometry_returns_typed_geometry() {
+        let geometry_type = crate::schema::GeometryType::try_new("EPSG:4326").unwrap();
+        let bytes = vec![
+            1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let array = Arc::new(BinaryArray::from_vec(vec![bytes.as_slice()])) as ArrayRef;
+
+        let scalar =
+            extract_scalar(array.as_ref(), 0, &DataType::from(geometry_type.clone())).unwrap();
+        assert_eq!(
+            scalar,
+            Scalar::Geometry(GeometryData::try_new(geometry_type, bytes).unwrap())
+        );
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn test_extract_scalar_geometry_null_returns_typed_null() {
+        let geometry_type = crate::schema::GeometryType::try_new("EPSG:4326").unwrap();
+        let array = new_null_array(&ArrowDataType::Binary, 1);
+
+        assert_eq!(
+            extract_scalar(array.as_ref(), 0, &DataType::from(geometry_type.clone())).unwrap(),
+            Scalar::Null(DataType::from(geometry_type))
+        );
     }
 }

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -104,6 +104,8 @@ impl Scalar {
             IntervalDayTime(val) => append_val_n_as!(array::Int64Builder, *val),
             Date(val) => append_val_n_as!(array::Date32Builder, *val),
             Binary(val) => append_val_as!(array::BinaryBuilder, val),
+            #[cfg(feature = "geo-type-in-dev")]
+            Geometry(geometry) => append_val_as!(array::BinaryBuilder, geometry.bytes()),
             // precision and scale were already set at builder construction time
             Decimal(val) => append_val_n_as!(array::Decimal128Builder, val.bits()),
             Struct(data) => {
@@ -220,8 +222,14 @@ impl Scalar {
             DataType::INTERVAL_YEAR_MONTH => append_nulls_as!(array::Int32Builder),
             DataType::INTERVAL_DAY_TIME => append_nulls_as!(array::Int64Builder),
             #[cfg(feature = "geo-type-in-dev")]
-            DataType::Primitive(PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)) => {
-                return Err(Error::unsupported("Geo is not supported as scalar yet."));
+            DataType::Primitive(PrimitiveType::Geometry(_)) => {
+                append_nulls_as!(array::BinaryBuilder)
+            }
+            #[cfg(feature = "geo-type-in-dev")]
+            DataType::Primitive(PrimitiveType::Geography(_)) => {
+                return Err(Error::unsupported(
+                    "Geography is not supported as scalar yet.",
+                ));
             }
         }
         Ok(())

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -6,9 +6,9 @@ use Predicate as Pred;
 
 use super::*;
 use crate::arrow::array::{
-    create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, GenericStringArray, Int32Array,
-    Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder, MapFieldNames, StringArray,
-    StringBuilder, StringViewArray, StructArray,
+    create_array, Array, ArrayRef, AsArray as _, BinaryViewArray, BooleanArray, GenericStringArray,
+    Int32Array, Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder, MapFieldNames,
+    StringArray, StringBuilder, StringViewArray, StructArray,
 };
 use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
@@ -20,6 +20,8 @@ use crate::engine::arrow_expression::opaque::{
     ArrowOpaquePredicateOp,
 };
 use crate::engine::arrow_utils::apply_schema::apply_schema;
+#[cfg(feature = "geo-type-in-dev")]
+use crate::expressions::GeometryData;
 use crate::expressions::*;
 use crate::kernel_predicates::{
     DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
@@ -248,6 +250,21 @@ fn test_literal_type_array() {
     let result = evaluate_predicate(&not_in_op, &batch, true).unwrap();
     let in_expected = BooleanArray::from(vec![false]);
     assert_eq!(result, in_expected);
+}
+
+#[cfg(feature = "geo-type-in-dev")]
+#[test]
+fn test_geometry_scalar_to_array_uses_binary_storage() {
+    let geometry_type = crate::schema::GeometryType::try_new("EPSG:4326").unwrap();
+    let bytes = vec![
+        1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+    let scalar = Scalar::Geometry(GeometryData::try_new(geometry_type, bytes.clone()).unwrap());
+
+    let array = scalar.to_array(2).unwrap();
+    let binary = array.as_binary::<i32>();
+    assert_eq!(binary.value(0), bytes.as_slice());
+    assert_eq!(binary.value(1), bytes.as_slice());
 }
 
 #[test]
@@ -1474,10 +1491,17 @@ fn test_interval_scalar_to_array(#[case] scalar: Scalar, #[case] arrow_type: Dat
 }
 
 #[cfg(feature = "geo-type-in-dev")]
-#[rstest]
-#[case(geometry_type("EPSG:4326"))]
-#[case(geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical))]
-fn test_geo_append_null_unsupported(#[case] dt: KernelDataType) {
+#[test]
+fn test_geometry_append_null_uses_binary_storage() {
+    let mut builder: Box<dyn crate::arrow::array::ArrayBuilder> =
+        Box::new(crate::arrow::array::BinaryBuilder::new());
+    Scalar::append_null(builder.as_mut(), &geometry_type("EPSG:4326"), 1).unwrap();
+}
+
+#[cfg(feature = "geo-type-in-dev")]
+#[test]
+fn test_geography_append_null_unsupported() {
+    let dt = geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical);
     let mut builder: Box<dyn crate::arrow::array::ArrayBuilder> =
         Box::new(crate::arrow::array::BinaryBuilder::new());
     let err = Scalar::append_null(builder.as_mut(), &dt, 1).unwrap_err();

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -13,6 +13,8 @@ pub use self::column_names::{
     col, column_expr_ref, column_name, column_pred, joined_column_expr, joined_column_name,
     ColumnName,
 };
+#[cfg(feature = "geo-type-in-dev")]
+pub use self::scalars::GeometryData;
 pub use self::scalars::{ArrayData, DecimalData, MapData, Scalar, StructData};
 use crate::kernel_predicates::{
     DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -11,6 +11,8 @@ use strum::AsRefStr;
 
 use crate::error::add_scalar_path_context;
 use crate::schema::derive_macro_utils::{GetStructField, ToDataType};
+#[cfg(feature = "geo-type-in-dev")]
+use crate::schema::GeometryType;
 use crate::schema::{
     parse_interval_type, ArrayType, DataType, DecimalType, IntervalField, IntervalFieldRange,
     MapType, PrimitiveType, StructField, StructType,
@@ -61,6 +63,44 @@ impl DecimalData {
 
     pub fn scale(&self) -> u8 {
         self.ty.scale()
+    }
+}
+
+/// Canonical geometry scalar data backed by WKB bytes and its logical geometry type.
+#[cfg(feature = "geo-type-in-dev")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GeometryData {
+    ty: GeometryType,
+    bytes: Vec<u8>,
+}
+
+#[cfg(feature = "geo-type-in-dev")]
+impl GeometryData {
+    /// Creates a geometry scalar from logical type metadata and WKB bytes.
+    ///
+    /// The input bytes are normalized to canonical WKB before storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` are not valid WKB for a geometry value.
+    pub fn try_new(ty: GeometryType, bytes: impl Into<Vec<u8>>) -> DeltaResult<Self> {
+        let bytes = crate::geometry::normalize_geometry_wkb(&ty, &bytes.into())?;
+        Ok(Self { ty, bytes })
+    }
+
+    /// Returns the logical geometry type metadata carried by this value.
+    pub fn ty(&self) -> &GeometryType {
+        &self.ty
+    }
+
+    /// Returns the canonical WKB payload for this geometry value.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Consumes this geometry and returns its canonical WKB bytes.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
     }
 }
 
@@ -349,6 +389,9 @@ pub enum Scalar {
     Date(i32),
     /// Binary data
     Binary(Vec<u8>),
+    /// Geometry value encoded as canonical WKB plus its logical geometry type.
+    #[cfg(feature = "geo-type-in-dev")]
+    Geometry(GeometryData),
     /// Decimal value with a given precision and scale.
     Decimal(DecimalData),
     /// Null value with a given data type.
@@ -378,6 +421,8 @@ impl Scalar {
             Self::IntervalDayTime(_) => DataType::INTERVAL_DAY_TIME,
             Self::Date(_) => DataType::DATE,
             Self::Binary(_) => DataType::BINARY,
+            #[cfg(feature = "geo-type-in-dev")]
+            Self::Geometry(geometry) => DataType::from(geometry.ty().clone()),
             Self::Decimal(d) => DataType::from(*d.ty()),
             Self::Null(data_type) => data_type.clone(),
             Self::Struct(data) => DataType::struct_type_unchecked(data.fields.clone()),
@@ -497,6 +542,8 @@ impl Display for Scalar {
             Self::IntervalDayTime(micros) => write!(f, "{micros}"),
             Self::Date(d) => write!(f, "{d}"),
             Self::Binary(b) => write!(f, "{b:?}"),
+            #[cfg(feature = "geo-type-in-dev")]
+            Self::Geometry(geometry) => write!(f, "{} {:?}", geometry.ty(), geometry.bytes()),
             Self::Decimal(d) => match d.scale().cmp(&0) {
                 Ordering::Equal => {
                     write!(f, "{}", d.bits())
@@ -620,6 +667,10 @@ impl Scalar {
             (Date(_), _) => None,
             (Binary(a), Binary(b)) => a.partial_cmp(b),
             (Binary(_), _) => None,
+            #[cfg(feature = "geo-type-in-dev")]
+            (Geometry(_), Geometry(_)) => None,
+            #[cfg(feature = "geo-type-in-dev")]
+            (Geometry(_), _) => None,
             (Decimal(d1), Decimal(d2)) => (d1.ty() == d2.ty())
                 .then(|| d1.bits().partial_cmp(&d2.bits()))
                 .flatten(),
@@ -714,6 +765,13 @@ impl From<Vec<u8>> for Scalar {
 impl From<bytes::Bytes> for Scalar {
     fn from(b: bytes::Bytes) -> Self {
         Self::Binary(b.into())
+    }
+}
+
+#[cfg(feature = "geo-type-in-dev")]
+impl From<GeometryData> for Scalar {
+    fn from(geometry: GeometryData) -> Self {
+        Self::Geometry(geometry)
     }
 }
 
@@ -1282,6 +1340,8 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    #[cfg(feature = "geo-type-in-dev")]
+    use crate::expressions::GeometryData;
     use crate::expressions::{col, lit, BinaryPredicateOp};
     use crate::schema::{schema, ToSchema as _};
     use crate::table_features::TableFeature;
@@ -1863,6 +1923,28 @@ mod tests {
         } else {
             panic!("Expected Binary scalar");
         }
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn test_geometry_data_round_trips_and_geometry_scalars_are_unordered() {
+        let geometry_type = crate::schema::GeometryType::try_new("EPSG:4326").unwrap();
+        let bytes = vec![
+            1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let geometry = GeometryData::try_new(geometry_type.clone(), bytes.clone()).unwrap();
+
+        assert_eq!(geometry.ty(), &geometry_type);
+        assert_eq!(geometry.bytes(), bytes.as_slice());
+        assert_eq!(geometry.clone().into_bytes(), bytes);
+
+        let scalar = Scalar::Geometry(geometry.clone());
+        assert_eq!(scalar.data_type(), DataType::from(geometry_type));
+        assert_eq!(
+            scalar.logical_partial_cmp(&Scalar::Geometry(geometry)),
+            None,
+            "geometry scalars should not participate in ordered scalar comparisons"
+        );
     }
 
     const INTERVAL_YM_LITERAL: &str = "INTERVAL '1-0' YEAR TO MONTH";

--- a/kernel/src/geometry.rs
+++ b/kernel/src/geometry.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use geoarrow_array::array::WkbArray;
+use geoarrow_array::cast::{from_wkb, to_wkb};
+use geoarrow_arrow_array_58::BinaryArray as GeoBinaryArray;
+use geoarrow_schema::{
+    GeoArrowType, GeometryType as GeoArrowGeometryType, Metadata as GeoArrowMetadata,
+};
+
+use crate::schema::GeometryType;
+use crate::{DeltaResult, Error};
+
+pub(crate) fn normalize_geometry_wkb(_ty: &GeometryType, bytes: &[u8]) -> DeltaResult<Vec<u8>> {
+    let geometry = parse_wkb_geometry(bytes)?;
+    let wkb = to_wkb::<i32>(geometry.as_ref()).map_err(geoarrow_error)?;
+    Ok(wkb.inner().value(0).to_vec())
+}
+
+fn parse_wkb_geometry(bytes: &[u8]) -> DeltaResult<Arc<dyn geoarrow_array::GeoArrowArray>> {
+    let binary = GeoBinaryArray::from(vec![Some(bytes)]);
+    let wkb = WkbArray::new(binary, Arc::new(GeoArrowMetadata::default()));
+    let geometry_type = GeoArrowGeometryType::new(Arc::new(GeoArrowMetadata::default()));
+    from_wkb(&wkb, GeoArrowType::Geometry(geometry_type)).map_err(geoarrow_error)
+}
+
+fn geoarrow_error(err: impl std::fmt::Display) -> Error {
+    Error::generic(format!("Invalid geometry value: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn zero_point_wkb() -> Vec<u8> {
+        vec![
+            1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]
+    }
+
+    #[test]
+    fn normalize_geometry_wkb_round_trips_point() {
+        let ty = GeometryType::try_new("EPSG:4326").unwrap();
+        let bytes = zero_point_wkb();
+        assert_eq!(normalize_geometry_wkb(&ty, &bytes).unwrap(), bytes);
+    }
+
+    #[test]
+    fn normalize_geometry_wkb_rejects_invalid_bytes() {
+        let ty = GeometryType::try_new("EPSG:4326").unwrap();
+        let err = normalize_geometry_wkb(&ty, &[0x01, 0x02, 0x03]).unwrap_err();
+        assert!(err.to_string().contains("Invalid geometry value"));
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -98,6 +98,8 @@ pub(crate) mod crc;
 pub mod engine_data;
 pub mod error;
 pub mod expressions;
+#[cfg(feature = "geo-type-in-dev")]
+pub(crate) mod geometry;
 pub mod incremental_scan;
 mod log_compaction;
 mod log_path;

--- a/kernel/src/partition/serialization.rs
+++ b/kernel/src/partition/serialization.rs
@@ -97,6 +97,14 @@ pub fn serialize_partition_value(value: &Scalar) -> DeltaResult<Option<String>> 
         Scalar::Decimal(d) => Ok(Some(format_decimal(d))),
         Scalar::Binary(b) if b.is_empty() => Ok(None),
         Scalar::Binary(b) => Ok(Some(format_binary(b)?)),
+        #[cfg(feature = "geo-type-in-dev")]
+        Scalar::Geometry(_) | Scalar::Struct(_) | Scalar::Array(_) | Scalar::Map(_) => {
+            Err(Error::generic(format!(
+                "cannot serialize partition value: type {:?} is not a valid partition column type",
+                value.data_type()
+            )))
+        }
+        #[cfg(not(feature = "geo-type-in-dev"))]
         Scalar::Struct(_) | Scalar::Array(_) | Scalar::Map(_) => Err(Error::generic(format!(
             "cannot serialize partition value: type {:?} is not a valid partition column type",
             value.data_type()
@@ -247,7 +255,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::expressions::{ArrayData, MapData, Scalar, StructData};
+    use crate::expressions::{ArrayData, GeometryData, MapData, Scalar, StructData};
     use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, StructField};
 
     // ============================================================================
@@ -638,5 +646,19 @@ mod tests {
         )
         .unwrap();
         assert!(serialize_partition_value(&Scalar::Map(data)).is_err());
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn test_non_null_geometry_returns_error() {
+        let geometry_type = crate::schema::GeometryType::try_new("EPSG:4326").unwrap();
+        let geometry = GeometryData::try_new(
+            geometry_type,
+            vec![
+                1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+        )
+        .unwrap();
+        assert!(serialize_partition_value(&Scalar::Geometry(geometry)).is_err());
     }
 }

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -10,6 +10,8 @@ use super::schema::SimplePrimitiveType as Simple;
 use super::{
     expressions as proto_expr, operation as proto_op, plan as proto_plan, schema as proto_schema,
 };
+#[cfg(feature = "geo-type-in-dev")]
+use crate::expressions::GeometryData;
 use crate::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
     ColumnName, DecimalData, Expression, ExpressionFieldPatch, ExpressionStructPatch,
@@ -551,6 +553,8 @@ impl From<&Scalar> for proto_expr::Scalar {
             Scalar::IntervalDayTime(v) => Value::IntervalDayTime(*v),
             Scalar::Date(v) => Value::Date(*v),
             Scalar::Binary(v) => Value::Binary(v.clone()),
+            #[cfg(feature = "geo-type-in-dev")]
+            Scalar::Geometry(geometry) => Value::Geometry(geometry.into()),
             Scalar::Decimal(decimal) => Value::Decimal(decimal.into()),
             Scalar::Null(data_type) => Value::Null(data_type.into()),
             Scalar::Struct(struct_data) => Value::Struct(struct_data.into()),
@@ -566,6 +570,16 @@ impl From<&DecimalData> for proto_expr::DecimalData {
         proto_expr::DecimalData {
             bits: decimal.bits().to_be_bytes().to_vec(),
             decimal_type: Some((*decimal.ty()).into()),
+        }
+    }
+}
+
+#[cfg(feature = "geo-type-in-dev")]
+impl From<&GeometryData> for proto_expr::GeometryData {
+    fn from(geometry: &GeometryData) -> Self {
+        proto_expr::GeometryData {
+            geometry_type: Some(geometry.ty().into()),
+            wkb: geometry.bytes().to_vec(),
         }
     }
 }
@@ -975,6 +989,8 @@ mod tests {
     #[cfg(feature = "geo-type-in-dev")]
     use super::EdgeAlgo;
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
+    #[cfg(feature = "geo-type-in-dev")]
+    use crate::expressions::GeometryData;
     use crate::expressions::{
         col, column_name, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp, ColumnName,
         DecimalData, Expression, ExpressionStructPatchBuilder, JunctionPredicateOp, MapData,
@@ -1886,6 +1902,20 @@ mod tests {
     #[case(Scalar::TimestampNtz(9), "timestamp_ntz")]
     #[case(Scalar::Date(9), "date")]
     #[case(Scalar::Binary(vec![1, 2, 3]), "binary")]
+    #[cfg(feature = "geo-type-in-dev")]
+    #[case(
+        Scalar::Geometry(
+            GeometryData::try_new(
+                GeometryType::try_new("EPSG:4326").unwrap(),
+                vec![
+                    1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0,
+                ],
+            )
+            .unwrap(),
+        ),
+        "geometry"
+    )]
     #[case(
         Scalar::Decimal(
             DecimalData::try_new(1234i128, DecimalType::try_new(10, 2).unwrap()).unwrap(),
@@ -1933,6 +1963,8 @@ mod tests {
             Value::IntervalDayTime(_) => "interval_day_time",
             Value::Date(_) => "date",
             Value::Binary(_) => "binary",
+            #[cfg(feature = "geo-type-in-dev")]
+            Value::Geometry(_) => "geometry",
             Value::Decimal(_) => "decimal",
             Value::Null(_) => "null",
             Value::Struct(_) => "struct",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3280/files) to review incremental changes.
- [**stack/geometry-data-scalar**](https://github.com/delta-io/delta-kernel-rs/pull/3280) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3280/files)] ← _this PR_
  - [stack/geometry-stats-json](https://github.com/delta-io/delta-kernel-rs/pull/3281) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3281/files/cf9b7bf49a29f8e1da67f55cb24682ccfb2a0278..411b87f41907c3b3a00e5614cbc30436ab3f370c)]
    - [stack/geometry-data-skipping](https://github.com/delta-io/delta-kernel-rs/pull/3282) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3282/files/411b87f41907c3b3a00e5614cbc30436ab3f370c..e4db8e4225bb180a51864643da3df5a6e51e748c)]

---------
## What changes are proposed in this pull request?

## What changes are proposed in this pull request?

Automatic AI reviews currently fail for fork PRs because
`actions/checkout` refuses to fetch a
fork head SHA during `pull_request_target`. Resolve the head repository
from the SHA-bound PR
metadata and materialize GitHub's generated tarball for that exact SHA
as untrusted, read-only
review context. The workflow never executes files from the archive.

This is experimental infrastructure for the initial AI review rollout.
The workflow remains
non-blocking while its automatic trigger and publication behavior are
being validated.

## How was this change tested?

- Parsed the workflow YAML and ran `bash -n` on all embedded shell
steps.
- Downloaded and extracted PR #2330 at its exact fork head SHA; verified
the expected source tree
  and no `.git` directory.
- Ran the repository pre-commit checks: rustfmt, clippy, tests, and
coverage.

GitHub cannot dispatch a workflow from a fork-only ref. After merge,
retrigger PR #2330 to validate
the automatic `pull_request_target` path end to end.

## How was this change tested?
