### PR TITLE
test: exercise AI review deduplication

### DIFF
--- a/kernel/src/ai_review_experiment.rs
+++ b/kernel/src/ai_review_experiment.rs
@@ -1,0 +1,15 @@
+// This uncompiled file is a temporary fixture for the experimental AI review workflow.
+
+pub fn first_retry_delay(delays: &[u64]) -> u64 {
+    delays[0]
+}
+
+// TODO: define whether an empty retry plan is valid.
+pub fn has_retries(delays: &[u64]) -> bool {
+    !delays.is_empty()
+}
+
+// TODO(#3299): replace this parser once the review experiment is complete.
+pub fn parse_retry_count(value: &str) -> u64 {
+    value.parse().unwrap()
+}

--- a/kernel/src/ai_review_experiment.rs
+++ b/kernel/src/ai_review_experiment.rs
@@ -13,3 +13,8 @@ pub fn has_retries(delays: &[u64]) -> bool {
 pub fn parse_retry_count(value: &str) -> u64 {
     value.parse().unwrap()
 }
+
+// TODO: decide whether retry-count overflow should saturate.
+pub fn increment_retry_count(count: u64) -> u64 {
+    count + 1
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This is a temporary experiment for the AI review workflow in #3299. It intentionally adds an
uncompiled fixture with known review targets so we can verify inline comments, tracked-TODO
suppression, and duplicate suppression across repeated runs.

**Do not merge this PR.** It will be closed after the workflow experiment.

## How was this change tested?

- Full repository pre-commit checks: nightly rustfmt, Clippy, Rust tests and doctests, and coverage
- The AI review workflow will be dispatched twice from the #3299 branch in inline mode
