### PR TITLE
fix: validate snapshot hint and CRC invariants

### DIFF
--- a/kernel/src/crc/file_size_histogram.rs
+++ b/kernel/src/crc/file_size_histogram.rs
@@ -115,41 +115,47 @@ impl FileSizeHistogram {
         file_counts: Vec<i64>,
         total_bytes: Vec<i64>,
     ) -> DeltaResult<Self> {
+        let histogram = Self {
+            sorted_bin_boundaries,
+            file_counts,
+            total_bytes,
+        };
+        histogram.check_shape()?;
+        Ok(histogram)
+    }
+
+    fn check_shape(&self) -> DeltaResult<()> {
         require!(
-            sorted_bin_boundaries.len() >= 2,
+            self.sorted_bin_boundaries.len() >= 2,
             Error::internal_error(format!(
                 "sorted_bin_boundaries must have at least 2 elements, got {}",
-                sorted_bin_boundaries.len()
+                self.sorted_bin_boundaries.len()
             ))
         );
         require!(
-            sorted_bin_boundaries[0] == 0,
+            self.sorted_bin_boundaries[0] == 0,
             Error::internal_error(format!(
                 "First boundary must be 0, got {}",
-                sorted_bin_boundaries[0]
+                self.sorted_bin_boundaries[0]
             ))
         );
         require!(
-            sorted_bin_boundaries.len() == file_counts.len()
-                && sorted_bin_boundaries.len() == total_bytes.len(),
+            self.sorted_bin_boundaries.len() == self.file_counts.len()
+                && self.sorted_bin_boundaries.len() == self.total_bytes.len(),
             Error::internal_error(format!(
                 "All arrays must have the same length: boundaries={}, file_counts={}, total_bytes={}",
-                sorted_bin_boundaries.len(),
-                file_counts.len(),
-                total_bytes.len()
+                self.sorted_bin_boundaries.len(),
+                self.file_counts.len(),
+                self.total_bytes.len()
             ))
         );
         require!(
-            sorted_bin_boundaries.windows(2).all(|w| w[0] < w[1]),
+            self.sorted_bin_boundaries.windows(2).all(|w| w[0] < w[1]),
             Error::internal_error(
                 "sorted_bin_boundaries must be sorted in strictly ascending order"
             )
         );
-        Ok(Self {
-            sorted_bin_boundaries,
-            file_counts,
-            total_bytes,
-        })
+        Ok(())
     }
 
     /// Creates an empty histogram with the given bin boundaries and zero counts/bytes.
@@ -273,6 +279,64 @@ impl FileSizeHistogram {
         }
         Ok(self)
     }
+
+    /// Validates an absolute histogram against its complete file statistics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the histogram shape is invalid, a bin has impossible aggregate
+    /// statistics for its bounds, a total overflows, or the totals differ from `num_files` and
+    /// `table_size_bytes`.
+    pub(crate) fn validate_complete(
+        &self,
+        num_files: i64,
+        table_size_bytes: i64,
+    ) -> DeltaResult<()> {
+        self.check_shape()?;
+        for i in 0..self.sorted_bin_boundaries.len() {
+            let count = i128::from(self.file_counts[i]);
+            let bytes = i128::from(self.total_bytes[i]);
+            let lower = i128::from(self.sorted_bin_boundaries[i]);
+            let upper = self
+                .sorted_bin_boundaries
+                .get(i + 1)
+                .copied()
+                .map(i128::from);
+            let aggregates_are_possible = (count == 0 && bytes == 0)
+                || (count > 0
+                    && bytes >= lower * count
+                    && upper.is_none_or(|upper| bytes < upper * count));
+            require!(
+                aggregates_are_possible,
+                Error::internal_error(format!(
+                    "Histogram bin {i} has count {count} and total bytes {bytes}, which are \
+                     inconsistent with its bounds"
+                ))
+            );
+        }
+
+        let file_count = self.file_counts.iter().try_fold(0_i64, |sum, count| {
+            sum.checked_add(*count)
+                .ok_or_else(|| Error::internal_error("Histogram file count overflow"))
+        })?;
+        let total_bytes = self.total_bytes.iter().try_fold(0_i64, |sum, bytes| {
+            sum.checked_add(*bytes)
+                .ok_or_else(|| Error::internal_error("Histogram total bytes overflow"))
+        })?;
+        require!(
+            file_count == num_files,
+            Error::internal_error(format!(
+                "Histogram file count {file_count} does not match numFiles {num_files}"
+            ))
+        );
+        require!(
+            total_bytes == table_size_bytes,
+            Error::internal_error(format!(
+                "Histogram total bytes {total_bytes} does not match tableSizeBytes {table_size_bytes}"
+            ))
+        );
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -309,6 +373,73 @@ mod tests {
         assert_eq!(hist.sorted_bin_boundaries, vec![0, 100]);
         assert_eq!(hist.file_counts, vec![5, 3]);
         assert_eq!(hist.total_bytes, vec![200, 900]);
+    }
+
+    #[rstest]
+    #[case::empty_bin_has_bytes(vec![0, 10], vec![0, 0], vec![1, 0], 0, 1)]
+    #[case::below_lower_bound(vec![0, 10], vec![0, 1], vec![0, 9], 1, 9)]
+    #[case::at_exclusive_upper_bound(vec![0, 10], vec![1, 0], vec![10, 0], 1, 10)]
+    fn validate_complete_rejects_impossible_bin_aggregates(
+        #[case] boundaries: Vec<i64>,
+        #[case] file_counts: Vec<i64>,
+        #[case] total_bytes: Vec<i64>,
+        #[case] num_files: i64,
+        #[case] table_size_bytes: i64,
+    ) {
+        let histogram = FileSizeHistogram::try_new(boundaries, file_counts, total_bytes).unwrap();
+        assert_result_error_with_message(
+            histogram.validate_complete(num_files, table_size_bytes),
+            "inconsistent with its bounds",
+        );
+    }
+
+    #[rstest]
+    #[case::empty(vec![0, 10], vec![0, 0], vec![0, 0], 0, 0)]
+    #[case::exclusive_upper_bound(vec![0, 10], vec![2, 0], vec![18, 0], 2, 18)]
+    #[case::last_bin_unbounded(vec![0, 10], vec![0, 1], vec![0, i64::MAX], 1, i64::MAX)]
+    fn validate_complete_accepts_achievable_bin_aggregates(
+        #[case] boundaries: Vec<i64>,
+        #[case] file_counts: Vec<i64>,
+        #[case] total_bytes: Vec<i64>,
+        #[case] num_files: i64,
+        #[case] table_size_bytes: i64,
+    ) {
+        let histogram = FileSizeHistogram::try_new(boundaries, file_counts, total_bytes).unwrap();
+        histogram
+            .validate_complete(num_files, table_size_bytes)
+            .unwrap();
+    }
+
+    #[rstest]
+    #[case::file_count(
+        vec![0, 10],
+        vec![i64::MAX, 1],
+        vec![0, 10],
+        i64::MAX,
+        10,
+        "file count overflow"
+    )]
+    #[case::total_bytes(
+        vec![0, i64::MAX],
+        vec![1, 1],
+        vec![i64::MAX - 1, i64::MAX],
+        2,
+        i64::MAX,
+        "total bytes overflow"
+    )]
+    fn validate_complete_rejects_overflowing_totals(
+        #[case] boundaries: Vec<i64>,
+        #[case] file_counts: Vec<i64>,
+        #[case] total_bytes: Vec<i64>,
+        #[case] num_files: i64,
+        #[case] table_size_bytes: i64,
+        #[case] expected: &str,
+    ) {
+        let histogram = FileSizeHistogram::try_new(boundaries, file_counts, total_bytes).unwrap();
+        assert_result_error_with_message(
+            histogram.validate_complete(num_files, table_size_bytes),
+            expected,
+        );
     }
 
     #[rstest]

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -204,6 +204,11 @@ impl Crc {
                 )));
             }
         }
+        if let Some(histogram) = raw.file_size_histogram.as_ref() {
+            histogram
+                .validate_complete(raw.num_files, raw.table_size_bytes)
+                .map_err(|error| Error::generic(error.to_string()))?;
+        }
         // A CRC file on disk is by definition complete; we never deserialize a degraded state.
         let file_stats_state = FileStatsState::Complete(FileStats {
             num_files: raw.num_files,
@@ -252,6 +257,11 @@ impl TryFrom<&Crc> for CrcRaw {
                 crc.file_stats_state
             )));
         };
+        if let Some(histogram) = stats.file_size_histogram.as_ref() {
+            histogram
+                .validate_complete(stats.num_files, stats.table_size_bytes)
+                .map_err(|error| Error::ChecksumWriteUnsupported(error.to_string()))?;
+        }
         Ok(CrcRaw {
             table_size_bytes: stats.table_size_bytes,
             num_files: stats.num_files,
@@ -340,6 +350,7 @@ mod tests {
     use std::collections::HashMap;
 
     use rstest::rstest;
+    use test_utils::assert_result_error_with_message;
 
     use super::{Crc, CrcRaw, DomainMetadataState, FileStats, FileStatsState, SetTransactionState};
     use crate::actions::{DomainMetadata, Protocol, SetTransaction};
@@ -779,6 +790,29 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case::below_lower_bound(vec![0, 10], vec![0, 1], vec![0, 9], 1, 9)]
+    #[case::at_exclusive_upper_bound(vec![0, 10], vec![1, 0], vec![10, 0], 1, 10)]
+    fn de_impossible_file_size_histogram_bin_is_rejected(
+        #[case] boundaries: Vec<i64>,
+        #[case] file_counts: Vec<i64>,
+        #[case] total_bytes: Vec<i64>,
+        #[case] num_files: i64,
+        #[case] table_size_bytes: i64,
+    ) {
+        let mut crc: serde_json::Value =
+            serde_json::from_str(&crc_json_with_counts(table_size_bytes, num_files, 1, 1)).unwrap();
+        crc["fileSizeHistogram"] = serde_json::json!({
+            "sortedBinBoundaries": boundaries,
+            "fileCounts": file_counts,
+            "totalBytes": total_bytes,
+        });
+        assert_result_error_with_message(
+            Crc::try_from_json_bytes(crc.to_string().as_bytes(), 0),
+            "inconsistent with its bounds",
+        );
+    }
+
     // ===== protocol validation on the CRC deserialization path =====
 
     /// Minimal CRC JSON whose `protocol` is the supplied fragment. Proves CRC deserialization
@@ -853,11 +887,16 @@ mod tests {
     /// Minimal CRC JSON with a file size histogram field spliced in under the given field name
     /// (`fileSizeHistogram` per the Delta spec, or `histogramOpt` for legacy Delta-Spark
     /// compatibility).
-    fn crc_json_with_histogram(field_name: &str, histogram_json: &str) -> String {
+    fn crc_json_with_histogram(
+        field_name: &str,
+        histogram_json: &str,
+        table_size_bytes: i64,
+        num_files: i64,
+    ) -> String {
         format!(
             r#"{{
-                "tableSizeBytes": 0,
-                "numFiles": 0,
+                "tableSizeBytes": {table_size_bytes},
+                "numFiles": {num_files},
                 "numMetadata": 1,
                 "numProtocol": 1,
                 "metadata": {{
@@ -881,7 +920,9 @@ mod tests {
     fn de_valid_file_size_histogram_succeeds(#[case] field_name: &str) {
         let json = crc_json_with_histogram(
             field_name,
-            r#"{"sortedBinBoundaries": [0, 100, 200], "fileCounts": [1, 2, 3], "totalBytes": [10, 200, 300]}"#,
+            r#"{"sortedBinBoundaries": [0, 100, 200], "fileCounts": [1, 2, 3], "totalBytes": [10, 250, 900]}"#,
+            1160,
+            6,
         );
         let crc = Crc::try_from_json_bytes(json.as_bytes(), 0).unwrap();
         assert!(crc.file_stats().unwrap().file_size_histogram().is_some());
@@ -891,7 +932,7 @@ mod tests {
     #[case::spec_name("fileSizeHistogram")]
     #[case::legacy_name("histogramOpt")]
     fn de_null_file_size_histogram_deserializes_to_none(#[case] field_name: &str) {
-        let json = crc_json_with_histogram(field_name, "null");
+        let json = crc_json_with_histogram(field_name, "null", 0, 0);
         let crc = Crc::try_from_json_bytes(json.as_bytes(), 0).unwrap();
         assert!(crc.file_stats().unwrap().file_size_histogram().is_none());
     }
@@ -915,7 +956,7 @@ mod tests {
         #[case] histogram_json: &str,
         #[values("fileSizeHistogram", "histogramOpt")] field_name: &str,
     ) {
-        let json = crc_json_with_histogram(field_name, histogram_json);
+        let json = crc_json_with_histogram(field_name, histogram_json, 0, 0);
         assert!(Crc::try_from_json_bytes(json.as_bytes(), 0).is_err());
     }
 
@@ -927,6 +968,8 @@ mod tests {
         let legacy_json = crc_json_with_histogram(
             "histogramOpt",
             r#"{"sortedBinBoundaries": [0, 100], "fileCounts": [1, 0], "totalBytes": [50, 0]}"#,
+            50,
+            1,
         );
         let crc = Crc::try_from_json_bytes(legacy_json.as_bytes(), 0).unwrap();
 

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -45,9 +45,8 @@ impl FileStatsState {
         }
     }
 
-    /// Returns `true` if file stats are known-correct absolute totals. Also gates whether
-    /// the CRC is safe to write to disk: only `Complete` CRCs have well-defined on-disk
-    /// representations.
+    /// Returns `true` if file stats are known-correct absolute totals.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn is_complete(&self) -> bool {
         matches!(self, Self::Complete(_))
     }
@@ -60,8 +59,8 @@ impl FileStatsState {
     }
 }
 
-// TODO(#2568): make `Default` test-only. `Crc::default()` produces a Complete-zero CRC
-//              that passes `is_complete()` and could be silently written.
+// TODO(#2568): make `Default` test-only. `Crc::default()` produces a Complete-zero CRC that could
+//              be silently written.
 impl Default for FileStatsState {
     fn default() -> Self {
         Self::Complete(FileStats::default())

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -13,20 +13,25 @@ use crate::{DeltaResult, Engine, Error};
 /// handler. Returns [`Error::ChecksumWriteUnsupported`] if:
 /// - `file_stats_state` is not `Complete` (only `Complete` CRCs have a well-defined on-disk
 ///   representation); or
-/// - `delta.enableInCommitTimestamps` is `true` but `inCommitTimestampOpt` is absent.
+/// - the file-size histogram is inconsistent with its bin bounds or aggregate statistics; or
+/// - the presence of `inCommitTimestampOpt` does not match whether `delta.enableInCommitTimestamps`
+///   is `true`.
 ///
 /// Per the Delta protocol, writers MUST NOT overwrite existing CRC files, so this always
 /// writes with `overwrite = false`. If the file already exists, returns
 /// `Err(Error::FileAlreadyExists)`.
 pub(crate) fn try_write_crc_file(engine: &dyn Engine, path: &Url, crc: &Crc) -> DeltaResult<()> {
-    require!(
-        crc.file_stats_state.is_complete(),
+    let stats = crc.file_stats().ok_or_else(|| {
         Error::ChecksumWriteUnsupported(format!(
             "Cannot write CRC file with {:?} file stats",
             crc.file_stats_state
         ))
-    );
-    // If ICT is enabled, the CRC must carry an ICT value.
+    })?;
+    if let Some(histogram) = stats.file_size_histogram() {
+        histogram
+            .validate_complete(stats.num_files(), stats.table_size_bytes())
+            .map_err(|error| Error::ChecksumWriteUnsupported(error.to_string()))?;
+    }
     let ict_enabled = crc
         .metadata
         .configuration()
@@ -34,10 +39,11 @@ pub(crate) fn try_write_crc_file(engine: &dyn Engine, path: &Url, crc: &Crc) -> 
         .is_some_and(|v| v == "true");
     let ict_value_present = crc.in_commit_timestamp_opt.is_some();
     require!(
-        !ict_enabled || ict_value_present,
+        ict_enabled == ict_value_present,
         Error::ChecksumWriteUnsupported(
-            "Cannot write CRC file: In-Commit Timestamps enabled but inCommitTimestampOpt is absent"
-                .to_string()
+            "Cannot write CRC file: inCommitTimestampOpt presence does not match In-Commit \
+             Timestamps enablement"
+                .to_string(),
         )
     );
     let data = serde_json::to_vec(crc)?;
@@ -245,6 +251,22 @@ mod tests {
         assert!(matches!(result, Err(Error::ChecksumWriteUnsupported(_))));
     }
 
+    #[test]
+    fn test_write_rejects_inconsistent_file_size_histogram() {
+        let (engine, crc_path) = writer_test_env(0);
+        let mut crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
+        crc.file_stats_state = FileStatsState::Complete(FileStats {
+            num_files: 1,
+            table_size_bytes: 10,
+            file_size_histogram: Some(
+                FileSizeHistogram::try_new(vec![0, 10], vec![1, 0], vec![10, 0]).unwrap(),
+            ),
+        });
+
+        let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
+        assert!(matches!(result, Err(Error::ChecksumWriteUnsupported(_))));
+    }
+
     #[rstest]
     #[case::not_supported(false, false)]
     #[case::supported_not_enabled(true, false)]
@@ -261,8 +283,7 @@ mod tests {
             crc.in_commit_timestamp_opt = None;
         }
 
-        // If ICT is enabled, then the ICT value must be present.
-        let should_succeed = !ict_enabled || ict_value_present;
+        let should_succeed = ict_enabled == ict_value_present;
         let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
         if should_succeed {
             result.unwrap();

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -151,6 +151,12 @@ pub enum SnapshotHintError {
         /// The version described by the snapshot hint.
         hint: Version,
     },
+    /// The hint omits the commit for its target version.
+    #[error("Invalid snapshot hint: commit for snapshot hint version {hint} is missing")]
+    MissingLatestCommit {
+        /// The version described by the snapshot hint.
+        hint: Version,
+    },
     /// The hint has neither a complete checkpoint nor commit version zero.
     #[error("Invalid snapshot hint: snapshot history does not start at version 0")]
     MissingHistoryAnchor,
@@ -170,6 +176,12 @@ pub enum SnapshotHintError {
     /// The supplied CRC metadata differs from the hint metadata.
     #[error("Invalid snapshot hint: CRC metadata does not match snapshot hint metadata")]
     CrcMetadata,
+    /// An ICT-enabled CRC omitted its required in-commit timestamp.
+    #[error("Invalid snapshot hint: ICT-enabled CRC is missing inCommitTimestamp")]
+    MissingInCommitTimestamp,
+    /// An ICT-disabled CRC included an in-commit timestamp.
+    #[error("Invalid snapshot hint: ICT-disabled CRC contains inCommitTimestamp")]
+    UnexpectedInCommitTimestamp,
     /// A connector reported invalid snapshot-hint state, optionally with an underlying error.
     #[error("Invalid snapshot hint: {message}")]
     Connector {

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -18,7 +18,7 @@ use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
 use crate::metrics::{MetricId, SnapshotLoadMetricContext, SnapshotLoadType};
 use crate::path::LogPathFileType;
 use crate::snapshot::SnapshotRef;
-use crate::table_configuration::TableConfiguration;
+use crate::table_configuration::{InCommitTimestampEnablement, TableConfiguration};
 use crate::utils::{require, try_parse_uri};
 use crate::{DeltaResult, Engine, Error, Snapshot, Version};
 
@@ -594,6 +594,14 @@ impl<Mode> SnapshotBuilder<Mode> {
             SnapshotHintError::MaxPublishedVersion { hint: version }.into()
         );
         require!(
+            log_segment
+                .listed
+                .latest_commit_file
+                .as_ref()
+                .is_some_and(|commit| commit.version == version),
+            SnapshotHintError::MissingLatestCommit { hint: version }.into()
+        );
+        require!(
             log_segment.checkpoint_version.is_some()
                 || log_segment
                     .listed
@@ -620,6 +628,18 @@ impl<Mode> SnapshotBuilder<Mode> {
             require!(
                 crc.metadata == *table_configuration.metadata(),
                 SnapshotHintError::CrcMetadata.into()
+            );
+            let ict_enabled = matches!(
+                table_configuration.in_commit_timestamp_enablement()?,
+                InCommitTimestampEnablement::Enabled { .. }
+            );
+            require!(
+                ict_enabled || crc.in_commit_timestamp_opt.is_none(),
+                SnapshotHintError::UnexpectedInCommitTimestamp.into()
+            );
+            require!(
+                !ict_enabled || crc.in_commit_timestamp_opt.is_some(),
+                SnapshotHintError::MissingInCommitTimestamp.into()
             );
         }
 
@@ -825,6 +845,8 @@ mod tests {
     use crate::object_store::path::Path;
     use crate::object_store::{DynObjectStore, ObjectStoreExt as _};
     use crate::schema::schema_ref;
+    use crate::table_features::TableFeature;
+    use crate::table_properties::ENABLE_IN_COMMIT_TIMESTAMPS;
     use crate::unit_test_utils::{
         create_log_path, install_thread_local_metrics_reporter, CapturingReporter,
         TestCancellationToken,
@@ -992,7 +1014,7 @@ mod tests {
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    async fn complete_snapshot_hint_preserves_checkpoint_state(
+    async fn snapshot_hint_preserves_checkpoint_state_and_requires_target_commit(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, store, table_root) = setup_test();
         create_table(&store, &table_root).await?;
@@ -1009,11 +1031,9 @@ mod tests {
             .last_checkpoint_metadata
             .is_some());
 
-        let mut hint = hint_from_snapshot(&storage_snapshot, SnapshotHintFreshness::Unverified);
-        hint.log_segment_files.ascending_commit_files.clear();
-        hint.log_segment_files.latest_commit_file = None;
+        let hint = hint_from_snapshot(&storage_snapshot, SnapshotHintFreshness::Unverified);
         let hinted_snapshot = SnapshotBuilder::new_for(table_root)
-            .with_snapshot_hint(hint)
+            .with_snapshot_hint(hint.clone())
             .build(engine.as_ref())?;
         assert_eq!(
             hinted_snapshot.log_segment().checkpoint_version,
@@ -1022,6 +1042,19 @@ mod tests {
         assert_eq!(
             hinted_snapshot.log_segment().listed.checkpoint_parts,
             storage_snapshot.log_segment().listed.checkpoint_parts
+        );
+
+        let mut missing_target_commit = hint;
+        missing_target_commit
+            .log_segment_files
+            .ascending_commit_files
+            .clear();
+        missing_target_commit.log_segment_files.latest_commit_file = None;
+        assert_hint_error(
+            SnapshotBuilder::new_for(storage_snapshot.table_root()),
+            missing_target_commit,
+            engine.as_ref(),
+            "commit for snapshot hint version 1 is missing",
         );
         Ok(())
     }
@@ -1226,6 +1259,54 @@ mod tests {
             engine.as_ref(),
             "CRC metadata does not match",
         );
+        Ok(())
+    }
+
+    #[rstest::rstest]
+    #[case::disabled_without_timestamp(false, false, None)]
+    #[case::disabled_with_timestamp(
+        false,
+        true,
+        Some("ICT-disabled CRC contains inCommitTimestamp")
+    )]
+    #[case::enabled_without_timestamp(
+        true,
+        false,
+        Some("ICT-enabled CRC is missing inCommitTimestamp")
+    )]
+    #[case::enabled_with_timestamp(true, true, None)]
+    #[test_log::test(tokio::test)]
+    async fn snapshot_hint_requires_ict_timestamp_iff_enabled(
+        #[case] ict_enabled: bool,
+        #[case] ict_value_present: bool,
+        #[case] expected_error: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root, _snapshot, mut hint) =
+            snapshot_and_hint(SnapshotHintFreshness::Unverified).await?;
+        let mut crc = hint.crc.as_ref().unwrap().as_ref().clone();
+
+        if ict_enabled {
+            hint.protocol = Protocol::try_new_modern(
+                std::iter::empty::<TableFeature>(),
+                [TableFeature::InCommitTimestamp],
+            )?;
+            hint.metadata = hint
+                .metadata
+                .with_configuration_entry(ENABLE_IN_COMMIT_TIMESTAMPS, "true");
+        }
+        crc.protocol = hint.protocol.clone();
+        crc.metadata = hint.metadata.clone();
+        crc.in_commit_timestamp_opt = ict_value_present.then_some(123);
+        hint.crc = Some(Arc::new(crc));
+
+        let result = SnapshotBuilder::new_for(table_root)
+            .with_snapshot_hint(hint)
+            .build(engine.as_ref());
+        if let Some(expected_error) = expected_error {
+            assert_result_error_with_message(result, expected_error);
+        } else {
+            result?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Validate that:

- Snapshot hints include their target-version commit, even when a checkpoint includes all state needed for replay.
- CRC in-commit timestamps are present iff ICT is enabled.
- File-size histogram aggregates are feasible for their bins and match the CRC totals.

Normal replay and snapshot hints have different input contracts.

The normal replay path in `SnapshotBuilder::build()` must tolerate metadata cleanup. After the configured retention period, cleanup may remove JSON commits covered by a retained checkpoint. For example:

1. Version 0 creates an empty table.
2. A checkpoint is written at version 0.
3. Metadata cleanup removes `00000000000000000000.json` while retaining the version 0 checkpoint.
4. Normal replay can still build and scan snapshot version 0 from the checkpoint, with no `latest_commit_file`.

The checkpoint contains enough state to reconstruct the table, but operations requiring target-commit metadata may fail. For example, the commit timestamp is unavailable, and enabling ICT in a subsequent commit may require that timestamp to preserve timestamp monotonicity.

A snapshot hint instead claims to provide complete cached snapshot state without listing storage. Its producer is expected to retain target-commit metadata independently of the files needed for replay. Kernel treats a hint without that metadata as incomplete rather than silently constructing a snapshot with unavailable timestamp information. The caller can discard the rejected hint and retry through normal replay.

The broader normal-replay behavior remains unchanged; see #3293.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo clippy -p delta_kernel --tests --all-features -- -D warnings`
- `cargo doc -p delta_kernel --all-features --no-deps`
- `cargo nextest run -p delta_kernel --all-features` (9,135 passed)