### PR TITLE
feat: add geometry arrow stats conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1338,7 @@ version = "0.28.0"
 dependencies = [
  "arrow 58.1.0",
  "arrow 59.0.0",
+ "arrow-array 58.1.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -1337,6 +1347,8 @@ dependencies = [
  "delta_kernel",
  "delta_kernel_derive",
  "futures",
+ "geoarrow-array",
+ "geoarrow-schema",
  "hdfs-native",
  "hdfs-native-object-store",
  "indexmap",
@@ -1871,6 +1883,55 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geo-traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
+dependencies = [
+ "geo-types",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "geoarrow-array"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dafe7b7de3fab1a8b7099fd6a6434ca955fa65065f9c19f0f8a133693f3c2b0e"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
+ "geo-traits",
+ "geoarrow-schema",
+ "num-traits",
+ "wkb",
+ "wkt",
+]
+
+[[package]]
+name = "geoarrow-schema"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4a7edb2a1d87024a93805332a9c8184a0354836271d42c0d18cf628a5e3cd0"
+dependencies = [
+ "arrow-schema 58.1.0",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2799,6 +2860,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5600,6 +5683,31 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wkb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a120b336c7ad17749026d50427c23d838ecb50cd64aaea6254b5030152f890a9"
+dependencies = [
+ "byteorder",
+ "geo-traits",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wkt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -65,6 +65,9 @@ z85 = "3.0.6"
 reqwest = { version = "0.13", default-features = false, optional = true }
 # both arrow versions below are optional and require object_store
 object_store_13 = { package = "object_store", version = "0.13.2", optional = true, features = ["aws", "azure", "gcp", "http"] }
+geoarrow-array = { version = "0.8.0", optional = true }
+geoarrow-schema = { version = "0.8.0", optional = true }
+geoarrow_arrow_array_58 = { package = "arrow-array", version = "58", optional = true }
 
 # arrow 58
 [dependencies.arrow_58]
@@ -131,7 +134,11 @@ check-constraints-in-dev = []
 adaptive-metadata-in-dev = []
 # Experimental, temporary, test-only feature flag guarding the in-progress geospatial
 # (geometry/geography) type work. TODO(#2949): remove once full geo support ships.
-geo-type-in-dev = []
+geo-type-in-dev = [
+  "dep:geoarrow-array",
+  "dep:geoarrow-schema",
+  "dep:geoarrow_arrow_array_58",
+]
 # Experimental feature flag guarding Row Tracking preservation for file removals and
 # deletion-vector updates. TODO(#3227): remove the flag and emit `delta.rowTracking.preserved` in
 # CommitInfo tags when preservation support is ready.

--- a/kernel/src/engine/arrow_conversion/geo.rs
+++ b/kernel/src/engine/arrow_conversion/geo.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use serde_json::json;
+
+use crate::schema::GeometryType;
+
+pub(crate) const GEOARROW_EXTENSION_NAME_KEY: &str = "ARROW:extension:name";
+pub(crate) const GEOARROW_EXTENSION_METADATA_KEY: &str = "ARROW:extension:metadata";
+pub(crate) const GEOARROW_WKB_EXTENSION_NAME: &str = "geoarrow.wkb";
+
+pub(crate) fn geometry_geoarrow_metadata(geometry: &GeometryType) -> HashMap<String, String> {
+    HashMap::from([
+        (
+            GEOARROW_EXTENSION_NAME_KEY.to_string(),
+            GEOARROW_WKB_EXTENSION_NAME.to_string(),
+        ),
+        (
+            GEOARROW_EXTENSION_METADATA_KEY.to_string(),
+            json!({
+                "crs": geometry.crs(),
+                "crs_type": "authority_code",
+            })
+            .to_string(),
+        ),
+    ])
+}

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -15,6 +15,8 @@
 //! [`DefaultExpressionEvaluator`][crate::engine::arrow_expression::DefaultExpressionEvaluator]
 //! converts the logical schema to an Arrow schema as the output schema.
 
+#[cfg(feature = "geo-type-in-dev")]
+pub(crate) mod geo;
 pub mod scalar;
 
 use std::collections::HashMap;
@@ -183,6 +185,10 @@ impl TryFromKernel<&StructField> for ArrowField {
         // retained in Arrow; its content is processed by `kernel_field_into_arrow`.
         metadata.remove(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
         let arrow_type = kernel_field_into_arrow(f, f.name(), f.data_type())?;
+        #[cfg(feature = "geo-type-in-dev")]
+        if let DataType::Primitive(PrimitiveType::Geometry(geometry)) = f.data_type() {
+            metadata.extend(geo::geometry_geoarrow_metadata(geometry));
+        }
         Ok(ArrowField::new(f.name(), arrow_type, f.is_nullable()).with_metadata(metadata))
     }
 }
@@ -372,11 +378,11 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                     PrimitiveType::IntervalYearMonth => Ok(ArrowDataType::Int32),
                     PrimitiveType::IntervalDayTime => Ok(ArrowDataType::Int64),
                     #[cfg(feature = "geo-type-in-dev")]
-                    PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
-                        Err(ArrowError::SchemaError(format!(
-                            "Geo types are not yet supported in the default engine: {p}"
-                        )))
-                    }
+                    PrimitiveType::Geometry(_) => Ok(ArrowDataType::Binary),
+                    #[cfg(feature = "geo-type-in-dev")]
+                    PrimitiveType::Geography(_) => Err(ArrowError::SchemaError(format!(
+                        "Geo types are not yet supported in the default engine: {p}"
+                    ))),
                 }
             }
             DataType::Struct(s) => Ok(ArrowDataType::Struct(
@@ -681,12 +687,7 @@ mod tests {
 
     #[cfg(feature = "geo-type-in-dev")]
     #[rstest]
-    #[case(geometry_type("EPSG:4326"))]
     #[case(geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical))]
-    #[case(DataType::from(schema! {
-        nullable "g": (geometry_type("EPSG:4326")),
-    }))]
-    #[case(DataType::from(ArrayType::new(geometry_type("EPSG:4326"), true)))]
     #[case(DataType::from(MapType::new(
         DataType::STRING,
         geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical),
@@ -696,6 +697,47 @@ mod tests {
         let result: Result<ArrowDataType, _> = (&dt).try_into_arrow();
         let err = result.unwrap_err();
         assert!(matches!(err, ArrowError::SchemaError(_)), "got: {err:?}");
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn test_geometry_type_arrow_conversion_uses_binary() -> DeltaResult<()> {
+        let arrow_type = ArrowDataType::try_from_kernel(&geometry_type("EPSG:4326"))?;
+        assert_eq!(arrow_type, ArrowDataType::Binary);
+        Ok(())
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn test_geometry_field_arrow_conversion_adds_geoarrow_metadata() -> DeltaResult<()> {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "description",
+            MetadataValue::String("bbox corner".to_owned()),
+        );
+        let field =
+            StructField::nullable("geom", geometry_type("EPSG:4326")).with_metadata(metadata);
+
+        let arrow_field = ArrowField::try_from_kernel(&field)?;
+
+        assert_eq!(arrow_field.data_type(), &ArrowDataType::Binary);
+        assert_eq!(
+            arrow_field.metadata().get("ARROW:extension:name"),
+            Some(&"geoarrow.wkb".to_owned())
+        );
+        assert_eq!(
+            arrow_field.metadata().get("description"),
+            Some(&"bbox corner".to_owned())
+        );
+        let extension_metadata = arrow_field
+            .metadata()
+            .get("ARROW:extension:metadata")
+            .expect("geometry Arrow field should include GeoArrow extension metadata");
+        let extension_metadata: serde_json::Value = serde_json::from_str(extension_metadata)
+            .expect("GeoArrow extension metadata should be valid JSON");
+        assert_eq!(extension_metadata["crs"], "EPSG:4326");
+        assert_eq!(extension_metadata["crs_type"], "authority_code");
+        Ok(())
     }
 
     #[test]

--- a/kernel/src/engine/arrow_geometry.rs
+++ b/kernel/src/engine/arrow_geometry.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+
+use geoarrow_array::array::WktArray;
+use geoarrow_array::cast::to_wkb;
+use geoarrow_arrow_array_58::StringArray as GeoStringArray;
+use geoarrow_schema::Metadata as GeoArrowMetadata;
+
+use crate::{DeltaResult, Error};
+
+pub(crate) fn wkt_to_wkb_bytes(raw: &str) -> DeltaResult<Vec<u8>> {
+    let wkt = WktArray::new(
+        GeoStringArray::from(vec![Some(raw)]),
+        Arc::new(GeoArrowMetadata::default()),
+    );
+    let wkb = to_wkb::<i32>(&wkt).map_err(geoarrow_error)?;
+    Ok(wkb.inner().value(0).to_vec())
+}
+
+fn geoarrow_error(err: impl std::fmt::Display) -> Error {
+    Error::generic(format!("Invalid geometry stats value: {err}"))
+}

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -13,6 +13,8 @@ use tracing::debug;
 
 use self::apply_schema::apply_schema_to_struct;
 use crate::arrow::array::cast::AsArray;
+#[cfg(feature = "geo-type-in-dev")]
+use crate::arrow::array::BinaryBuilder;
 use crate::arrow::array::{
     make_array, new_null_array, Array as ArrowArray, ArrayRef as ArrowArrayRef, GenericListArray,
     MapArray, OffsetSizeTrait, PrimitiveArray, RecordBatch, RecordBatchOptions, StringArray,
@@ -26,8 +28,14 @@ use crate::arrow::datatypes::{
 };
 use crate::arrow::json::writer::{make_encoder, LineDelimited, NullableEncoder};
 use crate::arrow::json::{Encoder, EncoderFactory, EncoderOptions, ReaderBuilder, WriterBuilder};
+#[cfg(feature = "geo-type-in-dev")]
+use crate::engine::arrow_conversion::geo::{
+    GEOARROW_EXTENSION_NAME_KEY, GEOARROW_WKB_EXTENSION_NAME,
+};
 use crate::engine::arrow_conversion::{TryFromKernel as _, TryIntoArrow as _};
 use crate::engine::arrow_data::ArrowEngineData;
+#[cfg(feature = "geo-type-in-dev")]
+use crate::engine::arrow_geometry::wkt_to_wkb_bytes;
 use crate::engine::ensure_data_types::DataTypeCompat;
 use crate::engine_data::FilteredEngineData;
 use crate::parquet::arrow::arrow_reader::ArrowReaderMetadata;
@@ -1282,6 +1290,8 @@ impl<'a> SchemaTransform<'a> for StringifyFailureProneLeaves {
         use PrimitiveType::*;
         match ptype {
             Timestamp | TimestampNtz | Date | Decimal(_) => Cow::Owned(String),
+            #[cfg(feature = "geo-type-in-dev")]
+            Geometry(_) => Cow::Owned(String),
             _ => Cow::Borrowed(ptype),
         }
     }
@@ -1310,7 +1320,7 @@ fn safe_cast_back(decoded: RecordBatch, target: &ArrowSchemaRef) -> DeltaResult<
     let columns = columns
         .into_iter()
         .zip(target.fields().iter())
-        .map(|(arr, field)| cast_array_to_type(arr, field.data_type(), &opts))
+        .map(|(arr, field)| cast_array_to_field(arr, field, &opts))
         .collect::<DeltaResult<Vec<_>>>()?;
     Ok(RecordBatch::try_new_with_options(
         target.clone(),
@@ -1361,28 +1371,30 @@ pub(crate) fn coerce_columns_to_schema(
     columns
         .into_iter()
         .zip(target.fields().iter())
-        .map(|(arr, field)| cast_array_to_type(arr, field.data_type(), &opts))
+        .map(|(arr, field)| cast_array_to_field(arr, field, &opts))
         .collect()
 }
 
-/// Casts one Arrow [`ArrowArray`] of any type to `target`.
+/// Casts one Arrow [`ArrowArray`] of any type to `target`'s data type.
 ///
 /// A struct tracks which of its rows are null separately from its children, so casting a child
 /// means rebuilding the struct around it. This recurses into `Struct` by hand, carrying that
 /// row-level null information onto the rebuilt struct: given a struct column whose row 0 is null,
 /// row 0 is still null after the cast. Everything else, `Map` and `List` included, goes to
 /// [`cast_with_options`], which rebuilds the container using the field names in `target`.
+/// Geometry fields use `target`'s GeoArrow metadata to convert WKT strings to WKB bytes.
 ///
 /// `opts` decides what a failed leaf cast does: `safe: true` nulls the cell, strict errors.
-fn cast_array_to_type(
+fn cast_array_to_field(
     array: ArrowArrayRef,
-    target: &ArrowDataType,
+    target: &ArrowField,
     opts: &CastOptions<'_>,
 ) -> DeltaResult<ArrowArrayRef> {
-    if array.data_type() == target {
+    let target_type = target.data_type();
+    if array.data_type() == target_type {
         return Ok(array);
     }
-    match target {
+    match target_type {
         ArrowDataType::Struct(target_fields) => {
             let s = array.as_struct_opt().ok_or_else(|| {
                 Error::generic(format!(
@@ -1403,7 +1415,7 @@ fn cast_array_to_type(
                 .columns()
                 .iter()
                 .zip(target_fields.iter())
-                .map(|(c, f)| cast_array_to_type(c.clone(), f.data_type(), opts))
+                .map(|(c, f)| cast_array_to_field(c.clone(), f, opts))
                 .collect::<DeltaResult<Vec<_>>>()?;
             Ok(Arc::new(StructArray::try_new(
                 target_fields.clone(),
@@ -1411,8 +1423,69 @@ fn cast_array_to_type(
                 nulls,
             )?))
         }
-        _ => Ok(cast_with_options(&array, target, opts)?),
+        _ => {
+            #[cfg(feature = "geo-type-in-dev")]
+            if is_geoarrow_wkb_field(target) {
+                return cast_geometry_wkt_array_to_wkb(array, opts);
+            }
+            Ok(cast_with_options(&array, target_type, opts)?)
+        }
     }
+}
+
+#[cfg(feature = "geo-type-in-dev")]
+fn is_geoarrow_wkb_field(field: &ArrowField) -> bool {
+    field.data_type() == &ArrowDataType::Binary
+        && field
+            .metadata()
+            .get(GEOARROW_EXTENSION_NAME_KEY)
+            .is_some_and(|name| name == GEOARROW_WKB_EXTENSION_NAME)
+}
+
+#[cfg(feature = "geo-type-in-dev")]
+fn cast_geometry_wkt_array_to_wkb(
+    array: ArrowArrayRef,
+    opts: &CastOptions<'_>,
+) -> DeltaResult<ArrowArrayRef> {
+    match array.data_type() {
+        ArrowDataType::Binary => Ok(array),
+        ArrowDataType::Utf8 => Ok(Arc::new(append_geometry_wkt_values(
+            array.as_string::<i32>().iter(),
+            array.len(),
+            opts.safe,
+        )?)),
+        ArrowDataType::LargeUtf8 => Ok(Arc::new(append_geometry_wkt_values(
+            array.as_string::<i64>().iter(),
+            array.len(),
+            opts.safe,
+        )?)),
+        ArrowDataType::Utf8View => Ok(Arc::new(append_geometry_wkt_values(
+            array.as_string_view().iter(),
+            array.len(),
+            opts.safe,
+        )?)),
+        _ => Ok(cast_with_options(&array, &ArrowDataType::Binary, opts)?),
+    }
+}
+
+#[cfg(feature = "geo-type-in-dev")]
+fn append_geometry_wkt_values<'a>(
+    values: impl Iterator<Item = Option<&'a str>>,
+    len: usize,
+    safe: bool,
+) -> DeltaResult<crate::arrow::array::BinaryArray> {
+    let mut builder = BinaryBuilder::with_capacity(len, 0);
+    for value in values {
+        match value {
+            Some(raw) if !raw.is_empty() => match wkt_to_wkb_bytes(raw) {
+                Ok(bytes) => builder.append_value(bytes),
+                Err(_) if safe => builder.append_null(),
+                Err(err) => return Err(err),
+            },
+            _ => builder.append_null(),
+        }
+    }
+    Ok(builder.finish())
 }
 
 pub(crate) fn filter_to_record_batch(
@@ -1592,6 +1665,8 @@ mod tests {
     };
     use crate::table_features::ColumnMappingMode;
     use crate::unit_test_utils::assert_result_error_with_message;
+    #[cfg(feature = "geo-type-in-dev")]
+    use crate::unit_test_utils::geometry_type;
 
     fn column_mapping_cases() -> [ColumnMappingMode; 3] {
         [
@@ -2009,6 +2084,60 @@ mod tests {
         // UserId min/max stay populated on every row even when the sibling EventTime fails.
         assert_eq!(min_user.null_count(), 0);
         assert_eq!(max_user.null_count(), 0);
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn test_parse_json_impl_geometry_stats_parse_to_binary() {
+        let schema = schema_ref! {
+            nullable "minValues": {
+                nullable "geom": (geometry_type("EPSG:4326")),
+            },
+            nullable "maxValues": {
+                nullable "geom": (geometry_type("EPSG:4326")),
+            },
+        };
+        let inputs: Vec<Option<&str>> = vec![Some(
+            r#"{"minValues": {"geom": "POINT(-122.419 37.774)"},
+                "maxValues": {"geom": "LINESTRING(-122.419 37.774, -120.503 38.021)"}}"#,
+        )];
+
+        let batch = parse_json_impl(&StringArray::from(inputs), schema).unwrap();
+        let min_values = batch.column_by_name("minValues").unwrap().as_struct();
+        let max_values = batch.column_by_name("maxValues").unwrap().as_struct();
+        let min_geom = min_values.column_by_name("geom").unwrap();
+        let max_geom = max_values.column_by_name("geom").unwrap();
+
+        assert_eq!(min_geom.data_type(), &ArrowDataType::Binary);
+        assert_eq!(max_geom.data_type(), &ArrowDataType::Binary);
+        assert!(!min_geom.as_binary::<i32>().value(0).is_empty());
+        assert!(!max_geom.as_binary::<i32>().value(0).is_empty());
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn test_parse_json_impl_geometry_stats_bad_values_become_null() {
+        let schema = schema_ref! {
+            nullable "minValues": {
+                nullable "geom": (geometry_type("EPSG:4326")),
+            },
+            nullable "maxValues": {
+                nullable "geom": (geometry_type("EPSG:4326")),
+            },
+        };
+        let inputs: Vec<Option<&str>> = vec![Some(
+            r#"{"minValues": {"geom": ""},
+                "maxValues": {"geom": "not-wkt"}}"#,
+        )];
+
+        let batch = parse_json_impl(&StringArray::from(inputs), schema).unwrap();
+        let min_values = batch.column_by_name("minValues").unwrap().as_struct();
+        let max_values = batch.column_by_name("maxValues").unwrap().as_struct();
+        let min_geom = min_values.column_by_name("geom").unwrap();
+        let max_geom = max_values.column_by_name("geom").unwrap();
+
+        assert!(min_geom.is_null(0));
+        assert!(max_geom.is_null(0));
     }
 
     #[test]

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -42,6 +42,8 @@ pub mod arrow_utils;
 pub(crate) mod arrow_utils;
 #[cfg(all(feature = "internal-api", feature = "arrow-expression"))]
 pub use self::arrow_utils::{parse_json, to_json_bytes};
+#[cfg(all(feature = "arrow-expression", feature = "geo-type-in-dev"))]
+pub(crate) mod arrow_geometry;
 
 // The plan executor support modules read Arrow data (`arrow_utils`, `arrow_data`), so they
 // require the Arrow engine base in addition to the declarative-plans IR.


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds the Arrow foundation for geometry support in the default engine.
Kernel `GeometryType` values now map to physical Arrow `Binary` fields with GeoArrow WKB
extension metadata, while geography remains unsupported in Arrow conversion for now.

It also teaches `parse_json_impl` to handle geometry stats encoded as WKT strings. The JSON path
decodes geometry leaves through a string-first schema, converts valid WKT values to WKB bytes, and
keeps invalid geometry stats isolated to null cells in the parsed stats batch.

## How was this change tested?

```bash
cargo test -p delta_kernel --lib --features 'arrow-59 default-engine-base geo-type-in-dev test-utils' geometry -- --nocapture
cargo test -p delta_kernel --lib --features 'arrow-58 default-engine-base geo-type-in-dev test-utils' geometry -- --nocapture
cargo test -p delta_kernel --lib --features 'arrow-59 default-engine-base geo-type-in-dev test-utils' parse_json_safe_cast -- --nocapture
cargo clippy -p delta_kernel --benches --tests --features 'arrow-59 default-engine-base geo-type-in-dev test-utils' -- -D warnings
cargo check -p delta_kernel --no-default-features --features geo-type-in-dev
cargo nextest run --workspace --all-features
```
