### PR TITLE
feat: add frame reporting support to metrics layers

### DIFF
--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -43,7 +43,8 @@ the caller's memory space.
 - `src/column_default.rs` -- column-default (`allowColumnDefaults`) reads and the write-path ack
 - `src/scan.rs` -- scan FFI interface
 - `src/schema_visitor.rs` -- visitor pattern for schema traversal
-- `src/ffi_tracing.rs` -- log/tracing and metrics callback registration (`#[cfg(feature = "tracing")]`)
+- `src/ffi_tracing.rs` -- log, metrics, and frame callback registration
+  (`#[cfg(feature = "tracing")]`)
 - `src/ffi_metrics.rs` -- `repr(C)` mirror of kernel `MetricEvent` types (`#[cfg(feature = "tracing")]`)
 - `src/alloc_stats.rs` -- `peak_alloc` global allocator and native-heap FFI getters
   (`alloc-tracking`)
@@ -185,11 +186,12 @@ updates require both the `deletionVectors` reader/writer feature and
 
 ## Tracing & Metrics
 
-Gated behind the `tracing` feature. A single global `tracing` subscriber backs both logging and
-metrics; it is installed lazily the first time any `enable_*` function below is called. The
-subscriber has two reloadable slots: a logging layer (swapped wholesale between event-based and
-log-line formats) and a metrics layer (a fixed `ReportGeneratorLayer` toggled on/off via a
-reloadable level filter).
+Gated behind the `tracing` feature. A single global `tracing` subscriber backs logging, metrics,
+and frame lifecycle reporting; it is installed lazily the first time any `enable_*` function below
+is called. The subscriber has three reloadable slots: a logging layer (swapped wholesale between
+event-based and log-line formats), a metrics layer (a fixed `ReportGeneratorLayer` toggled on/off
+via a reloadable level filter), and a frame layer (a fixed `FrameReporterLayer` toggled on/off via
+a reloadable level filter).
 
 Logging registration (each re-callable to replace the active callback, format, and level):
 - `enable_event_tracing(callback, max_level)` -- structured `Event`s; the engine formats them
@@ -200,6 +202,15 @@ Logging registration (each re-callable to replace the active callback, format, a
 Metrics registration:
 - `enable_metrics_reporting(callback)` -- forwards each kernel `MetricEvent` to the callback as a
   `repr(C)` `MetricEvent` (see `src/ffi_metrics.rs`). Re-calling replaces the callback.
+
+Frame lifecycle registration:
+- `enable_frame_reporting(callback)` -- forwards OPEN/CLOSE for each dynamic activation of a span
+  declaring the static `enable_call_frame` field. The callback runs synchronously on the entering
+  or exiting thread. OPEN includes the span id and a borrowed UTF-8 name; CLOSE includes the same
+  id with an empty name. Calls may overlap across threads; callback state must be thread-safe, and
+  profile consumers must maintain a separate event stack for each callback thread. Registration is
+  one-shot so a callback cannot be replaced between a span's OPEN and CLOSE events; another call
+  fails and leaves the existing callback active.
 
 The `MetricEvent` and any `KernelStringSlice` it carries are only valid for the duration of the
 callback. Durations are `u64`, suffixed `_ns` (nanoseconds) or `_ms` (milliseconds). Operation ids

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -11,6 +11,20 @@
 #include "kernel_schema_visitor.h"
 #include "kernel_utils.h"
 
+static void frame_callback(
+  FrameEventType event_type,
+  uint64_t span_id,
+  KernelStringSlice name)
+{
+  switch (event_type) {
+    case FrameEventTypeOPEN:
+    case FrameEventTypeCLOSE:
+      break;
+  }
+  (void)span_id;
+  (void)name;
+}
+
 // Print the content of a selection vector if `VERBOSE` is defined in read_table.h
 void print_selection_vector(const char* indent, const KernelBoolSlice* selection_vec)
 {
@@ -427,6 +441,7 @@ int main(int argc, char* argv[])
 #else
   enable_event_tracing(tracing_callback, WARN);
 #endif
+  (void)enable_frame_reporting(frame_callback);
 
   KernelStringSlice table_path_slice = { table_path, strlen(table_path) };
 

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -1,7 +1,7 @@
 //! FFI functions to allow engines to receive log, tracing, and metrics events from kernel.
 //!
 //! We use a single global tracing subscriber, registered the first time any of
-//! [`enable_event_tracing`], [`enable_log_line_tracing`], [`enable_formatted_log_line_tracing`], or
+//! [`enable_event_tracing`], [`enable_log_line_tracing`], [`enable_formatted_log_line_tracing`],
 //! [`enable_metrics_reporting`], or [`enable_frame_reporting`] is called. The subscriber has
 //! independent layers for log events, metric reports, and frame lifecycle events:
 //!

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -2,21 +2,24 @@
 //!
 //! We use a single global tracing subscriber, registered the first time any of
 //! [`enable_event_tracing`], [`enable_log_line_tracing`], [`enable_formatted_log_line_tracing`], or
-//! [`enable_metrics_reporting`] is called. The subscriber has two layers, one for log events, and
-//! one for metric report events:
+//! [`enable_metrics_reporting`], or [`enable_frame_reporting`] is called. The subscriber has
+//! independent layers for log events, metric reports, and frame lifecycle events:
 //!
 //! - The logging layer is a type-erased [`Layer`] that an `enable_*_tracing` call swaps in (either
 //!   event-based or formatted log-line)
 //! - The metrics slot is a [`ReportGeneratorLayer`] that is `OFF` (zero overhead) until
 //!   [`enable_metrics_reporting`] turns it on.
+//! - The frame slot is a [`FrameReporterLayer`] that is `OFF` until [`enable_frame_reporting`]
+//!   turns it on. Only spans declaring an `enable_call_frame` field are reported.
 //!
-//! Both are reloadable so they can be swapped.
+//! Each layer can be enabled independently. Logging and metrics callbacks can also be replaced.
 
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use std::{fmt, io};
 
 use delta_kernel::metrics::{
-    MetricEvent as KernelMetricEvent, MetricsReporter, ReportGeneratorLayer,
+    FrameReporter, FrameReporterLayer, MetricEvent as KernelMetricEvent, MetricsReporter,
+    ReportGeneratorLayer,
 };
 use delta_kernel::{DeltaResult, Error};
 use tracing::field::{Field as TracingField, Visit};
@@ -383,6 +386,48 @@ impl MetricsReporter for FfiMetricsReporter {
     }
 }
 
+/// The lifecycle transition reported for a call-frame-enabled tracing span.
+///
+/// cbindgen:prefix-with-name=true
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FrameEventType {
+    /// The current thread entered the span.
+    OPEN = 0,
+    /// The current thread exited the span.
+    CLOSE = 1,
+}
+
+/// Callback registered through [`enable_frame_reporting`] to receive frame lifecycle events.
+///
+/// Calls run synchronously and may overlap across threads, so callback state must be thread-safe.
+/// Profile consumers should capture time and maintain a separate event stack for each callback
+/// thread. `name` is valid only until the callback returns. [`FrameEventType::OPEN`] passes the
+/// span name, while [`FrameEventType::CLOSE`] passes an empty string.
+pub type FrameEventFn =
+    extern "C" fn(event_type: FrameEventType, span_id: u64, name: KernelStringSlice);
+
+/// Forwards frame lifecycle notifications to the registered FFI callback.
+#[derive(Debug)]
+struct FfiFrameReporter {
+    callback: Arc<OnceLock<FrameEventFn>>,
+}
+
+impl FrameReporter for FfiFrameReporter {
+    fn enter(&self, span_id: u64, name: &'static str) {
+        if let Some(callback) = self.callback.get() {
+            callback(FrameEventType::OPEN, span_id, kernel_string_slice!(name));
+        }
+    }
+
+    fn exit(&self, span_id: u64) {
+        if let Some(callback) = self.callback.get() {
+            let name = "";
+            callback(FrameEventType::CLOSE, span_id, kernel_string_slice!(name));
+        }
+    }
+}
+
 fn build_event_layer(callback: TracingEventFn) -> BoxedLayer {
     Box::new(EventLayer { callback })
 }
@@ -442,6 +487,10 @@ struct GlobalTracingState {
     metrics_filter: Option<FilterHandle>,
     /// Shared callback the metrics layer's reporter forwards events to.
     metrics_callback: Arc<Mutex<Option<MetricsEventFn>>>,
+    /// Toggles and filters frame lifecycle reporting.
+    frame_filter: Option<FilterHandle>,
+    /// One-shot callback the frame layer's reporter forwards events to.
+    frame_callback: Arc<OnceLock<FrameEventFn>>,
 }
 
 impl GlobalTracingState {
@@ -452,11 +501,13 @@ impl GlobalTracingState {
             logging_filter: None,
             metrics_filter: None,
             metrics_callback: Arc::new(Mutex::new(None)),
+            frame_filter: None,
+            frame_callback: Arc::new(OnceLock::new()),
         }
     }
 
     /// If the global subscriber hasn't been installed yet, this installs it and sets up all the
-    /// logging layers. When called again, this is a no-op.
+    /// tracing layers. When called again, this is a no-op.
     fn ensure_installed(&mut self) -> DeltaResult<()> {
         if self.installed {
             return Ok(());
@@ -474,12 +525,20 @@ impl GlobalTracingState {
         let metrics: BoxedLayer =
             Box::new(ReportGeneratorLayer::new(reporter).with_filter(metrics_filter_layer));
 
-        let subscriber = Registry::default().with(vec![logging, metrics]);
+        let (frame_filter_layer, frame_filter) = reload::Layer::new(LevelFilter::OFF);
+        let reporter = Arc::new(FfiFrameReporter {
+            callback: self.frame_callback.clone(),
+        });
+        let frames: BoxedLayer =
+            Box::new(FrameReporterLayer::new(reporter).with_filter(frame_filter_layer));
+
+        let subscriber = Registry::default().with(vec![logging, metrics, frames]);
         set_global_default(Dispatch::new(subscriber))?;
 
         self.logging_layer = Some(logging_layer);
         self.logging_filter = Some(logging_filter);
         self.metrics_filter = Some(metrics_filter);
+        self.frame_filter = Some(frame_filter);
         self.installed = true;
         Ok(())
     }
@@ -546,6 +605,19 @@ impl GlobalTracingState {
             .reload(LevelFilter::INFO)
             .map_err(|e| Error::generic(format!("Unable to reload metrics subscriber: {e}")))
     }
+
+    /// Registers the frame callback and enables spans containing the `enable_call_frame` field.
+    fn register_frame_callback(&mut self, callback: FrameEventFn) -> DeltaResult<()> {
+        self.ensure_installed()?;
+        self.frame_callback
+            .set(callback)
+            .map_err(|_| Error::generic("frame callback already registered"))?;
+        self.frame_filter
+            .as_ref()
+            .ok_or_else(|| Error::generic("frame filter not installed"))?
+            .reload(LevelFilter::TRACE)
+            .map_err(|e| Error::generic(format!("Unable to reload frame subscriber: {e}")))
+    }
 }
 
 static TRACING_STATE: LazyLock<Mutex<GlobalTracingState>> =
@@ -602,10 +674,37 @@ fn setup_metrics_reporter(callback: MetricsEventFn) -> DeltaResult<()> {
     state.register_metrics_callback(callback)
 }
 
+/// Enables synchronous callbacks when opted-in kernel tracing spans are entered and exited.
+///
+/// A span opts in by declaring an `enable_call_frame` field. `callback` receives a
+/// [`FrameEventType::OPEN`] event immediately after the current thread enters the span and a
+/// matching [`FrameEventType::CLOSE`] event immediately before the exit completes. Re-entering a
+/// span produces another OPEN/CLOSE pair with the same span ID.
+///
+/// This function may be called only once so a callback cannot be replaced between a span's OPEN
+/// and CLOSE events. This guarantees that both events are delivered to the same callback. If a
+/// frame callback is already registered, this function returns `false` and leaves it active.
+///
+/// Returns `true` if reporting was enabled successfully, or `false` on failure.
+///
+/// # Safety
+///
+/// The caller must pass a valid function pointer. The callback must not unwind across the FFI
+/// boundary and must copy the OPEN event's name before returning if it needs to retain it.
+#[no_mangle]
+pub unsafe extern "C" fn enable_frame_reporting(callback: FrameEventFn) -> bool {
+    TRACING_STATE
+        .lock()
+        .map_err(|_e| Error::generic("Poisoned mutex while setting up frame reporter"))
+        .and_then(|mut state| state.register_frame_callback(callback))
+        .is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::LazyLock;
 
+    use tracing::field::Empty;
     use tracing::{debug, info, trace};
     use tracing_subscriber::fmt::time::FormatTime;
 
@@ -645,6 +744,14 @@ mod tests {
             callback: Arc::new(Mutex::new(Some(callback))),
         });
         let layer = ReportGeneratorLayer::new(reporter).with_filter(LevelFilter::TRACE);
+        Dispatch::new(Registry::default().with(layer))
+    }
+
+    fn create_frame_dispatch(callback: FrameEventFn) -> Dispatch {
+        let reporter = Arc::new(FfiFrameReporter {
+            callback: Arc::new(OnceLock::from(callback)),
+        });
+        let layer = FrameReporterLayer::new(reporter).with_filter(LevelFilter::TRACE);
         Dispatch::new(Registry::default().with(layer))
     }
 
@@ -1010,5 +1117,119 @@ mod tests {
             lock.as_deref(),
             Some(["json:3:100".to_string(), "parquet:2:50".to_string()].as_slice())
         );
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct CapturedFrameEvent {
+        event_type: FrameEventType,
+        span_id: u64,
+        name: Option<String>,
+    }
+
+    static FRAME_EVENTS: Mutex<Vec<CapturedFrameEvent>> = Mutex::new(vec![]);
+
+    extern "C" fn capture_frame_event(
+        event_type: FrameEventType,
+        span_id: u64,
+        name: KernelStringSlice,
+    ) {
+        let name: &str = unsafe { TryFromStringSlice::try_from_slice(&name).unwrap() };
+        let name = if name.is_empty() {
+            None
+        } else {
+            Some(name.to_string())
+        };
+        FRAME_EVENTS.lock().unwrap().push(CapturedFrameEvent {
+            event_type,
+            span_id,
+            name,
+        });
+    }
+
+    fn emit_reloadable_frame_span() {
+        let span = tracing::trace_span!("reloadable", enable_call_frame = Empty);
+        let _guard = span.enter();
+    }
+
+    #[test]
+    fn frame_reporting_delivers_nested_lifecycle_events_synchronously() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        FRAME_EVENTS.lock().unwrap().clear();
+        let dispatch = create_frame_dispatch(capture_frame_event);
+
+        tracing_core::dispatcher::with_default(&dispatch, || {
+            let ignored = tracing::info_span!("ignored");
+            let _ignored_guard = ignored.enter();
+
+            let outer = tracing::info_span!("outer", enable_call_frame = Empty);
+            let outer_guard = outer.enter();
+            assert_eq!(FRAME_EVENTS.lock().unwrap().len(), 1);
+
+            let inner = tracing::info_span!("inner", enable_call_frame = Empty);
+            let inner_guard = inner.enter();
+            assert_eq!(FRAME_EVENTS.lock().unwrap().len(), 2);
+            drop(inner_guard);
+            assert_eq!(FRAME_EVENTS.lock().unwrap().len(), 3);
+            drop(outer_guard);
+            assert_eq!(FRAME_EVENTS.lock().unwrap().len(), 4);
+        });
+
+        let events = FRAME_EVENTS.lock().unwrap();
+        assert_eq!(events[0].event_type, FrameEventType::OPEN);
+        assert_eq!(events[0].name.as_deref(), Some("outer"));
+        assert_eq!(events[1].event_type, FrameEventType::OPEN);
+        assert_eq!(events[1].name.as_deref(), Some("inner"));
+        assert_eq!(events[2].event_type, FrameEventType::CLOSE);
+        assert_eq!(events[2].span_id, events[1].span_id);
+        assert_eq!(events[2].name, None);
+        assert_eq!(events[3].event_type, FrameEventType::CLOSE);
+        assert_eq!(events[3].span_id, events[0].span_id);
+        assert_eq!(events[3].name, None);
+    }
+
+    #[test]
+    fn frame_reporter_callback_can_only_be_registered_once() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        FRAME_EVENTS.lock().unwrap().clear();
+        assert!(unsafe { enable_frame_reporting(capture_frame_event) });
+        assert!(!unsafe { enable_frame_reporting(capture_frame_event) });
+
+        let captured = tracing::info_span!("captured", enable_call_frame = Empty);
+        let captured_guard = captured.enter();
+        drop(captured_guard);
+
+        let events = FRAME_EVENTS.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, FrameEventType::OPEN);
+        assert_eq!(events[0].name.as_deref(), Some("captured"));
+        assert_eq!(events[1].event_type, FrameEventType::CLOSE);
+        assert_eq!(events[1].span_id, events[0].span_id);
+    }
+
+    #[test]
+    fn frame_filter_enables_existing_trace_callsites_when_reloaded() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        FRAME_EVENTS.lock().unwrap().clear();
+        let reporter = Arc::new(FfiFrameReporter {
+            callback: Arc::new(OnceLock::from(capture_frame_event as FrameEventFn)),
+        });
+        let (filter_layer, filter_handle) = reload::Layer::new(LevelFilter::OFF);
+        let layer = FrameReporterLayer::new(reporter).with_filter(filter_layer);
+        let dispatch = Dispatch::new(Registry::default().with(layer));
+
+        tracing_core::dispatcher::with_default(&dispatch, || {
+            emit_reloadable_frame_span();
+            assert!(FRAME_EVENTS.lock().unwrap().is_empty());
+
+            filter_handle.reload(LevelFilter::TRACE).unwrap();
+            emit_reloadable_frame_span();
+        });
+
+        let events = FRAME_EVENTS.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, FrameEventType::OPEN);
+        assert_eq!(events[0].name.as_deref(), Some("reloadable"));
+        assert_eq!(events[1].event_type, FrameEventType::CLOSE);
+        assert_eq!(events[1].span_id, events[0].span_id);
     }
 }

--- a/kernel/src/metrics/frame_reporter.rs
+++ b/kernel/src/metrics/frame_reporter.rs
@@ -162,12 +162,25 @@ mod tests {
 
     #[test]
     fn registers_interest_only_in_marked_spans() {
-        capture(|| {
+        let reporter = Arc::new(CapturingFrameReporter::default());
+        let layer = FrameReporterLayer::new(reporter);
+
+        with_default(Registry::default(), || {
             let unmarked = trace_span!("unmarked-trace");
             let marked = trace_span!("marked-trace", enable_call_frame = Empty);
+            let unmarked_metadata = unmarked.metadata().unwrap();
+            let marked_metadata = marked.metadata().unwrap();
 
-            assert!(unmarked.is_disabled());
-            assert!(!marked.is_disabled());
+            assert!(<FrameReporterLayer as Layer<Registry>>::register_callsite(
+                &layer,
+                unmarked_metadata
+            )
+            .is_never());
+            assert!(<FrameReporterLayer as Layer<Registry>>::register_callsite(
+                &layer,
+                marked_metadata
+            )
+            .is_always());
         });
     }
 

--- a/kernel/src/metrics/frame_reporter.rs
+++ b/kernel/src/metrics/frame_reporter.rs
@@ -1,0 +1,261 @@
+//! Tracing layer for reporting the dynamic lifetime of call-frame-enabled spans.
+
+use std::sync::Arc;
+
+use tracing::span::Id;
+use tracing::subscriber::Interest;
+use tracing::{Metadata, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+/// Tracing field whose presence opts a span into call-frame lifecycle reporting.
+pub const ENABLE_CALL_FRAME_FIELD: &str = "enable_call_frame";
+
+/// Receives synchronous notifications when a call-frame-enabled span is entered and exited.
+///
+/// Calls are synchronous and may occur concurrently on multiple threads. Profile consumers should
+/// capture time in these methods and maintain a separate event stack for each calling thread.
+pub trait FrameReporter: Send + Sync + std::fmt::Debug {
+    /// Reports that the current thread entered `name`, identified by `span_id`.
+    ///
+    /// The `name` comes from the span's static tracing metadata. A later [`Self::exit`] call uses
+    /// the same `span_id` to identify the matching span.
+    fn enter(&self, span_id: u64, name: &'static str);
+
+    /// Reports that the current thread exited the span identified by `span_id` from
+    /// [`Self::enter`].
+    fn exit(&self, span_id: u64);
+}
+
+/// A tracing layer that forwards dynamic span entry and exit to a [`FrameReporter`].
+///
+/// A span opts in by declaring a field named [`ENABLE_CALL_FRAME_FIELD`]. The field value is
+/// ignored; the frame name comes from the span's static tracing metadata.
+#[derive(Debug)]
+pub struct FrameReporterLayer {
+    reporter: Arc<dyn FrameReporter>,
+}
+
+impl FrameReporterLayer {
+    /// Creates a layer that forwards frame lifecycle notifications to the supplied `reporter`.
+    pub fn new(reporter: Arc<dyn FrameReporter>) -> Self {
+        Self { reporter }
+    }
+
+    fn is_call_frame_enabled(metadata: &Metadata<'_>) -> bool {
+        metadata.is_span() && metadata.fields().field(ENABLE_CALL_FRAME_FIELD).is_some()
+    }
+}
+
+impl<S> Layer<S> for FrameReporterLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        if Self::is_call_frame_enabled(metadata) {
+            Interest::always()
+        } else {
+            Interest::never()
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(metadata) = ctx.metadata(id) else {
+            return;
+        };
+        if Self::is_call_frame_enabled(metadata) {
+            self.reporter.enter(id.into_u64(), metadata.name());
+        }
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(metadata) = ctx.metadata(id) else {
+            return;
+        };
+        if Self::is_call_frame_enabled(metadata) {
+            self.reporter.exit(id.into_u64());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::Mutex;
+
+    use tracing::field::Empty;
+    use tracing::subscriber::with_default;
+    use tracing::{info_span, trace_span, Span};
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use tracing_subscriber::Registry;
+
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum FrameEvent {
+        Enter { id: u64, name: &'static str },
+        Exit { id: u64 },
+    }
+
+    #[derive(Debug, Default)]
+    struct CapturingFrameReporter {
+        events: Mutex<Vec<FrameEvent>>,
+    }
+
+    impl FrameReporter for CapturingFrameReporter {
+        fn enter(&self, span_id: u64, name: &'static str) {
+            self.events
+                .lock()
+                .unwrap()
+                .push(FrameEvent::Enter { id: span_id, name });
+        }
+
+        fn exit(&self, span_id: u64) {
+            self.events
+                .lock()
+                .unwrap()
+                .push(FrameEvent::Exit { id: span_id });
+        }
+    }
+
+    fn capture(f: impl FnOnce()) -> Vec<FrameEvent> {
+        let reporter = Arc::new(CapturingFrameReporter::default());
+        let subscriber = Registry::default().with(FrameReporterLayer::new(reporter.clone()));
+        with_default(subscriber, f);
+        let events = reporter.events.lock().unwrap().clone();
+        events
+    }
+
+    #[test]
+    fn reports_nested_dynamic_entries() {
+        let events = capture(|| {
+            let outer = info_span!("outer", enable_call_frame = Empty);
+            let _outer_guard = outer.enter();
+            let inner = info_span!("inner", enable_call_frame = Empty);
+            let _inner_guard = inner.enter();
+        });
+
+        let [FrameEvent::Enter {
+            id: outer_id,
+            name: "outer",
+        }, FrameEvent::Enter {
+            id: inner_id,
+            name: "inner",
+        }, FrameEvent::Exit { id: inner_exit_id }, FrameEvent::Exit { id: outer_exit_id }] =
+            events.as_slice()
+        else {
+            panic!("unexpected events: {events:?}");
+        };
+        assert_eq!(inner_id, inner_exit_id);
+        assert_eq!(outer_id, outer_exit_id);
+    }
+
+    #[test]
+    fn ignores_unmarked_spans() {
+        let events = capture(|| {
+            let span = info_span!("not-profiled");
+            let _guard = span.enter();
+        });
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn registers_interest_only_in_marked_spans() {
+        capture(|| {
+            let unmarked = trace_span!("unmarked-trace");
+            let marked = trace_span!("marked-trace", enable_call_frame = Empty);
+
+            assert!(unmarked.is_disabled());
+            assert!(!marked.is_disabled());
+        });
+    }
+
+    #[test]
+    fn ignores_the_opt_in_field_value() {
+        let events = capture(|| {
+            let span = info_span!("value-is-ignored", enable_call_frame = false);
+            let _guard = span.enter();
+        });
+
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            FrameEvent::Enter {
+                name: "value-is-ignored",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reports_each_sequential_entry_of_a_reused_span() {
+        let events = capture(|| {
+            let span = info_span!("reused", enable_call_frame = Empty);
+            for _ in 0..2 {
+                let _guard = span.enter();
+            }
+        });
+
+        let ids: Vec<_> = events
+            .iter()
+            .map(|event| match event {
+                FrameEvent::Enter { id, .. } | FrameEvent::Exit { id } => *id,
+            })
+            .collect();
+        assert_eq!(events.len(), 4);
+        assert!(ids.iter().all(|id| *id == ids[0]));
+        assert!(matches!(events[0], FrameEvent::Enter { .. }));
+        assert!(matches!(events[1], FrameEvent::Exit { .. }));
+        assert!(matches!(events[2], FrameEvent::Enter { .. }));
+        assert!(matches!(events[3], FrameEvent::Exit { .. }));
+    }
+
+    #[test]
+    fn reports_only_dynamically_entered_spans() {
+        let events = capture(|| {
+            let parent = info_span!("parent", enable_call_frame = Empty);
+            let child = info_span!(parent: &parent, "child", enable_call_frame = Empty);
+            let _child_guard = child.enter();
+        });
+
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], FrameEvent::Enter { name: "child", .. }));
+    }
+
+    #[test]
+    fn error_return_reports_exit() {
+        fn fail() -> Result<(), &'static str> {
+            let span = info_span!("fails", enable_call_frame = Empty);
+            let _guard = span.enter();
+            Err("expected")
+        }
+
+        let events = capture(|| assert_eq!(fail(), Err("expected")));
+
+        assert_eq!(events.len(), 2);
+        let FrameEvent::Enter { id, name: "fails" } = events[0] else {
+            panic!("unexpected enter event: {:?}", events[0]);
+        };
+        assert_eq!(events[1], FrameEvent::Exit { id });
+    }
+
+    #[test]
+    fn panic_unwinding_reports_exit() {
+        let events = capture(|| {
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                let span = info_span!("panics", enable_call_frame = Empty);
+                let _guard = span.enter();
+                panic!("expected");
+            }));
+            assert!(result.is_err());
+            assert!(Span::current().is_none());
+        });
+
+        assert_eq!(events.len(), 2);
+        let FrameEvent::Enter { id, name: "panics" } = events[0] else {
+            panic!("unexpected enter event: {:?}", events[0]);
+        };
+        assert_eq!(events[1], FrameEvent::Exit { id });
+    }
+}

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -4,6 +4,9 @@
 //! snapshot creation, scans, and transactions. Metrics are collected during operations
 //! and reported as events via the `MetricsReporter` trait.
 //!
+//! [`FrameReporterLayer`] separately reports dynamic enter/exit notifications for tracing spans
+//! that opt in with [`ENABLE_CALL_FRAME_FIELD`]. It does not create or modify [`MetricEvent`]s.
+//!
 //! Each operation (Snapshot, Transaction, Scan) is assigned a unique operation ID ([`MetricId`])
 //! when it starts, and all subsequent events for that operation reference this ID.
 //! This allows reporters to correlate events and track operation lifecycles.
@@ -73,6 +76,7 @@
 //! [`Engine`]: crate::Engine
 
 pub(crate) mod events;
+mod frame_reporter;
 mod metered_engine;
 mod metered_json;
 mod metered_parquet;
@@ -96,6 +100,7 @@ pub(crate) use events::{
     emit_log_segment_load, emit_log_segment_load_failure, emit_protocol_metadata_load,
     emit_protocol_metadata_load_failure,
 };
+pub use frame_reporter::{FrameReporter, FrameReporterLayer, ENABLE_CALL_FRAME_FIELD};
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_json::MeteredJsonHandler;
 pub use metered_parquet::MeteredParquetHandler;


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds a new tracing `Layer` which emits "frame" events. Within kernel functions, we can opt-in a callsite by adding an `enable_call_frame` field on the tracing annotation. When the layer receives span events with such a field, it will emit an 
OPEN/CLOSE signal so that subscribers can build up a frame profile using timings in between events.

The expectation is that the reporting callback runs on the same thread as the invoked function, so that subscribers can maintain a frame stack in some sort of thread-local context.

This PR also adds the necessary FFI bindings, though it does not explicitly enable any call sites to emit call frames.

## How was this change tested?
Unit tests