### PR TITLE
feat: add ScanBuilder::with_planner to restrict a scan's file set

### DIFF
--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -144,6 +144,8 @@ pub struct SerializableScanState {
 /// - Action Deduplication: Leverages the [`FileActionDeduplicator`] to ensure that for each unique
 ///   file (identified by its path and deletion vector unique ID), only the latest valid Add action
 ///   is processed.
+/// - Planner Restriction: If the scan has a [`ScanPlanner`](crate::scan::ScanPlanner), Adds it did
+///   not name are dropped in the same pass, after deduplication.
 /// - Parse-error fallback: If transformation and data skipping return [`Error::ParseError`],
 ///   deduplicates the raw batch first, then retries transformation and data skipping on the
 ///   surviving actions.
@@ -176,6 +178,8 @@ pub struct ScanLogReplayProcessor {
     partition_values_options: ScanPartitionValuesOptions,
     /// Information about checkpoint reading for stats optimization
     checkpoint_info: CheckpointReadInfo,
+    /// Files a [`ScanPlanner`](crate::scan::ScanPlanner) allowed, or `None` without a planner.
+    planned_files: Option<HashSet<FileActionKey>>,
     /// Metrics related to the scan
     metrics: Arc<ScanMetrics>,
 }
@@ -344,6 +348,7 @@ impl ScanLogReplayProcessor {
             stats_options,
             partition_values_options,
             checkpoint_info,
+            planned_files: None,
             metrics,
         })
     }
@@ -578,6 +583,8 @@ struct AddRemoveDedupVisitor<'a, D: Deduplicator> {
     state_info: Arc<StateInfo>,
     row_transform_exprs: Vec<Option<ExpressionRef>>,
     active_add_file_sizes: Vec<u64>,
+    /// Logical files the scan's planner allowed, or `None` without a planner.
+    planned_files: Option<&'a HashSet<FileActionKey>>,
     metrics: &'a ScanMetrics,
 }
 
@@ -586,6 +593,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         deduplicator: D,
         selection_vector: Vec<bool>,
         state_info: Arc<StateInfo>,
+        planned_files: Option<&'a HashSet<FileActionKey>>,
         metrics: &'a ScanMetrics,
     ) -> AddRemoveDedupVisitor<'a, D> {
         let active_add_file_sizes = vec![0; selection_vector.len()];
@@ -595,6 +603,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
             state_info,
             row_transform_exprs: Vec::new(),
             active_add_file_sizes,
+            planned_files,
             metrics,
         }
     }
@@ -647,8 +656,13 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
             self.metrics.incr_remove_files_seen_from_delta_files();
         };
 
-        // Check both adds and removes (skipping already-seen), but only transform and return adds
-        if self.deduplicator.check_and_record_seen(file_key) || !is_add {
+        // Check both adds and removes (skipping already-seen), but only transform and return adds.
+        // The planner check comes after the key is recorded, so a planner-pruned Add still shadows
+        // older actions for the same logical file.
+        let planned = self
+            .planned_files
+            .is_none_or(|planned| planned.contains(&file_key));
+        if self.deduplicator.check_and_record_seen(file_key) || !is_add || !planned {
             return Ok(false);
         }
 
@@ -986,6 +1000,7 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
                 deduplicator,
                 pre_dedup_selection,
                 self.state_info.clone(),
+                self.planned_files.as_ref(),
                 &self.metrics,
             );
             visitor.visit_rows_of(actions.as_ref())?;
@@ -1085,6 +1100,7 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
                 deduplicator,
                 pre_dedup_selection,
                 self.state_info.clone(),
+                self.planned_files.as_ref(),
                 &self.metrics,
             );
             visitor.visit_rows_of(actions.as_ref())?;
@@ -1145,6 +1161,9 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
 /// files and columnar data skipping is disabled (no stats-based or partition-value-based
 /// pruning), but row-level partition filtering still applies.
 ///
+/// When `planned_files` is set, only Adds it contains are selected; Removes and deduplication are
+/// unaffected.
+///
 /// Note: The iterator of [`ActionsBatch`]s ('action_iter' parameter) must be sorted by the order of
 /// the actions in the log from most recent to least recent.
 pub(crate) fn scan_action_iter(
@@ -1154,17 +1173,19 @@ pub(crate) fn scan_action_iter(
     checkpoint_info: CheckpointReadInfo,
     stats_options: ScanStatsOptions,
     partition_values_options: ScanPartitionValuesOptions,
+    planned_files: Option<HashSet<FileActionKey>>,
 ) -> DeltaResult<(
     impl Iterator<Item = DeltaResult<ScanMetadata>>,
     Arc<ScanMetrics>,
 )> {
-    let processor = ScanLogReplayProcessor::new(
+    let mut processor = ScanLogReplayProcessor::new(
         engine,
         state_info,
         checkpoint_info,
         stats_options,
         partition_values_options,
     )?;
+    processor.planned_files = planned_files;
     let metrics = processor.metrics.clone();
     Ok((processor.process_actions_iter(action_iter), metrics))
 }
@@ -1317,6 +1338,7 @@ mod tests {
             test_checkpoint_info(),
             ScanStatsOptions::default(),
             ScanPartitionValuesOptions::default(),
+            None,
         )
         .unwrap();
         for res in iter {
@@ -1346,6 +1368,7 @@ mod tests {
             test_checkpoint_info(),
             ScanStatsOptions::default(),
             ScanPartitionValuesOptions::default(),
+            None,
         )
         .unwrap();
 
@@ -1429,6 +1452,7 @@ mod tests {
             test_checkpoint_info(),
             ScanStatsOptions::default(),
             ScanPartitionValuesOptions::default(),
+            None,
         )
         .unwrap();
 
@@ -1492,6 +1516,7 @@ mod tests {
             test_checkpoint_info(),
             ScanStatsOptions::default(),
             ScanPartitionValuesOptions::default(),
+            None,
         )?;
 
         let mut iter = iter.peekable();
@@ -1948,6 +1973,7 @@ mod tests {
                 ..Default::default()
             },
             ScanPartitionValuesOptions::default(),
+            None,
         )
         .unwrap();
 
@@ -2031,6 +2057,7 @@ mod tests {
             test_checkpoint_info(),
             ScanStatsOptions::default(),
             ScanPartitionValuesOptions::default(),
+            None,
         )
         .unwrap();
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -47,8 +47,8 @@ use crate::table_features::{ColumnMappingMode, Operation};
 use crate::transforms::{transform_output_type, ExpressionTransform, SchemaTransform};
 use crate::utils::{FoldWithOption as _, IteratorExt};
 use crate::{
-    DeltaResult, DeltaResultIteratorStatic, Engine, EngineData, Error, FileMeta, SnapshotRef,
-    Version,
+    AsAny, DeltaResult, DeltaResultIteratorStatic, Engine, EngineData, Error, FileMeta,
+    SnapshotRef, Version,
 };
 
 pub(crate) mod data_skipping;
@@ -86,6 +86,7 @@ pub(crate) static CHECKPOINT_READ_SCHEMA_NO_JSON_STATS: LazyLock<SchemaRef> = La
     }
 });
 
+pub use crate::log_replay::FileActionKey;
 #[allow(unused)]
 pub use crate::parallel::parallel_scan_metadata::{
     AfterSequentialScanMetadata, ParallelScanMetadata, ParallelState, SequentialScanMetadata,
@@ -251,6 +252,36 @@ impl PartitionValuesOptions {
     }
 }
 
+/// A shared reference to a [`ScanPlanner`].
+pub type ScanPlannerRef = Arc<dyn ScanPlanner>;
+
+/// An engine-supplied restriction on the logical files a scan may read; see
+/// [`ScanBuilder::with_planner`].
+///
+/// Log replay runs unchanged and its live file set is intersected with the planner's answer, so a
+/// planner can remove files from a listing but never add one, and every listed file's deletion
+/// vector, partition values, stats and transform still come from the log.
+///
+/// Files are identified as log replay identifies them, by `(path, deletionVector.uniqueId)` as a
+/// [`FileActionKey`]; a path alone does not match a file that carries a deletion vector. How an
+/// implementation produces its answer, including any serialization of the predicate it receives,
+/// is its own concern: kernel defines no wire format.
+pub trait ScanPlanner: AsAny {
+    /// Returns the logical files the scan may read at `snapshot_version` of the table at
+    /// `table_root`.
+    ///
+    /// `predicate` is the scan predicate as the caller set it (logical column names), if any. It
+    /// is a hint: an implementation may ignore it and answer with a superset, since kernel still
+    /// applies data skipping and the engine still evaluates the predicate on rows. An error fails
+    /// the scan.
+    fn plan(
+        &self,
+        table_root: &Url,
+        snapshot_version: Version,
+        predicate: Option<&Predicate>,
+    ) -> DeltaResult<HashSet<FileActionKey>>;
+}
+
 /// Builder to scan a snapshot of a table.
 pub struct ScanBuilder {
     snapshot: SnapshotRef,
@@ -261,6 +292,7 @@ pub struct ScanBuilder {
     without_row_transforms: bool,
     partition_values: PartitionValuesOptions,
     cancellation_token: Option<CancellationTokenRef>,
+    planner: Option<ScanPlannerRef>,
 }
 
 impl std::fmt::Debug for ScanBuilder {
@@ -288,6 +320,7 @@ impl ScanBuilder {
             without_row_transforms: false,
             partition_values: PartitionValuesOptions::default(),
             cancellation_token: None,
+            planner: None,
         }
     }
 
@@ -403,6 +436,20 @@ impl ScanBuilder {
         self
     }
 
+    /// Restrict the scan to the logical files named by a [`ScanPlanner`]; without one the listing
+    /// is unchanged.
+    ///
+    /// The planner is consulted once per [`scan_metadata`](Scan::scan_metadata) call, not at
+    /// build time and not when the predicate is statically false. A planner error is returned
+    /// from `scan_metadata` rather than falling back to the unplanned listing: the caller gave the
+    /// planner authority over the file set, and a silent fallback would hide a wrong answer.
+    /// [`parallel_scan_metadata`](Scan::parallel_scan_metadata) rejects a planner rather than
+    /// ignoring it.
+    pub fn with_planner(mut self, planner: impl Into<Option<ScanPlannerRef>>) -> Self {
+        self.planner = planner.into();
+        self
+    }
+
     /// Build the [`Scan`].
     ///
     /// This does not scan the table at this point, but does do some work to ensure that the
@@ -437,7 +484,7 @@ impl ScanBuilder {
             logical_read_schema,
             table_schema,
             self.snapshot.table_configuration(),
-            self.predicate,
+            self.predicate.clone(),
             &self.stats,
             &self.partition_values,
             (), // No classifier, default is for scans
@@ -461,6 +508,8 @@ impl ScanBuilder {
             correlation_id: self.correlation_id,
             partition_values: self.partition_values,
             cancellation_token: self.cancellation_token,
+            predicate: self.predicate,
+            planner: self.planner,
         })
     }
 }
@@ -719,6 +768,11 @@ pub struct Scan {
     /// Optional cooperative cancellation token supplied via
     /// [`ScanBuilder::with_cancellation_token`]. `None` means the scan is not cancellable.
     cancellation_token: Option<CancellationTokenRef>,
+    /// The predicate as the caller set it (logical column names), handed to the planner; the
+    /// physical rewrite used for data skipping is in `state_info`.
+    predicate: Option<PredicateRef>,
+    /// Optional planner supplied via [`ScanBuilder::with_planner`].
+    planner: Option<ScanPlannerRef>,
 }
 
 /// Builds the physical `stats_parsed` output schema requested through `StatsOptions`.
@@ -1058,6 +1112,19 @@ impl Scan {
                 (None, Arc::new(ScanMetrics::default()))
             }
             _ => {
+                // The planner only narrows replay's answer, so it is not consulted for a
+                // statically false predicate, which lists nothing anyway.
+                let planned_files = self
+                    .planner
+                    .as_ref()
+                    .map(|planner| {
+                        planner.plan(
+                            self.snapshot.table_root(),
+                            self.snapshot.version(),
+                            self.predicate.as_deref(),
+                        )
+                    })
+                    .transpose()?;
                 // Wrap the input iterator (not the shared `process_actions_iter`) so token
                 // polling stays scoped to scans.
                 let actions = CancellableIterator::new(
@@ -1071,6 +1138,7 @@ impl Scan {
                     actions_with_checkpoint_info.checkpoint_info,
                     self.stats_options(),
                     self.partition_values_options(),
+                    planned_files,
                 )?;
                 (Some(it), m)
             }
@@ -1105,8 +1173,17 @@ impl Scan {
     /// # Errors
     ///
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
-    /// or if log discovery, checkpoint inspection, or plan construction fails.
+    /// if the scan has a [`ScanPlanner`] (the declarative plan does not apply it), or if log
+    /// discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
+        // The declarative plan never runs log replay's per-file visitor, so a planner's answer
+        // would be silently ignored; fail fast instead.
+        if self.planner.is_some() {
+            return Err(Error::unsupported(
+                "a scan planner is not supported by declarative_metadata_scan_plan; \
+                 use scan_metadata for a planner-restricted scan",
+            ));
+        }
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
         // whether the checkpoint carries a compatible parsed-stats column.
         let plan_executor = engine.require_plan_executor()?;
@@ -1208,7 +1285,8 @@ impl Scan {
     ///
     /// Cancellation is not supported on this path: it errors if a token was set via
     /// [`ScanBuilder::with_cancellation_token`], rather than silently running to completion.
-    /// Only [`scan_metadata`](Self::scan_metadata) honors the token today.
+    /// Only [`scan_metadata`](Self::scan_metadata) honors the token today. Likewise a
+    /// [`ScanPlanner`] set via [`ScanBuilder::with_planner`] is rejected rather than ignored.
     ///
     /// # Example
     ///
@@ -1270,6 +1348,14 @@ impl Scan {
             return Err(Error::unsupported(
                 "cancellation is not supported by parallel_scan_metadata; \
                  use scan_metadata for a cancellable scan",
+            ));
+        }
+        // Likewise for a planner: the distributed phase rebuilds its processor from serialized
+        // state, which does not carry the planner's answer.
+        if self.planner.is_some() {
+            return Err(Error::unsupported(
+                "a scan planner is not supported by parallel_scan_metadata; \
+                 use scan_metadata for a planner-restricted scan",
             ));
         }
         // For the sequential/parallel phase approach, we use a conservative checkpoint_info

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -182,6 +182,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         checkpoint_info,
         ScanStatsOptions::default(),
         ScanPartitionValuesOptions::default(),
+        None,
     )
     .unwrap();
     let mut batch_count = 0;

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -721,6 +721,247 @@ fn test_scan_metadata_from_with_update() {
     assert_eq!(new_files[1].num_rows(), 3);
 }
 
+/// A [`ScanPlanner`] that answers with a fixed file set and records every request it receives.
+struct FixedPlanner {
+    files: HashSet<FileActionKey>,
+    requests: Mutex<Vec<(Url, Version, Option<Pred>)>>,
+}
+
+impl FixedPlanner {
+    fn new(files: impl IntoIterator<Item = FileActionKey>) -> Self {
+        Self {
+            files: files.into_iter().collect(),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn requests(&self) -> Vec<(Url, Version, Option<Pred>)> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl ScanPlanner for FixedPlanner {
+    fn plan(
+        &self,
+        table_root: &Url,
+        snapshot_version: Version,
+        predicate: Option<&Pred>,
+    ) -> DeltaResult<HashSet<FileActionKey>> {
+        self.requests.lock().unwrap().push((
+            table_root.clone(),
+            snapshot_version,
+            predicate.cloned(),
+        ));
+        Ok(self.files.clone())
+    }
+}
+
+/// A [`ScanPlanner`] that always fails.
+struct FailingPlanner;
+
+impl ScanPlanner for FailingPlanner {
+    fn plan(
+        &self,
+        _table_root: &Url,
+        _snapshot_version: Version,
+        _predicate: Option<&Pred>,
+    ) -> DeltaResult<HashSet<FileActionKey>> {
+        Err(Error::generic("planner unavailable"))
+    }
+}
+
+/// The six live files of `./tests/data/basic_partitioned/` at its latest version, sorted.
+const BASIC_PARTITIONED_FILES: [&str; 6] = [
+    "letter=__HIVE_DEFAULT_PARTITION__/part-00000-8eb7f29a-e6a1-436e-a638-bbf0a7953f09.c000.snappy.parquet",
+    "letter=a/part-00000-0dbe0cc5-e3bf-4fb0-b36a-b5fdd67fe843.c000.snappy.parquet",
+    "letter=a/part-00000-a08d296a-d2c5-4a99-bea9-afcea42ba2e9.c000.snappy.parquet",
+    "letter=b/part-00000-41954fb0-ef91-47e5-bd41-b75169c41c17.c000.snappy.parquet",
+    "letter=c/part-00000-27a17b8f-be68-485c-9c49-70c742be30c0.c000.snappy.parquet",
+    "letter=e/part-00000-847cf2d1-1247-4aa0-89ef-2f90c68ea51e.c000.snappy.parquet",
+];
+
+/// Loads the latest snapshot of `table` with a [`SyncEngine`].
+fn planner_test_snapshot(table: &str) -> (Arc<SyncEngine>, Arc<Snapshot>) {
+    let path = std::fs::canonicalize(PathBuf::from(table)).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = Arc::new(SyncEngine::new());
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    (engine, snapshot)
+}
+
+/// A planner naming `paths`, none of which carry a deletion vector.
+fn planner_for_paths(paths: &[&str]) -> ScanPlannerRef {
+    let files = paths.iter().map(|path| FileActionKey::new(*path, None));
+    Arc::new(FixedPlanner::new(files))
+}
+
+/// Collects every listed file as its `(path, dv_unique_id)` identity.
+fn get_file_keys_for_scan(scan: Scan, engine: &dyn Engine) -> DeltaResult<Vec<FileActionKey>> {
+    fn scan_metadata_callback(keys: &mut Vec<FileActionKey>, scan_file: ScanFile) {
+        let dv_unique_id = scan_file.dv_info.deletion_vector.map(|dv| dv.unique_id());
+        keys.push(FileActionKey::new(scan_file.path, dv_unique_id));
+    }
+    let mut keys = vec![];
+    for res in scan.scan_metadata(engine)? {
+        keys = res?.visit_scan_files(keys, scan_metadata_callback)?;
+    }
+    Ok(keys)
+}
+
+/// Builds a scan over `snapshot` with `predicate` and a planner that answers with an empty set,
+/// checking that building does not consult the planner.
+fn scan_with_empty_plan(snapshot: Arc<Snapshot>, predicate: &Pred) -> (Scan, Arc<FixedPlanner>) {
+    let planner = Arc::new(FixedPlanner::new([]));
+    let scan = snapshot
+        .scan_builder()
+        .with_predicate(Arc::new(predicate.clone()))
+        .with_planner(planner.clone() as ScanPlannerRef)
+        .build()
+        .unwrap();
+    assert!(
+        planner.requests().is_empty(),
+        "build must not consult the planner"
+    );
+    (scan, planner)
+}
+
+/// A planner's answer is intersected with log replay's: it can remove files from the listing but
+/// never add one, and absent (or `None`) the listing is unchanged.
+#[rstest]
+#[case::absent(None, &BASIC_PARTITIONED_FILES[..])]
+#[case::all(Some(&BASIC_PARTITIONED_FILES[..]), &BASIC_PARTITIONED_FILES[..])]
+#[case::subset(Some(&BASIC_PARTITIONED_FILES[1..3]), &BASIC_PARTITIONED_FILES[1..3])]
+#[case::unknown_path_is_not_added(
+    Some(&[BASIC_PARTITIONED_FILES[0], "letter=z/part-00000-not-in-the-log.c000.snappy.parquet"][..]),
+    &BASIC_PARTITIONED_FILES[..1]
+)]
+#[case::empty(Some(&[][..]), &[][..])]
+fn test_scan_planner_intersects_with_log_replay(
+    #[case] planned: Option<&[&str]>,
+    #[case] expected: &[&str],
+) {
+    let (engine, snapshot) = planner_test_snapshot("./tests/data/basic_partitioned/");
+    let scan = snapshot
+        .scan_builder()
+        .with_planner(planned.map(planner_for_paths))
+        .build()
+        .unwrap();
+    let mut files = get_files_for_scan(scan, engine.as_ref()).unwrap();
+    files.sort();
+    assert_eq!(files, expected);
+}
+
+/// A logical file is identified by `(path, deletionVector.uniqueId)`, not by path alone. The live
+/// file of `table-with-dv-small` was added without a deletion vector, then removed and re-added
+/// with one; naming its path with no DV id, or the wrong one, lists nothing.
+#[rstest]
+#[case::no_dv(None, false)]
+#[case::wrong_dv(Some("uvBn[lx{q8@P<9BNH/isA@2"), false)]
+#[case::exact_dv(Some("uvBn[lx{q8@P<9BNH/isA@1"), true)]
+fn test_scan_planner_matches_deletion_vector_identity(
+    #[case] dv_unique_id: Option<&str>,
+    #[case] matches: bool,
+) {
+    const PATH: &str = "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet";
+    let (engine, snapshot) = planner_test_snapshot("./tests/data/table-with-dv-small/");
+    let planned = FileActionKey::new(PATH, dv_unique_id.map(str::to_string));
+    let planner: ScanPlannerRef = Arc::new(FixedPlanner::new([planned.clone()]));
+    let scan = snapshot
+        .scan_builder()
+        .with_planner(planner)
+        .build()
+        .unwrap();
+    let keys = get_file_keys_for_scan(scan, engine.as_ref()).unwrap();
+    let expected: Vec<_> = matches.then_some(planned).into_iter().collect();
+    assert_eq!(keys, expected);
+}
+
+/// A planner failure is the caller's error, not a silent fallback to the unplanned listing.
+#[test]
+fn test_scan_planner_error_propagates() {
+    let (engine, snapshot) = planner_test_snapshot("./tests/data/basic_partitioned/");
+    let planner: ScanPlannerRef = Arc::new(FailingPlanner);
+    let scan = snapshot
+        .scan_builder()
+        .with_planner(planner)
+        .build()
+        .unwrap();
+    assert_result_error_with_message(scan.scan_metadata(engine.as_ref()), "planner unavailable");
+}
+
+/// The planner is consulted by `scan_metadata`, not `build`, and receives the table root, the
+/// snapshot version, and the predicate exactly as the caller set it.
+#[test]
+fn test_scan_planner_receives_table_root_version_and_predicate() {
+    let (engine, snapshot) = planner_test_snapshot("./tests/data/basic_partitioned/");
+    let predicate = Pred::is_not_null(col!("number"));
+    let (scan, planner) = scan_with_empty_plan(snapshot.clone(), &predicate);
+    assert!(get_files_for_scan(scan, engine.as_ref())
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        planner.requests(),
+        vec![(
+            snapshot.table_root().clone(),
+            snapshot.version(),
+            Some(predicate)
+        )]
+    );
+}
+
+/// Under column mapping the planner receives the logical predicate, not the physical rewrite
+/// kernel uses for its own data skipping.
+#[test]
+fn test_scan_planner_receives_logical_predicate_under_column_mapping() {
+    let table = "table-with-columnmapping-mode-name";
+    let tempdir = load_test_data("tests/golden_data", table).unwrap();
+    // Golden tables extract to `<name>/delta/` (with a sibling `expected/`).
+    let table_path = tempdir.path().join(table).join("delta");
+    let url = url::Url::from_directory_path(table_path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let predicate = Pred::is_not_null(col!("LongType"));
+    let (scan, planner) = scan_with_empty_plan(snapshot.clone(), &predicate);
+    assert_ne!(scan.physical_predicate().unwrap().as_ref(), &predicate);
+    // The table has two files; the empty plan removes both.
+    assert!(get_files_for_scan(scan, &engine).unwrap().is_empty());
+    assert_eq!(
+        planner.requests(),
+        vec![(
+            snapshot.table_root().clone(),
+            snapshot.version(),
+            Some(predicate)
+        )]
+    );
+}
+
+/// A statically false predicate already lists nothing, so the planner is not consulted.
+#[test]
+fn test_scan_planner_not_consulted_when_predicate_is_statically_false() {
+    let (engine, snapshot) = planner_test_snapshot("./tests/data/basic_partitioned/");
+    let (scan, planner) = scan_with_empty_plan(snapshot, &Pred::FALSE);
+    assert!(get_files_for_scan(scan, engine.as_ref())
+        .unwrap()
+        .is_empty());
+    assert!(planner.requests().is_empty());
+}
+
+/// Like cancellation, a planner is not threaded through `parallel_scan_metadata`, which fails
+/// fast rather than silently listing files the planner did not name.
+#[test]
+fn test_scan_planner_rejected_by_parallel_scan_metadata() {
+    let (engine, snapshot) = planner_test_snapshot("./tests/data/basic_partitioned/");
+    let scan = snapshot
+        .scan_builder()
+        .with_planner(planner_for_paths(&BASIC_PARTITIONED_FILES))
+        .build()
+        .unwrap();
+    assert_result_error_with_message(
+        scan.parallel_scan_metadata(engine),
+        "planner is not supported by parallel_scan_metadata",
+    );
+}
+
 #[test]
 fn test_get_partition_value() {
     let cases = [


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prototype for #3294 (for design review and discussion).

Adds an optional hook an engine can use to restrict the set of data files a scan reads,
the Kernel side of what delta-spark's `ServerSidePlanningClient` does (delta-io/delta#5623).

- `ScanPlanner::plan(table_root, version, predicate) -> HashSet<FileActionKey>`
- `ScanBuilder::with_planner(...)`; without a planner nothing changes
- One check in `AddRemoveDedupVisitor::is_valid_add`: an Add the planner did not name is
  dropped, after the key is recorded for dedup

The planner's answer is compared against the log replay, so it can remove files but never add
one; DVs, partition values, stats and row filtering are unchanged. 

Files are identified by the existing `FileActionKey` (`(path, deletionVector.uniqueId)`). 

The planner gets the predicate as the caller set it; how it serializes or evaluates it is its own concern. 

A planner error fails the scan. 

`parallel_scan_metadata` and the declarative plan reject a planner rather than ignore it.


### This PR affects the following public APIs

New: `scan::ScanPlanner`, `scan::ScanPlannerRef`, `scan::FileActionKey` (re-export),
`ScanBuilder::with_planner`.

## How was this change tested?
13 new unit test cases: 

- absent planner unchanged
- subset
- unknown path not added
- DV identity (wrong or missing DV id does not match)
- error propagation
- planner inputs including under column mapping
- statically false predicate
- parallel path rejection
- Full suite
- clippy `-D warnings`
- rustdoc pass