### PR TITLE
fix: harden the release workflow

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -67,3 +67,10 @@ env:
 run: |
     echo "Comment: $COMMENT_BODY"
 ```
+
+## Release tooling checks
+
+The `release-tooling` job in `build.yml` fetches full history and tags because it verifies the
+pending release changelog against every PR since the previous Kernel release. Keep `fetch-depth: 0`
+on that checkout. The job must run on every pull request so a release PR is rechecked whenever its
+base branch advances; do not add a path-based workflow filter.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -73,5 +73,5 @@ run: |
 The `release-tooling` job in `build.yml` fetches full history and tags because release branches
 verify the pending changelog against every PR since the previous Kernel release. Keep
 `fetch-depth: 0` on that checkout. The regression tests run on every pull request, while live
-verification is restricted to branches whose names start with `release`; otherwise the window
+verification is restricted to branches whose names start with `release/`; otherwise the window
 between merging a release PR and pushing its tag could block unrelated pull requests.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -70,7 +70,8 @@ run: |
 
 ## Release tooling checks
 
-The `release-tooling` job in `build.yml` fetches full history and tags because it verifies the
-pending release changelog against every PR since the previous Kernel release. Keep `fetch-depth: 0`
-on that checkout. The job must run on every pull request so a release PR is rechecked whenever its
-base branch advances; do not add a path-based workflow filter.
+The `release-tooling` job in `build.yml` fetches full history and tags because release branches
+verify the pending changelog against every PR since the previous Kernel release. Keep
+`fetch-depth: 0` on that checkout. The regression tests run on every pull request, while live
+verification is restricted to branches whose names start with `release`; otherwise the window
+between merging a release PR and pushing its tag could block unrelated pull requests.

--- a/.github/scripts/test-release.sh
+++ b/.github/scripts/test-release.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 REPOSITORY_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/delta-kernel-release-test.XXXXXX")
 trap 'rm -rf "$TEST_ROOT"' EXIT
+export TMPDIR="$TEST_ROOT"
 
 fail() {
     echo "release tooling test failed: $1" >&2
@@ -44,6 +45,32 @@ test_registry_override() {
     fi
 }
 
+test_release_command_dispatch() {
+    local capture="$TEST_ROOT/release-command"
+
+    (
+        # shellcheck source=release.sh
+        source "$REPOSITORY_ROOT/release.sh"
+        check_requirements() { :; }
+        is_main_branch() { return 1; }
+        handle_release_branch() { printf 'branch %s\n' "$1" > "$capture"; }
+
+        main release 0.29.0
+    )
+    assert_contains "$capture" "branch 0.29.0"
+
+    (
+        # shellcheck source=release.sh
+        source "$REPOSITORY_ROOT/release.sh"
+        check_requirements() { :; }
+        is_main_branch() { return 0; }
+        handle_main_branch() { printf 'main\n' > "$capture"; }
+
+        main release
+    )
+    assert_contains "$capture" "main"
+}
+
 commit_file() {
     local message="$1" contents="$2"
     printf '%s\n' "$contents" > tracked.txt
@@ -55,6 +82,7 @@ test_changelog_refresh_and_verification() {
     local repository="$TEST_ROOT/repository"
     local failing_bin="$TEST_ROOT/failing-bin"
     local saved_changelog="$TEST_ROOT/changelog-before-failure"
+    local backup refresh_log failure_backup
     mkdir -p "$repository"
     cp "$REPOSITORY_ROOT/release.sh" "$REPOSITORY_ROOT/cliff.toml" "$repository/"
 
@@ -90,7 +118,22 @@ test_changelog_refresh_and_verification() {
     [[ "$(latest_kernel_release_tag)" == "v0.28.0" ]] || \
         fail "artifact tag was selected as the latest Kernel release"
 
-    ./release.sh changelog 0.29.0
+    if (
+        latest_kernel_release_tag() { :; }
+        verify_release_changelog 0.29.0
+    ) > no-tag.log 2>&1; then
+        fail "verification unexpectedly passed without a prior Kernel release tag"
+    fi
+    assert_contains no-tag.log "No prior Kernel release tag found"
+
+    ./release.sh > help.log
+    assert_contains help.log "./release.sh release [version]"
+
+    refresh_log="$TEST_ROOT/refresh.log"
+    ./release.sh changelog 0.29.0 > "$refresh_log"
+    assert_contains "$refresh_log" "backup retained at"
+    backup=$(sed -n 's/.*backup retained at //p' "$refresh_log")
+    [[ -f "$backup" ]] || fail "successful changelog refresh did not retain its backup"
     assert_contains CHANGELOG.md "([#101])"
     assert_contains CHANGELOG.md "v0.28.0...v0.29.0"
     assert_count CHANGELOG.md 1 "## [v0.28.0]"
@@ -142,7 +185,12 @@ test_changelog_refresh_and_verification() {
     assert_contains refresh-failure.log "Failed to refresh CHANGELOG.md"
     cmp -s CHANGELOG.md "$saved_changelog" || \
         fail "failed changelog refresh did not restore CHANGELOG.md"
+    failure_backup=$(sed -n 's/.*original saved at //p' refresh-failure.log)
+    [[ -f "$failure_backup" ]] || fail "failed changelog refresh did not retain its backup"
+    cmp -s "$failure_backup" "$saved_changelog" || \
+        fail "failed changelog refresh retained the wrong backup contents"
 }
 
 test_registry_override
+test_release_command_dispatch
 test_changelog_refresh_and_verification

--- a/.github/scripts/test-release.sh
+++ b/.github/scripts/test-release.sh
@@ -57,15 +57,25 @@ test_changelog_refresh_and_verification() {
     cp "$REPOSITORY_ROOT/release.sh" "$REPOSITORY_ROOT/cliff.toml" "$repository/"
 
     cd "$repository"
-    git init -q
+    git init -q -b main
     git config user.email release-test@example.com
     git config user.name "Release Test"
     git config core.hooksPath /dev/null
 
-    printf '# Changelog\n' > CHANGELOG.md
+    printf '%s\n' \
+        '# Changelog' \
+        '' \
+        '## [v0.28.0](https://github.com/delta-io/delta-kernel-rs/tree/v0.28.0/)' \
+        '' \
+        'Previous release notes' > CHANGELOG.md
     git add CHANGELOG.md
     git commit -q -m "chore: previous release"
     git tag v0.28.0
+
+    git switch -q -c divergent-release
+    commit_file "release 100.0.0" "divergent"
+    git tag v100.0.0
+    git switch -q main
 
     commit_file "chore: publish DAT artifact" "dat"
     git tag v999.0.0_dat
@@ -81,10 +91,20 @@ test_changelog_refresh_and_verification() {
     ./release.sh changelog 0.29.0
     assert_contains CHANGELOG.md "([#101])"
     assert_contains CHANGELOG.md "v0.28.0...v0.29.0"
+    assert_count CHANGELOG.md 1 "## [v0.28.0]"
+    assert_contains CHANGELOG.md "Previous release notes"
     git add CHANGELOG.md
     git commit -q -m "release 0.29.0 (#999)"
 
-    # A release commit cannot mention its own PR in the changelog it introduced.
+    # Exercise the no-argument path used by CI. A release commit cannot mention its own PR in the
+    # changelog it introduced, and cliff.toml deliberately skips it.
+    get_current_version() {
+        [[ "$1" == "delta_kernel" ]] || fail "unexpected crate name: $1"
+        echo 0.29.0
+    }
+    verify_release_changelog
+
+    commit_file "chore: refresh release changelog (#998)" "housekeeping"
     ./release.sh verify-changelog 0.29.0
 
     commit_file "fix: include late change (#102)" "late"
@@ -92,10 +112,16 @@ test_changelog_refresh_and_verification() {
         fail "stale changelog verification unexpectedly passed"
     fi
     assert_contains verification.log "missing PR #102"
+    if grep -Fq "missing PR #998" verification.log; then
+        fail "verification required a commit skipped by cliff.toml"
+    fi
 
     ./release.sh changelog 0.29.0
     assert_count CHANGELOG.md 1 "([#101])"
     assert_count CHANGELOG.md 1 "([#102])"
+    assert_count CHANGELOG.md 1 "## [v0.29.0]"
+    assert_count CHANGELOG.md 1 "## [v0.28.0]"
+    assert_contains CHANGELOG.md "Previous release notes"
     ./release.sh verify-changelog 0.29.0
 }
 

--- a/.github/scripts/test-release.sh
+++ b/.github/scripts/test-release.sh
@@ -53,6 +53,8 @@ commit_file() {
 
 test_changelog_refresh_and_verification() {
     local repository="$TEST_ROOT/repository"
+    local failing_bin="$TEST_ROOT/failing-bin"
+    local saved_changelog="$TEST_ROOT/changelog-before-failure"
     mkdir -p "$repository"
     cp "$REPOSITORY_ROOT/release.sh" "$REPOSITORY_ROOT/cliff.toml" "$repository/"
 
@@ -104,10 +106,19 @@ test_changelog_refresh_and_verification() {
     }
     verify_release_changelog
 
+    mkdir -p "$failing_bin"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$failing_bin/git-cliff"
+    chmod +x "$failing_bin/git-cliff"
+    if PATH="$failing_bin:$PATH" verify_release_changelog 0.29.0 \
+        > tag-failure.log 2>&1; then
+        fail "tag lookup failure unexpectedly passed verification"
+    fi
+    assert_contains tag-failure.log "Could not resolve the latest Kernel release tag"
+
     commit_file "chore: refresh release changelog (#998)" "housekeeping"
     ./release.sh verify-changelog 0.29.0
 
-    commit_file "fix: include late change (#102)" "late"
+    commit_file "fix: include late change (#102) [skip ci]" "late"
     if ./release.sh verify-changelog 0.29.0 > verification.log 2>&1; then
         fail "stale changelog verification unexpectedly passed"
     fi
@@ -123,6 +134,14 @@ test_changelog_refresh_and_verification() {
     assert_count CHANGELOG.md 1 "## [v0.28.0]"
     assert_contains CHANGELOG.md "Previous release notes"
     ./release.sh verify-changelog 0.29.0
+
+    cp CHANGELOG.md "$saved_changelog"
+    if PATH="$failing_bin:$PATH" ./release.sh changelog 0.29.0 > refresh-failure.log 2>&1; then
+        fail "changelog refresh unexpectedly passed with a failing git-cliff"
+    fi
+    assert_contains refresh-failure.log "Failed to refresh CHANGELOG.md"
+    cmp -s CHANGELOG.md "$saved_changelog" || \
+        fail "failed changelog refresh did not restore CHANGELOG.md"
 }
 
 test_registry_override

--- a/.github/scripts/test-release.sh
+++ b/.github/scripts/test-release.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPOSITORY_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/delta-kernel-release-test.XXXXXX")
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+    echo "release tooling test failed: $1" >&2
+    exit 1
+}
+
+assert_contains() {
+    local path="$1" expected="$2"
+    grep -Fq -- "$expected" "$path" || fail "$path does not contain: $expected"
+}
+
+assert_count() {
+    local path="$1" expected="$2" value="$3"
+    local actual
+    actual=$(grep -Fc "$value" "$path")
+    [[ "$actual" == "$expected" ]] || \
+        fail "$path contains '$value' $actual times; expected $expected"
+}
+
+test_registry_override() {
+    local capture="$TEST_ROOT/cargo-args"
+
+    # shellcheck source=release.sh
+    source "$REPOSITORY_ROOT/release.sh"
+    cargo() {
+        printf '%s\n' "$@" > "$capture"
+    }
+
+    DELTA_KERNEL_RELEASE_REGISTRY=databricks-proxy run_cargo_release 0.29.0
+    assert_contains "$capture" "--registry"
+    assert_contains "$capture" "databricks-proxy"
+
+    unset DELTA_KERNEL_RELEASE_REGISTRY
+    run_cargo_release 0.29.0
+    if grep -Fq -- "--registry" "$capture"; then
+        fail "cargo release received --registry without an override"
+    fi
+}
+
+commit_file() {
+    local message="$1" contents="$2"
+    printf '%s\n' "$contents" > tracked.txt
+    git add tracked.txt
+    git commit -q -m "$message"
+}
+
+test_changelog_refresh_and_verification() {
+    local repository="$TEST_ROOT/repository"
+    mkdir -p "$repository"
+    cp "$REPOSITORY_ROOT/release.sh" "$REPOSITORY_ROOT/cliff.toml" "$repository/"
+
+    cd "$repository"
+    git init -q
+    git config user.email release-test@example.com
+    git config user.name "Release Test"
+    git config core.hooksPath /dev/null
+
+    printf '# Changelog\n' > CHANGELOG.md
+    git add CHANGELOG.md
+    git commit -q -m "chore: previous release"
+    git tag v0.28.0
+
+    commit_file "chore: publish DAT artifact" "dat"
+    git tag v0.0.1_dat
+    commit_file "fix: include first change (#101)" "first"
+
+    ./release.sh changelog 0.29.0
+    assert_contains CHANGELOG.md "([#101])"
+    assert_contains CHANGELOG.md "v0.28.0...v0.29.0"
+    git add CHANGELOG.md
+    git commit -q -m "release 0.29.0"
+
+    commit_file "fix: include late change (#102)" "late"
+    if ./release.sh verify-changelog 0.29.0 > verification.log 2>&1; then
+        fail "stale changelog verification unexpectedly passed"
+    fi
+    assert_contains verification.log "missing PR #102"
+
+    ./release.sh changelog 0.29.0
+    assert_count CHANGELOG.md 1 "([#101])"
+    assert_count CHANGELOG.md 1 "([#102])"
+    ./release.sh verify-changelog 0.29.0
+}
+
+test_registry_override
+test_changelog_refresh_and_verification

--- a/.github/scripts/test-release.sh
+++ b/.github/scripts/test-release.sh
@@ -33,9 +33,9 @@ test_registry_override() {
         printf '%s\n' "$@" > "$capture"
     }
 
-    DELTA_KERNEL_RELEASE_REGISTRY=databricks-proxy run_cargo_release 0.29.0
+    DELTA_KERNEL_RELEASE_REGISTRY=mirror run_cargo_release 0.29.0
     assert_contains "$capture" "--registry"
-    assert_contains "$capture" "databricks-proxy"
+    assert_contains "$capture" "mirror"
 
     unset DELTA_KERNEL_RELEASE_REGISTRY
     run_cargo_release 0.29.0

--- a/.github/scripts/test-release.sh
+++ b/.github/scripts/test-release.sh
@@ -68,14 +68,24 @@ test_changelog_refresh_and_verification() {
     git tag v0.28.0
 
     commit_file "chore: publish DAT artifact" "dat"
-    git tag v0.0.1_dat
+    git tag v999.0.0_dat
     commit_file "fix: include first change (#101)" "first"
+
+    # The artifact tag sorts above the real release numerically, but cliff.toml still defines
+    # v0.28.0 as the latest Kernel release boundary.
+    # shellcheck source=release.sh
+    source ./release.sh
+    [[ "$(latest_kernel_release_tag)" == "v0.28.0" ]] || \
+        fail "artifact tag was selected as the latest Kernel release"
 
     ./release.sh changelog 0.29.0
     assert_contains CHANGELOG.md "([#101])"
     assert_contains CHANGELOG.md "v0.28.0...v0.29.0"
     git add CHANGELOG.md
-    git commit -q -m "release 0.29.0"
+    git commit -q -m "release 0.29.0 (#999)"
+
+    # A release commit cannot mention its own PR in the changelog it introduced.
+    ./release.sh verify-changelog 0.29.0
 
     commit_file "fix: include late change (#102)" "late"
     if ./release.sh verify-changelog 0.29.0 > verification.log 2>&1; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Test release tooling
         run: .github/scripts/test-release.sh
       - name: Verify pending release changelog
-        if: startsWith(github.head_ref, 'release') || startsWith(github.ref_name, 'release')
+        if: startsWith(github.head_ref, 'release/') || startsWith(github.ref_name, 'release/')
         run: ./release.sh verify-changelog
 
   ai-review-config:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Test release tooling
         run: .github/scripts/test-release.sh
       - name: Verify pending release changelog
+        if: startsWith(github.head_ref, 'release') || startsWith(github.ref_name, 'release')
         run: ./release.sh verify-changelog
 
   ai-review-config:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,20 @@ env:
 # are installed via taiki-e/install-action, which fetches prebuilt binaries.
 
 jobs:
+  release-tooling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: taiki-e/install-action@7bc99eee1f1b8902a125006cf790a1f4c8461e63 # v2.69.8
+        with:
+          tool: git-cliff
+      - name: Test release tooling
+        run: .github/scripts/test-release.sh
+      - name: Verify pending release changelog
+        run: ./release.sh verify-changelog
+
   ai-review-config:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,5 +140,6 @@ If it was tested in a way different from regular unit tests, please clarify how 
 
 ## Resources
 
+- [Release process](RELEASING.md) - Maintainer runbook for changelogs, publishing, and tags
 - [Delta Protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md)
 - [Delta Lake Slack](https://go.delta.io/slack) - Join us in the `#delta-kernel` channel

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,129 @@
+# Releasing Delta Kernel Rust
+
+This runbook covers the workspace-versioned Kernel crates:
+
+- `delta_kernel_derive`
+- `delta_kernel`
+- `delta_kernel_default_engine`
+
+Independently versioned crates use their own release instructions until the per-crate release
+workflow is available.
+
+## Prerequisites
+
+Install `cargo-release`, `git-cliff`, and `jq`. Configure the `origin` remote to point to your fork
+and `upstream` to point to `delta-io/delta-kernel-rs`. Fetch `main` and all tags before starting:
+
+```bash
+git fetch upstream main --tags
+git switch -c release/0.29.0 upstream/main
+```
+
+The working tree must be clean.
+
+### Databricks registry proxy
+
+Databricks maintainers should use their standard Cargo configuration for the
+`databricks-proxy` registry. Select it for release preparation through the environment instead of
+editing `release.sh`:
+
+```bash
+DELTA_KERNEL_RELEASE_REGISTRY=databricks-proxy ./release.sh 0.29.0
+```
+
+The variable is passed only to `cargo release`; publishing still uses the release destination
+described below. Do not mark `release.sh` as `skip-worktree` or keep a private edit to it.
+
+## Prepare the release PR
+
+Run the release script from a branch created at the latest `upstream/main`:
+
+```bash
+./release.sh 0.29.0
+```
+
+The script updates workspace versions, refreshes `CHANGELOG.md`, creates the release commit, and
+can push the branch and open the PR. Review the generated changelog before requesting approval:
+
+1. Compare the commits after the previous release tag with the changelog.
+2. Remove entries already shipped in a patch release.
+3. Move true API or contract breaks into **Breaking changes** and explain their impact. New APIs and
+   changes restricted to `internal-api` are not breaking changes.
+4. Run `./release.sh verify-changelog 0.29.0`.
+
+Kernel changelogs only use plain semantic-version tags such as `v0.28.0` as release boundaries.
+Artifact-specific tags such as `v0.0.1_dat` do not truncate the changelog range.
+
+### If `main` changes while the PR is open
+
+The `release-tooling` CI job compares the release section with every merged PR since the previous
+Kernel release. A new merge to `main` makes a stale changelog check fail. Update the release branch
+and regenerate the section:
+
+```bash
+git fetch upstream main
+git rebase upstream/main
+./release.sh changelog 0.29.0
+git add CHANGELOG.md
+git commit -m "chore: refresh release changelog"
+git push --force-with-lease origin HEAD
+```
+
+The refresh command replaces the pending version's section, so it is safe to rerun. Do not merge a
+release PR until `release-tooling` passes against the current base branch.
+
+## Publish and tag
+
+After the release PR merges, update local `main` and verify that it points at the release commit:
+
+```bash
+git switch main
+git pull --ff-only upstream main
+```
+
+Maintainers publishing directly to crates.io can then run:
+
+```bash
+./release.sh
+```
+
+The script publishes in dependency order (`delta_kernel_derive`, `delta_kernel`, then
+`delta_kernel_default_engine`) and creates the `v<version>` tag. Check each crate on crates.io and
+announce the release in the Delta community channels. Databricks maintainers must instead use the
+secure publishing path below.
+
+### Databricks secure publishing access
+
+Databricks maintainers publish through the
+[`secure-public-registry-releases-eng` repository][secure-release-repository] rather than from a
+workstation.
+
+Before release day:
+
+1. Ask in `#unblock-release-public` for access to the repository and include your GitHub username.
+2. Request the [`app.github-databricks` group][release-repository-opal] through Opal.
+3. Confirm you can view and run the `delta-kernel-rs.yml` workflow.
+4. Ask the Kernel release-token owner to install a short-lived token in the repository secret.
+
+Run the workflow one crate at a time in dependency order. Dry-run each crate before publishing it;
+the next crate may need to wait until its newly published dependency is visible. Ask the token owner
+to revoke the token when the release is complete. Tag the release commit only after all crates are
+published:
+
+```bash
+git tag -a v0.29.0 -m "Release v0.29.0"
+git push upstream tag v0.29.0
+```
+
+For a new crate, first add it to the secure workflow's allowlist, run the security scan, confirm its
+SBOM appears, and update the dependency-proxy allowlist. Coordinate both reviews in
+`#unblock-release-public` before attempting the release.
+
+[secure-release-repository]: https://github.com/databricks/secure-public-registry-releases-eng
+[release-repository-opal]: https://app.opal.dev/groups/6e445be4-f11d-4d78-8a43-dafce57e2be6
+
+## Patch releases
+
+Create the patch branch from the previous release tag, cherry-pick only the intended fixes, and open
+the generated release PR against that patch branch. Keep patch-only entries out of the next minor
+release changelog when reviewing it.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,14 +21,13 @@ git switch -c release/0.29.0 upstream/main
 
 The working tree must be clean.
 
-### Databricks registry proxy
+### Alternate Cargo registry
 
-Databricks maintainers should use their standard Cargo configuration for the
-`databricks-proxy` registry. Select it for release preparation through the environment instead of
+If `cargo-release` must use an alternate registry, select it through the environment instead of
 editing `release.sh`:
 
 ```bash
-DELTA_KERNEL_RELEASE_REGISTRY=databricks-proxy ./release.sh 0.29.0
+DELTA_KERNEL_RELEASE_REGISTRY=<registry-name> ./release.sh 0.29.0
 ```
 
 The variable is passed only to `cargo release`; publishing still uses the release destination
@@ -89,38 +88,7 @@ Maintainers publishing directly to crates.io can then run:
 
 The script publishes in dependency order (`delta_kernel_derive`, `delta_kernel`, then
 `delta_kernel_default_engine`) and creates the `v<version>` tag. Check each crate on crates.io and
-announce the release in the Delta community channels. Databricks maintainers must instead use the
-secure publishing path below.
-
-### Databricks secure publishing access
-
-Databricks maintainers publish through the
-[`secure-public-registry-releases-eng` repository][secure-release-repository] rather than from a
-workstation.
-
-Before release day:
-
-1. Ask in `#unblock-release-public` for access to the repository and include your GitHub username.
-2. Request the [`app.github-databricks` group][release-repository-opal] through Opal.
-3. Confirm you can view and run the `delta-kernel-rs.yml` workflow.
-4. Ask the Kernel release-token owner to install a short-lived token in the repository secret.
-
-Run the workflow one crate at a time in dependency order. Dry-run each crate before publishing it;
-the next crate may need to wait until its newly published dependency is visible. Ask the token owner
-to revoke the token when the release is complete. Tag the release commit only after all crates are
-published:
-
-```bash
-git tag -a v0.29.0 -m "Release v0.29.0"
-git push upstream tag v0.29.0
-```
-
-For a new crate, first add it to the secure workflow's allowlist, run the security scan, confirm its
-SBOM appears, and update the dependency-proxy allowlist. Coordinate both reviews in
-`#unblock-release-public` before attempting the release.
-
-[secure-release-repository]: https://github.com/databricks/secure-public-registry-releases-eng
-[release-repository-opal]: https://app.opal.dev/groups/6e445be4-f11d-4d78-8a43-dafce57e2be6
+announce the release in the Delta community channels.
 
 ## Patch releases
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,7 @@ If `cargo-release` must use an alternate registry, select it through the environ
 editing `release.sh`:
 
 ```bash
-DELTA_KERNEL_RELEASE_REGISTRY=<registry-name> ./release.sh 0.29.0
+DELTA_KERNEL_RELEASE_REGISTRY=<registry-name> ./release.sh release 0.29.0
 ```
 
 The variable is passed only to `cargo release`; publishing still uses the release destination
@@ -38,7 +38,7 @@ described below. Do not mark `release.sh` as `skip-worktree` or keep a private e
 Run the release script from a branch created at the latest `upstream/main`:
 
 ```bash
-./release.sh 0.29.0
+./release.sh release 0.29.0
 ```
 
 The script updates workspace versions, refreshes `CHANGELOG.md`, creates the release commit, and
@@ -83,7 +83,7 @@ git pull --ff-only upstream main
 Maintainers publishing directly to crates.io can then run:
 
 ```bash
-./release.sh
+./release.sh release
 ```
 
 The script publishes in dependency order (`delta_kernel_derive`, `delta_kernel`, then

--- a/cliff.toml
+++ b/cliff.toml
@@ -5,6 +5,7 @@ header = """
 # Changelog\n
 """
 # Tera template
+# release.sh parses the `## [v{{ version }}]` prefix below when it replaces and verifies a section.
 body = """
 ## [v{{ version }}](https://github.com/delta-io/delta-kernel-rs/tree/v{{ version }}/) ({{ timestamp | date(format="%Y-%m-%d") }})
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -5,7 +5,8 @@ header = """
 # Changelog\n
 """
 # Tera template
-# release.sh parses the `## [v{{ version }}]` prefix below when it replaces and verifies a section.
+# release.sh parses the `## [v{{ version }}]` prefix and `[#N]:` references below when it replaces
+# and verifies a section.
 body = """
 ## [v{{ version }}](https://github.com/delta-io/delta-kernel-rs/tree/v{{ version }}/) ({{ timestamp | date(format="%Y-%m-%d") }})
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -40,6 +40,9 @@ trim = true
 postprocessors = []
 
 [git]
+# Only plain semver tags mark Kernel releases. Artifact-specific tags such as v0.0.1_dat must not
+# truncate the Kernel changelog range.
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$"
 # parse the commits based on https://www.conventionalcommits.org
 conventional_commits = true
 # filter out the commits that are not conventional
@@ -51,6 +54,8 @@ commit_preprocessors = []
 # regex for parsing and grouping commits. note that e.g. both doc and docs are matched since we have
 # trim = true above.
 commit_parsers = [
+  { message = "^release [0-9]", skip = true },
+  { message = "^chore: refresh release changelog", skip = true },
   { field = "github.pr_labels", pattern = "breaking-change", group = "<!-- 0 --> 🏗️ Breaking changes" },
   { message = "^feat", group = "<!-- 1 -->🚀 Features / new APIs" },
   { message = "^fix", group = "<!-- 2 -->🐛 Bug Fixes" },

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -23,18 +23,8 @@ pre-release-replacements = [
   { file = "../README.md", search = "version = \"[a-z0-9\\.-]+\"", replace = "version = \"{{version}}\"" },
 ]
 pre-release-hook = [
-  "git",
-  "cliff",
-  "--repository",
-  "../",
-  "--config",
-  "../cliff.toml",
-  "--unreleased",
-  "--prepend",
-  "../CHANGELOG.md",
-  "--include-path",
-  "*",
-  "--tag",
+  "../release.sh",
+  "changelog",
   "{{version}}",
 ]
 

--- a/release.sh
+++ b/release.sh
@@ -94,8 +94,8 @@ get_current_version() {
         jq -r --arg name "$crate_name" '.packages[] | select(.name == $name) | .version'
 }
 
-# Run cargo-release with an optional read registry. This avoids editing release.sh when the
-# maintainer's network requires dependency metadata to come from a registry proxy.
+# Run cargo-release with an optional registry selection. This avoids editing release.sh when a
+# maintainer's Cargo configuration requires a registry proxy.
 run_cargo_release() {
     local version="$1"
     local args=(
@@ -150,7 +150,10 @@ verify_release_changelog() {
         version=$(get_current_version "delta_kernel")
     fi
 
-    previous_tag=$(latest_kernel_release_tag)
+    if ! previous_tag=$(latest_kernel_release_tag); then
+        log_warning "Could not resolve the latest Kernel release tag"
+        return 1
+    fi
     if [[ -z "$previous_tag" ]]; then
         log_warning "No prior Kernel release tag found; skipping changelog verification"
         return 0
@@ -172,7 +175,8 @@ verify_release_changelog() {
     fi
 
     while IFS= read -r subject; do
-        if [[ "$subject" =~ \(\#([0-9]+)\)$ ]]; then
+        # The greedy prefix selects the last PR token, matching cliff.toml's link extraction.
+        if [[ "$subject" =~ .*\(\#([0-9]+)\) ]]; then
             pr="${BASH_REMATCH[1]}"
             if ! grep -Fq "[#$pr]:" <<< "$section"; then
                 log_warning "CHANGELOG.md v$version is missing PR #$pr: $subject"

--- a/release.sh
+++ b/release.sh
@@ -2,13 +2,13 @@
 
 ###################################################################################################
 # USAGE:
-# 1. on a release branch: ./release.sh <version> (example: ./release.sh 0.1.0)
-# 2. on main branch (after merging release branch): ./release.sh
+# 1. on a release branch: ./release.sh release <version> (example: ./release.sh release 0.1.0)
+# 2. on main branch (after merging release branch): ./release.sh release
 # 3. refresh a release PR after merging/rebasing main: ./release.sh changelog <version>
 # 4. verify that a release changelog covers every merged PR: ./release.sh verify-changelog [version]
 #
 # Set DELTA_KERNEL_RELEASE_REGISTRY when cargo-release must use an alternate registry:
-#   DELTA_KERNEL_RELEASE_REGISTRY=<registry-name> ./release.sh 0.29.0
+#   DELTA_KERNEL_RELEASE_REGISTRY=<registry-name> ./release.sh release 0.29.0
 ###################################################################################################
 
 # This is a script to automate a large portion of the release process for the crates we publish to
@@ -19,6 +19,7 @@
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+RELEASE_CHANGELOG_HEADING=
 
 # print commands before executing them for debugging
 # set -x
@@ -94,8 +95,7 @@ get_current_version() {
         jq -r --arg name "$crate_name" '.packages[] | select(.name == $name) | .version'
 }
 
-# Run cargo-release with an optional registry selection. This avoids editing release.sh when a
-# maintainer's Cargo configuration requires a registry proxy.
+# Run cargo-release with an optional registry selection.
 run_cargo_release() {
     local version="$1"
     local args=(
@@ -118,13 +118,12 @@ latest_kernel_release_tag() {
 
 release_changelog_heading() {
     local version="$1"
-    printf '## [v%s]' "$version"
+    printf -v RELEASE_CHANGELOG_HEADING '## [v%s]' "$version"
 }
 
 release_changelog_section() {
-    local heading
-    heading=$(release_changelog_heading "$1")
-    awk -v heading="$heading" '
+    release_changelog_heading "$1"
+    awk -v heading="$RELEASE_CHANGELOG_HEADING" '
         index($0, heading) == 1 { in_release = 1 }
         in_release && /^## \[v/ && index($0, heading) != 1 { exit }
         in_release { print }
@@ -155,8 +154,8 @@ verify_release_changelog() {
         return 1
     fi
     if [[ -z "$previous_tag" ]]; then
-        log_warning "No prior Kernel release tag found; skipping changelog verification"
-        return 0
+        log_warning "No prior Kernel release tag found"
+        return 1
     fi
     if [[ "$previous_tag" == "v$version" ]]; then
         log_info "Workspace version $version is already tagged; no release changelog to verify"
@@ -193,10 +192,11 @@ verify_release_changelog() {
     log_success "CHANGELOG.md v$version covers every merged PR since $previous_tag"
 }
 
+# Remove the changelog section for the version specified as the first argument.
 strip_release_changelog_section() {
-    local output="$2" heading
-    heading=$(release_changelog_heading "$1")
-    awk -v heading="$heading" '
+    local output="$2"
+    release_changelog_heading "$1"
+    awk -v heading="$RELEASE_CHANGELOG_HEADING" '
         index($0, heading) == 1 { skipping = 1; next }
         skipping && /^## \[v/ { skipping = 0 }
         !skipping { print }
@@ -219,12 +219,11 @@ refresh_release_changelog() {
     if ! git cliff --repository "$REPO_ROOT" --config "$REPO_ROOT/cliff.toml" \
         --use-branch-tags --unreleased --prepend "$changelog" --include-path "*" \
         --tag "$version"; then
-        mv "$backup" "$changelog"
-        log_error "Failed to refresh CHANGELOG.md"
+        cp "$backup" "$changelog"
+        log_error "Failed to refresh CHANGELOG.md; original saved at $backup"
     fi
 
-    rm -f "$backup"
-    log_success "Refreshed CHANGELOG.md for v$version"
+    log_success "Refreshed CHANGELOG.md for v$version; backup retained at $backup"
 }
 
 # Prompt user for confirmation
@@ -330,6 +329,14 @@ validate_version() {
     fi
 }
 
+usage() {
+    printf '%s\n' \
+        "Usage:" \
+        "  $0 release [version]" \
+        "  $0 changelog <version>" \
+        "  $0 verify-changelog [version]"
+}
+
 main() {
     case "${1:-}" in
         changelog)
@@ -349,20 +356,29 @@ main() {
                 log_error "Release changelog is incomplete"
             fi
             ;;
-        *)
+        release)
             check_requirements
             if is_main_branch; then
-                if [[ $# -ne 0 ]]; then
-                    log_error "Version argument not expected on main branch\nUsage: $0"
+                if [[ $# -ne 1 ]]; then
+                    usage >&2
+                    log_error "Version argument not expected on main branch"
                 fi
                 handle_main_branch
             else
-                if [[ $# -ne 1 ]]; then
-                    log_error "Version argument required when on release branch\nUsage: $0 <version>"
+                if [[ $# -ne 2 ]]; then
+                    usage >&2
+                    log_error "Version argument required when on release branch"
                 fi
-                validate_version "$1"
-                handle_release_branch "$1"
+                validate_version "$2"
+                handle_release_branch "$2"
             fi
+            ;;
+        "" | help | -h | --help)
+            usage
+            ;;
+        *)
+            usage >&2
+            log_error "Unknown command: $1"
             ;;
     esac
 }

--- a/release.sh
+++ b/release.sh
@@ -112,25 +112,38 @@ run_cargo_release() {
 # Ask git-cliff for the latest Kernel release so changelog generation and verification use the
 # same tag grammar from cliff.toml.
 latest_kernel_release_tag() {
-    git cliff --repository "$REPO_ROOT" --config "$REPO_ROOT/cliff.toml" --latest --context | \
-        jq -r '.[0].version // empty'
+    git cliff --repository "$REPO_ROOT" --config "$REPO_ROOT/cliff.toml" --use-branch-tags \
+        --latest --context | jq -r '.[0].version // empty'
+}
+
+release_changelog_heading() {
+    local version="$1"
+    printf '## [v%s]' "$version"
 }
 
 release_changelog_section() {
-    local version="$1"
-    awk -v heading="## [v$version]" '
+    local heading
+    heading=$(release_changelog_heading "$1")
+    awk -v heading="$heading" '
         index($0, heading) == 1 { in_release = 1 }
         in_release && /^## \[v/ && index($0, heading) != 1 { exit }
         in_release { print }
     ' "$REPO_ROOT/CHANGELOG.md"
 }
 
-# Verify that the current release section contains every PR reachable from the previous Kernel
-# release tag. The commit that introduced the section is excluded because that release PR cannot
-# list itself. This check runs against GitHub's merge ref, so it becomes stale whenever main moves.
+release_changelog_subjects() {
+    local version="$1"
+    git cliff --repository "$REPO_ROOT" --config "$REPO_ROOT/cliff.toml" --use-branch-tags \
+        --unreleased --include-path "*" --tag "$version" --context | \
+        jq -r '.[].commits[].message | split("\n")[0]'
+}
+
+# Verify that the current release section contains every PR git-cliff would render after the
+# previous Kernel release. This check runs against GitHub's merge ref, so it becomes stale whenever
+# main moves.
 verify_release_changelog() {
     local version="${1:-}"
-    local previous_tag section release_commit hash subject pr
+    local previous_tag section subjects subject pr
     local missing=0
 
     if [[ -z "$version" ]]; then
@@ -153,12 +166,12 @@ verify_release_changelog() {
         return 1
     fi
 
-    release_commit=$(git -C "$REPO_ROOT" log -S"## [v$version]" --format=%H \
-        "$previous_tag..HEAD" -- CHANGELOG.md | head -n 1)
+    if ! subjects=$(release_changelog_subjects "$version"); then
+        log_warning "Could not determine the changelog entries for v$version"
+        return 1
+    fi
 
-    while IFS=$'\t' read -r hash subject; do
-        [[ -n "$hash" ]] || continue
-        [[ "$hash" == "$release_commit" ]] && continue
+    while IFS= read -r subject; do
         if [[ "$subject" =~ \(\#([0-9]+)\)$ ]]; then
             pr="${BASH_REMATCH[1]}"
             if ! grep -Fq "[#$pr]:" <<< "$section"; then
@@ -166,7 +179,7 @@ verify_release_changelog() {
                 missing=1
             fi
         fi
-    done < <(git -C "$REPO_ROOT" log --format='%H%x09%s' "$previous_tag..HEAD")
+    done <<< "$subjects"
 
     if (( missing != 0 )); then
         log_warning "Update from main, then run: ./release.sh changelog $version"
@@ -177,8 +190,9 @@ verify_release_changelog() {
 }
 
 strip_release_changelog_section() {
-    local version="$1" output="$2"
-    awk -v heading="## [v$version]" '
+    local output="$2" heading
+    heading=$(release_changelog_heading "$1")
+    awk -v heading="$heading" '
         index($0, heading) == 1 { skipping = 1; next }
         skipping && /^## \[v/ { skipping = 0 }
         !skipping { print }
@@ -198,8 +212,9 @@ refresh_release_changelog() {
     strip_release_changelog_section "$version" "$stripped"
     mv "$stripped" "$changelog"
 
-    if ! git cliff --repository "$REPO_ROOT" --config "$REPO_ROOT/cliff.toml" --unreleased \
-        --prepend "$changelog" --include-path "*" --tag "$version"; then
+    if ! git cliff --repository "$REPO_ROOT" --config "$REPO_ROOT/cliff.toml" \
+        --use-branch-tags --unreleased --prepend "$changelog" --include-path "*" \
+        --tag "$version"; then
         mv "$backup" "$changelog"
         log_error "Failed to refresh CHANGELOG.md"
     fi

--- a/release.sh
+++ b/release.sh
@@ -4,6 +4,11 @@
 # USAGE:
 # 1. on a release branch: ./release.sh <version> (example: ./release.sh 0.1.0)
 # 2. on main branch (after merging release branch): ./release.sh
+# 3. refresh a release PR after merging/rebasing main: ./release.sh changelog <version>
+# 4. verify that a release changelog covers every merged PR: ./release.sh verify-changelog [version]
+#
+# Set DELTA_KERNEL_RELEASE_REGISTRY when cargo-release must resolve through another registry:
+#   DELTA_KERNEL_RELEASE_REGISTRY=databricks-proxy ./release.sh 0.29.0
 ###################################################################################################
 
 # This is a script to automate a large portion of the release process for the crates we publish to
@@ -12,6 +17,8 @@
 
 # Exit on error, undefined variables, and pipe failures
 set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # print commands before executing them for debugging
 # set -x
@@ -37,6 +44,18 @@ check_requirements() {
     command -v jq >/dev/null 2>&1 || log_error "jq is required but not installed."
 
     log_success "All required tools are available"
+}
+
+check_changelog_requirements() {
+    command -v git >/dev/null 2>&1 || log_error "git is required but not installed"
+    command -v git-cliff >/dev/null 2>&1 || \
+        log_error "git-cliff is required but not installed. Install with: cargo install git-cliff"
+}
+
+check_changelog_verification_requirements() {
+    command -v cargo >/dev/null 2>&1 || log_error "cargo is required but not installed"
+    command -v git >/dev/null 2>&1 || log_error "git is required but not installed"
+    command -v jq >/dev/null 2>&1 || log_error "jq is required but not installed"
 }
 
 is_main_branch() {
@@ -69,8 +88,122 @@ is_version_published() {
 # get current version from Cargo.toml
 get_current_version() {
     local crate_name="$1"
-    cargo metadata --no-deps --format-version 1 | \
+    cargo metadata --locked --no-deps --format-version 1 | \
         jq -r --arg name "$crate_name" '.packages[] | select(.name == $name) | .version'
+}
+
+# Run cargo-release with an optional read registry. This avoids editing release.sh when the
+# maintainer's network requires dependency metadata to come from a registry proxy.
+run_cargo_release() {
+    local version="$1"
+    local args=(
+        release --workspace "$version" --no-publish --no-push --no-tag --execute
+    )
+
+    if [[ -n "${DELTA_KERNEL_RELEASE_REGISTRY:-}" ]]; then
+        args+=(--registry "$DELTA_KERNEL_RELEASE_REGISTRY")
+    fi
+
+    cargo "${args[@]}"
+}
+
+# Return the highest merged Kernel release tag. Other artifacts use suffixed tags such as
+# v0.0.1_dat; accepting those as Kernel releases can silently drop commits from the changelog.
+latest_kernel_release_tag() {
+    git -C "$REPO_ROOT" tag --merged HEAD --sort=-version:refname | \
+        awk '/^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$/ { print; exit }'
+}
+
+release_changelog_section() {
+    local version="$1"
+    awk -v heading="## [v$version]" '
+        index($0, heading) == 1 { in_release = 1 }
+        in_release && /^## \[v/ && index($0, heading) != 1 { exit }
+        in_release { print }
+    ' "$REPO_ROOT/CHANGELOG.md"
+}
+
+# Verify that the current release section contains every PR reachable from the previous Kernel
+# release tag. The commit that introduced the section is excluded because that release PR cannot
+# list itself. This check runs against GitHub's merge ref, so it becomes stale whenever main moves.
+verify_release_changelog() {
+    local version="${1:-}"
+    local previous_tag section release_commit hash subject pr
+    local missing=0
+
+    if [[ -z "$version" ]]; then
+        version=$(get_current_version "delta_kernel")
+    fi
+
+    previous_tag=$(latest_kernel_release_tag)
+    if [[ -z "$previous_tag" ]]; then
+        log_warning "No prior Kernel release tag found; skipping changelog verification"
+        return 0
+    fi
+    if [[ "$previous_tag" == "v$version" ]]; then
+        log_info "Workspace version $version is already tagged; no release changelog to verify"
+        return 0
+    fi
+
+    section=$(release_changelog_section "$version")
+    if [[ -z "$section" ]]; then
+        log_warning "CHANGELOG.md has no section for v$version"
+        return 1
+    fi
+
+    release_commit=$(git -C "$REPO_ROOT" log -S"## [v$version]" --format=%H \
+        "$previous_tag..HEAD" -- CHANGELOG.md | head -n 1)
+
+    while IFS=$'\t' read -r hash subject; do
+        [[ -n "$hash" ]] || continue
+        [[ "$hash" == "$release_commit" ]] && continue
+        if [[ "$subject" =~ \(\#([0-9]+)\)$ ]]; then
+            pr="${BASH_REMATCH[1]}"
+            if ! grep -Fq "[#$pr]:" <<< "$section"; then
+                log_warning "CHANGELOG.md v$version is missing PR #$pr: $subject"
+                missing=1
+            fi
+        fi
+    done < <(git -C "$REPO_ROOT" log --format='%H%x09%s' "$previous_tag..HEAD")
+
+    if (( missing != 0 )); then
+        log_warning "Update from main, then run: ./release.sh changelog $version"
+        return 1
+    fi
+
+    log_success "CHANGELOG.md v$version covers every merged PR since $previous_tag"
+}
+
+strip_release_changelog_section() {
+    local version="$1" output="$2"
+    awk -v heading="## [v$version]" '
+        index($0, heading) == 1 { skipping = 1; next }
+        skipping && /^## \[v/ { skipping = 0 }
+        !skipping { print }
+    ' "$REPO_ROOT/CHANGELOG.md" > "$output"
+}
+
+# Replace, rather than append, the pending release section so this command is safe to rerun after
+# the release branch is updated from main.
+refresh_release_changelog() {
+    local version="$1"
+    local changelog="$REPO_ROOT/CHANGELOG.md"
+    local backup stripped
+
+    backup=$(mktemp "${TMPDIR:-/tmp}/delta-kernel-changelog-backup.XXXXXX")
+    stripped=$(mktemp "${TMPDIR:-/tmp}/delta-kernel-changelog-stripped.XXXXXX")
+    cp "$changelog" "$backup"
+    strip_release_changelog_section "$version" "$stripped"
+    mv "$stripped" "$changelog"
+
+    if ! git cliff --repository "$REPO_ROOT" --config "$REPO_ROOT/cliff.toml" --unreleased \
+        --prepend "$changelog" --include-path "*" --tag "$version"; then
+        mv "$backup" "$changelog"
+        log_error "Failed to refresh CHANGELOG.md"
+    fi
+
+    rm -f "$backup"
+    log_success "Refreshed CHANGELOG.md for v$version"
 }
 
 # Prompt user for confirmation
@@ -92,8 +225,12 @@ handle_release_branch() {
 
     # Update CHANGELOG and README
     log_info "Updating CHANGELOG.md and README.md..."
-    if ! cargo release --workspace "$version" --no-publish --no-push --no-tag --execute; then
+    if ! run_cargo_release "$version"; then
         log_error "Failed to update CHANGELOG and README"
+    fi
+
+    if ! verify_release_changelog "$version"; then
+        log_error "Generated changelog is incomplete"
     fi
 
     if confirm "Print diff of CHANGELOG/README changes?"; then
@@ -172,17 +309,43 @@ validate_version() {
     fi
 }
 
-check_requirements
+main() {
+    case "${1:-}" in
+        changelog)
+            if [[ $# -ne 2 ]]; then
+                log_error "Usage: $0 changelog <version>"
+            fi
+            check_changelog_requirements
+            validate_version "$2"
+            refresh_release_changelog "$2"
+            ;;
+        verify-changelog)
+            if [[ $# -gt 2 ]]; then
+                log_error "Usage: $0 verify-changelog [version]"
+            fi
+            check_changelog_verification_requirements
+            if ! verify_release_changelog "${2:-}"; then
+                log_error "Release changelog is incomplete"
+            fi
+            ;;
+        *)
+            check_requirements
+            if is_main_branch; then
+                if [[ $# -ne 0 ]]; then
+                    log_error "Version argument not expected on main branch\nUsage: $0"
+                fi
+                handle_main_branch
+            else
+                if [[ $# -ne 1 ]]; then
+                    log_error "Version argument required when on release branch\nUsage: $0 <version>"
+                fi
+                validate_version "$1"
+                handle_release_branch "$1"
+            fi
+            ;;
+    esac
+}
 
-if is_main_branch; then
-    if [[ $# -ne 0 ]]; then
-        log_error "Version argument not expected on main branch\nUsage: $0"
-    fi
-    handle_main_branch
-else
-    if [[ $# -ne 1 ]]; then
-        log_error "Version argument required when on release branch\nUsage: $0 <version>"
-    fi
-    validate_version "$1"
-    handle_release_branch "$1"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
 fi

--- a/release.sh
+++ b/release.sh
@@ -7,8 +7,8 @@
 # 3. refresh a release PR after merging/rebasing main: ./release.sh changelog <version>
 # 4. verify that a release changelog covers every merged PR: ./release.sh verify-changelog [version]
 #
-# Set DELTA_KERNEL_RELEASE_REGISTRY when cargo-release must resolve through another registry:
-#   DELTA_KERNEL_RELEASE_REGISTRY=databricks-proxy ./release.sh 0.29.0
+# Set DELTA_KERNEL_RELEASE_REGISTRY when cargo-release must use an alternate registry:
+#   DELTA_KERNEL_RELEASE_REGISTRY=<registry-name> ./release.sh 0.29.0
 ###################################################################################################
 
 # This is a script to automate a large portion of the release process for the crates we publish to

--- a/release.sh
+++ b/release.sh
@@ -55,6 +55,8 @@ check_changelog_requirements() {
 check_changelog_verification_requirements() {
     command -v cargo >/dev/null 2>&1 || log_error "cargo is required but not installed"
     command -v git >/dev/null 2>&1 || log_error "git is required but not installed"
+    command -v git-cliff >/dev/null 2>&1 || \
+        log_error "git-cliff is required but not installed. Install with: cargo install git-cliff"
     command -v jq >/dev/null 2>&1 || log_error "jq is required but not installed"
 }
 
@@ -107,11 +109,11 @@ run_cargo_release() {
     cargo "${args[@]}"
 }
 
-# Return the highest merged Kernel release tag. Other artifacts use suffixed tags such as
-# v0.0.1_dat; accepting those as Kernel releases can silently drop commits from the changelog.
+# Ask git-cliff for the latest Kernel release so changelog generation and verification use the
+# same tag grammar from cliff.toml.
 latest_kernel_release_tag() {
-    git -C "$REPO_ROOT" tag --merged HEAD --sort=-version:refname | \
-        awk '/^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$/ { print; exit }'
+    git cliff --repository "$REPO_ROOT" --config "$REPO_ROOT/cliff.toml" --latest --context | \
+        jq -r '.[0].version // empty'
 }
 
 release_changelog_section() {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Harden the Kernel release workflow:

- allow maintainers to select an alternate Cargo registry without editing `release.sh`
- add an idempotent changelog refresh command plus CI verification so PRs merged while a release
  PR is open cannot be silently omitted
- restrict Kernel release boundaries to semantic-version tags so artifact tags such as
  `v0.0.1_dat` cannot truncate the changelog

Changelog verification uses git-cliff's own filtered commit context and reachable branch tags,
runs only on `release/` branches, and fails closed if its tooling cannot resolve the release range.
A failed refresh restores the existing changelog.

This complements #3066, which handles independently versioned UC crates. Its suffixed per-crate
tags are deliberately excluded from Kernel changelog boundaries.

## How was this change tested?

- `.github/scripts/test-release.sh` with git-cliff 2.10.1, covering alternate-registry forwarding,
  artifact and divergent tags, late PRs, skipped release commits, idempotent refresh, and failure
  restoration
- `./release.sh verify-changelog`
- `bash -n` and ShellCheck 0.10.0
- actionlint 1.7.7
- `cargo +nightly fmt -- --check`
- `cargo doc --workspace --all-features --no-deps`
