### PR TITLE
fix: harden multipart checkpoint validation

### DIFF
--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1599,8 +1599,8 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
             } if num_parts >= 2 && num_parts as usize == n => {
                 let index = usize::try_from(part_num)
                     .ok()
-                    .and_then(|part_num| part_num.checked_sub(1))
-                    .filter(|part_num| *part_num < n)
+                    .and_then(|index| index.checked_sub(1))
+                    .filter(|index| *index < num_parts as usize)
                     .ok_or_else(|| {
                         Error::invalid_checkpoint(format!(
                             "multi-part checkpoint part number {part_num} is outside 1..={num_parts}"
@@ -1614,6 +1614,7 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
                 );
                 seen_part_numbers[index] = true;
             }
+            // The protocol requires p > 1; path parsing only validates 1 <= part_num <= p.
             LogPathFileType::MultiPartCheckpoint { num_parts, .. } if num_parts < 2 => {
                 return Err(Error::invalid_checkpoint(format!(
                     "multi-part checkpoint must contain at least two parts but num_parts field says {num_parts}"

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1580,8 +1580,7 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
     }
     let n = parts.len();
     let first_version = parts[0].version;
-    // TODO(#3297): Validate multi-part checkpoint part-number range and uniqueness, and require
-    // more than one part.
+    let mut seen_part_numbers = vec![false; n];
     for p in parts {
         if !p.is_checkpoint() {
             return Err(Error::invalid_checkpoint(
@@ -1594,7 +1593,32 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
             ));
         }
         match p.file_type {
-            LogPathFileType::MultiPartCheckpoint { num_parts, .. } if num_parts as usize == n => {}
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts,
+            } if num_parts >= 2 && num_parts as usize == n => {
+                let index = usize::try_from(part_num)
+                    .ok()
+                    .and_then(|part_num| part_num.checked_sub(1))
+                    .filter(|part_num| *part_num < n)
+                    .ok_or_else(|| {
+                        Error::invalid_checkpoint(format!(
+                            "multi-part checkpoint part number {part_num} is outside 1..={num_parts}"
+                        ))
+                    })?;
+                require!(
+                    !seen_part_numbers[index],
+                    Error::invalid_checkpoint(format!(
+                        "multi-part checkpoint contains duplicate part number {part_num}"
+                    ))
+                );
+                seen_part_numbers[index] = true;
+            }
+            LogPathFileType::MultiPartCheckpoint { num_parts, .. } if num_parts < 2 => {
+                return Err(Error::invalid_checkpoint(format!(
+                    "multi-part checkpoint must contain at least two parts but num_parts field says {num_parts}"
+                )));
+            }
             LogPathFileType::MultiPartCheckpoint { num_parts, .. } => {
                 return Err(Error::invalid_checkpoint(format!(
                     "multi-part checkpoint part count mismatch: slice has {n} parts but num_parts field says {num_parts}"

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2706,6 +2706,8 @@ fn test_validate_listed_log_file_checkpoint_parts_contains_non_checkpoint() {
 
 #[rstest]
 #[case::complete(&[1, 2], 2, None)]
+#[case::out_of_order(&[2, 1], 2, None)]
+#[case::three_complete(&[1, 2, 3], 3, None)]
 #[case::duplicate(&[1, 1], 2, Some("duplicate part number 1"))]
 #[case::zero(&[0, 2], 2, Some("part number 0 is outside 1..=2"))]
 #[case::above_range(&[1, 3], 2, Some("part number 3 is outside 1..=2"))]

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2704,6 +2704,37 @@ fn test_validate_listed_log_file_checkpoint_parts_contains_non_checkpoint() {
     assert!(matches!(result, Err(Error::InvalidCheckpoint(_))));
 }
 
+#[rstest]
+#[case::complete(&[1, 2], 2, None)]
+#[case::duplicate(&[1, 1], 2, Some("duplicate part number 1"))]
+#[case::zero(&[0, 2], 2, Some("part number 0 is outside 1..=2"))]
+#[case::above_range(&[1, 3], 2, Some("part number 3 is outside 1..=2"))]
+#[case::one_part(&[1], 1, Some("must contain at least two parts"))]
+fn test_validate_multipart_checkpoint_part_numbers(
+    #[case] part_numbers: &[u32],
+    #[case] num_parts: u32,
+    #[case] expected_error: Option<&str>,
+) {
+    let parts = part_numbers
+        .iter()
+        .map(|part_num| {
+            let mut part =
+                create_log_path("file:///_delta_log/00000000000000000010.checkpoint.parquet");
+            part.file_type = LogPathFileType::MultiPartCheckpoint {
+                part_num: *part_num,
+                num_parts,
+            };
+            part
+        })
+        .collect_vec();
+
+    let result = validate_checkpoint_parts(&parts);
+    match expected_error {
+        Some(expected_error) => assert_result_error_with_message(result, expected_error),
+        None => result.unwrap(),
+    }
+}
+
 #[test]
 fn test_validate_listed_log_file_multipart_checkpoint_part_count_mismatch() {
     // Two parts that agree on version but claim num_parts=3 (count mismatch: 2 != 3)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Small change. Validate that multipart checkpoints declare at least two parts and contain unique part numbers within the declared range.

Fixes #3297. Follow-up to: https://github.com/delta-io/delta-kernel-rs/pull/3222#discussion_r3973218723

## How was this change tested?

- Focused multipart checkpoint tests
- Workspace clippy and docs
- Full workspace test suite