### PR TITLE
feat!: expose read-side expected stats schemas

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -740,9 +740,8 @@ impl CheckpointWriter {
 
         // Get stats schema from table configuration.
         // This already excludes partition columns and applies column mapping.
-        let stats_schema = tc
-            .build_expected_stats_schemas(physical_clustering_columns.as_deref(), None)?
-            .physical;
+        let stats_schema =
+            tc.build_expected_physical_stats_schema(physical_clustering_columns.as_deref(), None)?;
 
         // Build partition schema for partitionValues_parsed (None for non-partitioned tables)
         let partition_schema = tc.build_partition_values_parsed_schema();

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -226,7 +226,8 @@ impl DataSkippingFilter {
     /// unlike the scan path which reads pre-parsed `stats_parsed` from transformed batches.
     ///
     /// The stats schema is derived from the predicate's column references via
-    /// [`TableConfiguration::build_expected_stats_schemas`], matching the write side exactly;
+    /// [`TableConfiguration::build_expected_physical_stats_schema`], matching the write side
+    /// exactly;
     /// references outside the table's stats columns fold to NULL (keeping the file). Partition
     /// values are parsed from the raw `add.partitionValues` string map with
     /// [`Expression::map_to_struct`], so predicates over partition columns prune too.
@@ -261,9 +262,8 @@ impl DataSkippingFilter {
             .collect();
         let physical_stats_columns = table_configuration.physical_stats_columns_set(None);
         let physical_stats_schema = table_configuration
-            .build_expected_stats_schemas(None, Some(&predicate_refs))
-            .ok()?
-            .physical;
+            .build_expected_physical_stats_schema(None, Some(&predicate_refs))
+            .ok()?;
         let partition_schema = table_configuration.predicate_partition_schema(&predicate_refs);
 
         // Parse JSON stats from the raw action batch's `add.stats` column, parse partition values

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -743,8 +743,7 @@ fn build_physical_stats_output_schema(
                 return Ok(None);
             }
             let stats_schema = table_configuration
-                .build_expected_stats_schemas(Some(requested), Some(requested))?
-                .physical;
+                .build_expected_physical_stats_schema(Some(requested), Some(requested))?;
             Ok(stats_schema_with_data_columns(stats_schema))
         }
     }

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -172,11 +172,11 @@ fn build_data_skipping_schemas(
         resolve_physical_columns(table_configuration, predicate_column_names_logical);
 
     // A stats schema with only `numRecords` and `tightBounds` (the bookkeeping fields
-    // `build_expected_stats_schemas` always emits) has nothing to prune by. Return `None`
+    // `build_expected_physical_stats_schema` always emits) has nothing to prune by. Return `None`
     // in that case so the caller skips building a `DataSkippingFilter`. `nullCount` is the
     // per-column stats wrapper, so its presence is the signal that at least one data
     // column survived. The Delta protocol allows `minValues` / `maxValues` without
-    // `nullCount`, but `build_expected_stats_schemas` always emits `nullCount` whenever it
+    // `nullCount`, but `build_expected_physical_stats_schema` always emits `nullCount` whenever it
     // emits min/max; this check relies on that implementation property.
     let with_data_cols = |stats_schema: SchemaRef| -> Option<SchemaRef> {
         stats_schema
@@ -188,8 +188,7 @@ fn build_data_skipping_schemas(
     let stats_schema = match (struct_stats, physical_predicate) {
         (StructStats::AllIndexed { .. }, _) => with_data_cols(
             table_configuration
-                .build_expected_stats_schemas(requested_physical_stats_columns, None)?
-                .physical,
+                .build_expected_physical_stats_schema(requested_physical_stats_columns, None)?,
         ),
         // Requested columns bypass the indexed set and seed the stats schema; predicate refs join
         // the schema so kernel can still prune.
@@ -198,18 +197,16 @@ fn build_data_skipping_schemas(
                 .unwrap_or_default()
                 .to_vec();
             union_extra_into_filter(&mut filter, &predicate_refs_physical);
-            with_data_cols(
-                table_configuration
-                    .build_expected_stats_schemas(requested_physical_stats_columns, Some(&filter))?
-                    .physical,
-            )
+            with_data_cols(table_configuration.build_expected_physical_stats_schema(
+                requested_physical_stats_columns,
+                Some(&filter),
+            )?)
         }
         // No requested columns, but a predicate is present. Use just the predicate refs so the
         // stats schema is trimmed to what the rewritten predicate needs.
         (_, PhysicalPredicate::Some(_, _)) => with_data_cols(
             table_configuration
-                .build_expected_stats_schemas(None, Some(&predicate_refs_physical))?
-                .physical,
+                .build_expected_physical_stats_schema(None, Some(&predicate_refs_physical))?,
         ),
         // No struct stats requested and no predicate: nothing to read or emit, so no stats schema.
         (_, _) => None,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -2270,6 +2270,89 @@ fn scan_builder_tolerates_nonexistent_extra_indexed_column() {
     );
 }
 
+#[rstest]
+#[case::no_column_mapping(None)]
+#[case::name_column_mapping(Some("name"))]
+#[case::id_column_mapping(Some("id"))]
+fn snapshot_expected_stats_schemas_match_scan_output(#[case] column_mapping_mode: Option<&str>) {
+    let table_root = "memory:///expected-stats-schemas/";
+    let store = Arc::new(InMemory::new());
+    let engine = SyncEngine::new_with_store(store);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "value": LONG,
+    };
+    let mut create_builder = create_table(table_root, schema, "DefaultEngine")
+        .with_table_properties([("delta.dataSkippingNumIndexedCols", "1")]);
+    if let Some(mode) = column_mapping_mode {
+        create_builder = create_builder.with_table_properties([("delta.columnMapping.mode", mode)]);
+    }
+    create_builder
+        .build(&engine, Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(&engine)
+        .unwrap()
+        .unwrap_committed();
+
+    let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
+    let extra_indexed_columns = vec![column_name!("value"), column_name!("unresolvable_extra")];
+    let expected = snapshot
+        .expected_stats_schemas(&extra_indexed_columns)
+        .unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .with_stats(StatsOptions::all_struct_with_extra_indexed(
+            extra_indexed_columns,
+        ))
+        .build()
+        .unwrap();
+
+    assert_eq!(
+        scan.physical_stats_output_schema.as_ref(),
+        Some(&expected.physical)
+    );
+
+    let DataType::Struct(logical_min_values) = expected
+        .logical
+        .field(MIN_VALUES)
+        .expect("logical stats should have minValues")
+        .data_type()
+    else {
+        panic!("logical minValues should be a struct");
+    };
+    assert!(logical_min_values.field("id").is_some());
+    assert!(logical_min_values.field("value").is_some());
+    assert!(logical_min_values.field("unresolvable_extra").is_none());
+
+    let DataType::Struct(physical_min_values) = expected
+        .physical
+        .field(MIN_VALUES)
+        .expect("physical stats should have minValues")
+        .data_type()
+    else {
+        panic!("physical minValues should be a struct");
+    };
+    assert_eq!(physical_min_values.num_fields(), 2);
+    if column_mapping_mode.is_some() {
+        assert!(logical_min_values.fields().all(|field| {
+            field
+                .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+                .is_none()
+                && field
+                    .get_config_value(&ColumnMetadataKey::ParquetFieldId)
+                    .is_none()
+        }));
+        assert!(physical_min_values.fields().all(|field| {
+            field.name().starts_with("col-")
+                && field
+                    .get_config_value(&ColumnMetadataKey::ParquetFieldId)
+                    .is_none()
+        }));
+    } else {
+        assert_eq!(physical_min_values, logical_min_values);
+    }
+}
+
 /// A [`ParquetHandler`] that returns an empty iterator for every `read_parquet_files` call.
 /// Used to simulate a buggy connector that drops all data for a file.
 struct EmptyParquetHandler;

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -32,6 +32,7 @@ use crate::schema::{
     StructType,
 };
 use crate::transaction::create_table::create_table;
+use crate::transaction::data_layout::DataLayout;
 use crate::{
     DeltaResultIteratorStatic, Engine, EngineData, FileDataReadResultIterator, FileMeta,
     ParquetFooter, ParquetHandler, PredicateRef, Snapshot,
@@ -39,6 +40,32 @@ use crate::{
 
 fn field_names(s: &StructArray) -> Vec<String> {
     s.fields().iter().map(|f| f.name().clone()).collect()
+}
+
+fn stats_struct_field<'a>(schema: &'a StructType, name: &str) -> &'a StructType {
+    let DataType::Struct(inner) = schema
+        .field(name)
+        .unwrap_or_else(|| panic!("stats schema should have {name}"))
+        .data_type()
+    else {
+        panic!("{name} should be a struct");
+    };
+    inner
+}
+
+fn assert_stats_schemas_aligned(logical: &StructType, physical: &StructType) {
+    assert_eq!(logical.num_fields(), physical.num_fields());
+    for (logical_field, physical_field) in logical.fields().zip(physical.fields()) {
+        assert_eq!(logical_field.is_nullable(), physical_field.is_nullable());
+        assert!(logical_field.metadata().is_empty());
+        assert!(physical_field.metadata().is_empty());
+        match (logical_field.data_type(), physical_field.data_type()) {
+            (DataType::Struct(logical), DataType::Struct(physical)) => {
+                assert_stats_schemas_aligned(logical, physical);
+            }
+            (logical, physical) => assert_eq!(logical, physical),
+        }
+    }
 }
 
 #[test]
@@ -2281,6 +2308,7 @@ fn snapshot_expected_stats_schemas_match_scan_output(#[case] column_mapping_mode
     let schema = schema_ref! {
         nullable "id": LONG,
         nullable "value": LONG,
+        nullable "other": LONG,
     };
     let mut create_builder = create_table(table_root, schema, "DefaultEngine")
         .with_table_properties([("delta.dataSkippingNumIndexedCols", "1")]);
@@ -2298,7 +2326,8 @@ fn snapshot_expected_stats_schemas_match_scan_output(#[case] column_mapping_mode
     let extra_indexed_columns = vec![column_name!("value"), column_name!("unresolvable_extra")];
     let expected = snapshot
         .expected_stats_schemas(&extra_indexed_columns)
-        .unwrap();
+        .unwrap()
+        .expect("stats should include indexed data columns");
     let scan = snapshot
         .scan_builder()
         .with_stats(StatsOptions::all_struct_with_extra_indexed(
@@ -2312,26 +2341,15 @@ fn snapshot_expected_stats_schemas_match_scan_output(#[case] column_mapping_mode
         Some(&expected.physical)
     );
 
-    let DataType::Struct(logical_min_values) = expected
-        .logical
-        .field(MIN_VALUES)
-        .expect("logical stats should have minValues")
-        .data_type()
-    else {
-        panic!("logical minValues should be a struct");
-    };
+    assert_stats_schemas_aligned(&expected.logical, &expected.physical);
+
+    let logical_min_values = stats_struct_field(&expected.logical, MIN_VALUES);
     assert!(logical_min_values.field("id").is_some());
     assert!(logical_min_values.field("value").is_some());
+    assert!(logical_min_values.field("other").is_none());
     assert!(logical_min_values.field("unresolvable_extra").is_none());
 
-    let DataType::Struct(physical_min_values) = expected
-        .physical
-        .field(MIN_VALUES)
-        .expect("physical stats should have minValues")
-        .data_type()
-    else {
-        panic!("physical minValues should be a struct");
-    };
+    let physical_min_values = stats_struct_field(&expected.physical, MIN_VALUES);
     assert_eq!(physical_min_values.num_fields(), 2);
     if column_mapping_mode.is_some() {
         assert!(logical_min_values.fields().all(|field| {
@@ -2351,6 +2369,95 @@ fn snapshot_expected_stats_schemas_match_scan_output(#[case] column_mapping_mode
     } else {
         assert_eq!(physical_min_values, logical_min_values);
     }
+}
+
+#[test]
+fn snapshot_expected_stats_schemas_returns_none_without_data_columns() {
+    let table_root = "memory:///expected-stats-schemas-empty/";
+    let store = Arc::new(InMemory::new());
+    let engine = SyncEngine::new_with_store(store);
+    create_table(
+        table_root,
+        schema_ref! { nullable "id": LONG },
+        "DefaultEngine",
+    )
+    .with_table_properties([("delta.dataSkippingNumIndexedCols", "0")])
+    .build(&engine, Box::new(FileSystemCommitter::new()))
+    .unwrap()
+    .commit(&engine)
+    .unwrap()
+    .unwrap_committed();
+
+    let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
+    assert!(snapshot.expected_stats_schemas(&[]).unwrap().is_none());
+
+    let scan = snapshot
+        .scan_builder()
+        .with_stats(StatsOptions::all_struct())
+        .build()
+        .unwrap();
+    assert!(scan.physical_stats_output_schema.is_none());
+}
+
+#[rstest]
+#[case::no_column_mapping(None)]
+#[case::name_column_mapping(Some("name"))]
+#[case::id_column_mapping(Some("id"))]
+fn snapshot_expected_stats_schemas_respect_explicit_columns_and_partitions(
+    #[case] column_mapping_mode: Option<&str>,
+) {
+    let table_root = "memory:///expected-stats-schemas-explicit/";
+    let store = Arc::new(InMemory::new());
+    let engine = SyncEngine::new_with_store(store);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "info": {
+            nullable "name": STRING,
+            nullable "age": INTEGER,
+        },
+        nullable "part": STRING,
+        nullable "other": LONG,
+    };
+    let mut create_builder = create_table(table_root, schema, "DefaultEngine")
+        .with_data_layout(DataLayout::partitioned(["part"]))
+        .with_table_properties([("delta.dataSkippingStatsColumns", "info.name")]);
+    if let Some(mode) = column_mapping_mode {
+        create_builder = create_builder.with_table_properties([("delta.columnMapping.mode", mode)]);
+    }
+    create_builder
+        .build(&engine, Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(&engine)
+        .unwrap()
+        .unwrap_committed();
+
+    let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
+    let extra_indexed_columns = vec![column_name!("other")];
+    let expected = snapshot
+        .expected_stats_schemas(&extra_indexed_columns)
+        .unwrap()
+        .expect("explicit and extra stats columns should be selected");
+    let scan = snapshot
+        .scan_builder()
+        .with_stats(StatsOptions::all_struct_with_extra_indexed(
+            extra_indexed_columns,
+        ))
+        .build()
+        .unwrap();
+
+    assert_eq!(
+        scan.physical_stats_output_schema.as_ref(),
+        Some(&expected.physical)
+    );
+    assert_stats_schemas_aligned(&expected.logical, &expected.physical);
+
+    let null_count = stats_struct_field(&expected.logical, NULL_COUNT);
+    assert!(null_count.field("id").is_none());
+    assert!(null_count.field("part").is_none());
+    assert!(null_count.field("other").is_some());
+    let info = stats_struct_field(null_count, "info");
+    assert!(info.field("name").is_some());
+    assert!(info.field("age").is_none());
 }
 
 /// A [`ParquetHandler`] that returns an empty iterator for every `read_parquet_files` call.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -345,30 +345,28 @@ impl Snapshot {
         self.table_configuration.logical_schema()
     }
 
-    /// Returns the expected logical and physical schemas for file statistics.
+    /// Returns aligned schemas for scans using all indexed structured statistics.
     ///
     /// `extra_indexed_columns` are logical column paths that may have statistics even when they
-    /// fall outside the table's configured indexed-column set. Resolvable extra columns are
-    /// included in both returned schemas; partition columns and unresolvable paths are omitted.
-    /// The physical schema applies the table's column-mapping mode.
+    /// fall outside the table's configured indexed-column set. Pass the same columns to
+    /// [`StatsOptions::all_struct_with_extra_indexed`] when building the scan. Partition columns
+    /// and unresolvable paths are omitted.
     ///
-    /// Both schemas contain `numRecords` and `tightBounds`. When at least one data column is
-    /// selected, they also contain `nullCount` and, for eligible data types, `minValues` and
-    /// `maxValues`. Nested fields mirror the selected portion of the table schema.
-    ///
-    /// Pass the same extra columns to [`StatsOptions::all_struct_with_extra_indexed`] when building
-    /// a scan that returns structured statistics.
+    /// The returned schemas have the same shape and field order. The logical schema uses table
+    /// column names, while the physical schema applies the table's column-mapping mode. Returns
+    /// `None` when no data columns are selected and the scan will not emit `stats_parsed`.
     ///
     /// # Errors
     ///
-    /// Returns an error if kernel cannot construct a valid stats schema.
+    /// Returns an error if a selected logical column cannot be mapped to the physical schema or
+    /// the selected fields cannot form a valid stats schema.
     ///
     /// [`StatsOptions::all_struct_with_extra_indexed`]:
     /// crate::scan::StatsOptions::all_struct_with_extra_indexed
     pub fn expected_stats_schemas(
         &self,
         extra_indexed_columns: &[ColumnName],
-    ) -> DeltaResult<ExpectedStatsSchemas> {
+    ) -> DeltaResult<Option<ExpectedStatsSchemas>> {
         self.table_configuration
             .build_expected_stats_schemas(extra_indexed_columns)
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -30,7 +30,9 @@ use crate::metrics::{
 use crate::path::ParsedLogPath;
 use crate::scan::ScanBuilder;
 use crate::schema::SchemaRef;
-use crate::table_configuration::{InCommitTimestampEnablement, TableConfiguration};
+use crate::table_configuration::{
+    ExpectedStatsSchemas, InCommitTimestampEnablement, TableConfiguration,
+};
 use crate::table_features::{physical_to_logical_column_name_and_type, TableFeature};
 use crate::table_properties::TableProperties;
 use crate::transaction::builder::alter_table::AlterTableTransactionBuilder;
@@ -341,6 +343,34 @@ impl Snapshot {
     /// [`Schema`]: crate::schema::Schema
     pub fn schema(&self) -> SchemaRef {
         self.table_configuration.logical_schema()
+    }
+
+    /// Returns the expected logical and physical schemas for file statistics.
+    ///
+    /// `extra_indexed_columns` are logical column paths that may have statistics even when they
+    /// fall outside the table's configured indexed-column set. Resolvable extra columns are
+    /// included in both returned schemas; partition columns and unresolvable paths are omitted.
+    /// The physical schema applies the table's column-mapping mode.
+    ///
+    /// Both schemas contain `numRecords` and `tightBounds`. When at least one data column is
+    /// selected, they also contain `nullCount` and, for eligible data types, `minValues` and
+    /// `maxValues`. Nested fields mirror the selected portion of the table schema.
+    ///
+    /// Pass the same extra columns to [`StatsOptions::all_struct_with_extra_indexed`] when building
+    /// a scan that returns structured statistics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if kernel cannot construct a valid stats schema.
+    ///
+    /// [`StatsOptions::all_struct_with_extra_indexed`]:
+    /// crate::scan::StatsOptions::all_struct_with_extra_indexed
+    pub fn expected_stats_schemas(
+        &self,
+        extra_indexed_columns: &[ColumnName],
+    ) -> DeltaResult<ExpectedStatsSchemas> {
+        self.table_configuration
+            .build_expected_stats_schemas(extra_indexed_columns)
     }
 
     /// Estimated owned heap size in bytes for this snapshot. Best-effort estimate

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -41,13 +41,16 @@ use crate::transforms::SchemaTransform as _;
 use crate::utils::require;
 use crate::{DeltaResult, Error, Version};
 
-/// Expected logical and physical schemas for file statistics.
+/// Aligned logical and physical schemas for structured file statistics.
+///
+/// The schemas have the same shape and field order. They differ only in the names of table
+/// columns when column mapping is enabled. All field metadata is removed.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ExpectedStatsSchemas {
-    /// Stats schema using logical table column names for connector-facing processing.
+    /// Schema using logical table column names.
     pub logical: SchemaRef,
-    /// Stats schema using physical column names as encoded in Delta statistics.
+    /// Schema using physical column names as encoded in Delta statistics.
     pub physical: SchemaRef,
 }
 
@@ -72,6 +75,18 @@ fn strip_metadata(schema: SchemaRef) -> SchemaRef {
         Cow::Owned(s) => Arc::new(s),
         _ => schema,
     }
+}
+
+fn build_stats_schema_for_columns(
+    data_schema: &StructType,
+    selected_columns: &[ColumnName],
+) -> DeltaResult<SchemaRef> {
+    let config = StatsConfig {
+        data_skipping_stats_columns: Some(selected_columns),
+        data_skipping_num_indexed_cols: None,
+    };
+    let schema = Arc::new(expected_stats_schema(data_schema, &config, None, None)?);
+    Ok(strip_metadata(schema))
 }
 
 fn validate_partition_columns(metadata: &Metadata, logical_schema: &StructType) -> DeltaResult<()> {
@@ -291,7 +306,7 @@ impl TableConfiguration {
         Self::try_new_from(table_configuration, new_metadata, new_protocol, new_version)
     }
 
-    /// Generates the logical and physical expected schemas for file statistics.
+    /// Generates aligned logical and physical schemas for structured file statistics.
     ///
     /// `extra_indexed_columns` use logical table column names. Resolvable columns are always
     /// included, even when they fall outside the configured indexed-column set. Unresolvable
@@ -299,16 +314,17 @@ impl TableConfiguration {
     pub(crate) fn build_expected_stats_schemas(
         &self,
         extra_indexed_columns: &[ColumnName],
-    ) -> DeltaResult<ExpectedStatsSchemas> {
-        let resolved_extra_columns: Vec<_> = extra_indexed_columns
+    ) -> DeltaResult<Option<ExpectedStatsSchemas>> {
+        let logical_schema = self.logical_schema_without_partition_columns();
+        let column_mapping_mode = self.column_mapping_mode();
+        let required_logical_columns: Vec<_> = extra_indexed_columns
             .iter()
             .filter_map(|logical_column| {
                 get_any_level_column_physical_name(
-                    &self.logical_schema_without_partition_columns(),
+                    &logical_schema,
                     logical_column,
-                    self.column_mapping_mode(),
+                    column_mapping_mode,
                 )
-                .map(|physical_column| (logical_column.clone(), physical_column))
                 .inspect_err(|e| {
                     warn!(
                         "Couldn't translate extra indexed stats column '{logical_column}' to a \
@@ -316,15 +332,8 @@ impl TableConfiguration {
                     );
                 })
                 .ok()
+                .map(|_| logical_column.clone())
             })
-            .collect();
-        let required_logical_columns: Vec<_> = resolved_extra_columns
-            .iter()
-            .map(|(logical, _)| logical.clone())
-            .collect();
-        let required_physical_columns: Vec<_> = resolved_extra_columns
-            .into_iter()
-            .map(|(_, physical)| physical)
             .collect();
 
         let logical_config = StatsConfig {
@@ -334,19 +343,33 @@ impl TableConfiguration {
                 .as_deref(),
             data_skipping_num_indexed_cols: self.table_properties().data_skipping_num_indexed_cols,
         };
-        let logical = Arc::new(expected_stats_schema(
-            &self.logical_schema_without_partition_columns(),
+        let logical_columns = stats_column_names(
+            &logical_schema,
             &logical_config,
             Some(&required_logical_columns),
-            None,
-        )?);
-        let physical =
-            self.build_expected_physical_stats_schema(Some(&required_physical_columns), None)?;
+        );
+        if logical_columns.is_empty() {
+            return Ok(None);
+        }
 
-        Ok(ExpectedStatsSchemas {
-            logical: strip_metadata(logical),
-            physical,
-        })
+        let physical_columns = logical_columns
+            .iter()
+            .map(|logical_column| {
+                get_any_level_column_physical_name(
+                    &logical_schema,
+                    logical_column,
+                    column_mapping_mode,
+                )
+            })
+            .collect::<DeltaResult<Vec<_>>>()?;
+
+        let logical = build_stats_schema_for_columns(&logical_schema, &logical_columns)?;
+        let physical = build_stats_schema_for_columns(
+            &self.physical_data_schema_without_partition_columns(),
+            &physical_columns,
+        )?;
+
+        Ok(Some(ExpectedStatsSchemas { logical, physical }))
     }
 
     /// Generates the expected physical schema for file statistics.
@@ -361,10 +384,11 @@ impl TableConfiguration {
     ///   nullCount: { <columns with LONG type> },
     ///   minValues: { <columns with original types> },
     ///   maxValues: { <columns with original types> },
+    ///   tightBounds: boolean,
     /// }
     /// ```
     ///
-    /// The schemas are affected by:
+    /// The schema is affected by:
     /// - **Column mapping mode**: Physical schema field names use physical names from column
     ///   mapping metadata.
     /// - **`delta.dataSkippingStatsColumns`**: If set, only specified columns are included.
@@ -377,7 +401,6 @@ impl TableConfiguration {
     ///
     /// See the Delta protocol for more details on per-file statistics:
     /// <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#per-file-statistics>
-    #[allow(unused)]
     #[internal_api]
     pub(crate) fn build_expected_physical_stats_schema(
         &self,

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -41,14 +41,13 @@ use crate::transforms::SchemaTransform as _;
 use crate::utils::require;
 use crate::{DeltaResult, Error, Version};
 
-/// Expected schema for file statistics, using physical column names.
-///
-/// Wrapped in a struct so it can be extended with a logical-name variant if needed.
-#[allow(unused)]
+/// Expected logical and physical schemas for file statistics.
 #[derive(Debug, Clone)]
-#[internal_api]
-pub(crate) struct ExpectedStatsSchemas {
-    /// Stats schema using physical column names (for storage).
+#[non_exhaustive]
+pub struct ExpectedStatsSchemas {
+    /// Stats schema using logical table column names for connector-facing processing.
+    pub logical: SchemaRef,
+    /// Stats schema using physical column names as encoded in Delta statistics.
     pub physical: SchemaRef,
 }
 
@@ -292,11 +291,68 @@ impl TableConfiguration {
         Self::try_new_from(table_configuration, new_metadata, new_protocol, new_version)
     }
 
-    /// Generates the expected schema for file statistics.
+    /// Generates the logical and physical expected schemas for file statistics.
+    ///
+    /// `extra_indexed_columns` use logical table column names. Resolvable columns are always
+    /// included, even when they fall outside the configured indexed-column set. Unresolvable
+    /// columns are omitted with a warning.
+    pub(crate) fn build_expected_stats_schemas(
+        &self,
+        extra_indexed_columns: &[ColumnName],
+    ) -> DeltaResult<ExpectedStatsSchemas> {
+        let resolved_extra_columns: Vec<_> = extra_indexed_columns
+            .iter()
+            .filter_map(|logical_column| {
+                get_any_level_column_physical_name(
+                    &self.logical_schema_without_partition_columns(),
+                    logical_column,
+                    self.column_mapping_mode(),
+                )
+                .map(|physical_column| (logical_column.clone(), physical_column))
+                .inspect_err(|e| {
+                    warn!(
+                        "Couldn't translate extra indexed stats column '{logical_column}' to a \
+                         physical name: {e}; skipping"
+                    );
+                })
+                .ok()
+            })
+            .collect();
+        let required_logical_columns: Vec<_> = resolved_extra_columns
+            .iter()
+            .map(|(logical, _)| logical.clone())
+            .collect();
+        let required_physical_columns: Vec<_> = resolved_extra_columns
+            .into_iter()
+            .map(|(_, physical)| physical)
+            .collect();
+
+        let logical_config = StatsConfig {
+            data_skipping_stats_columns: self
+                .table_properties()
+                .data_skipping_stats_columns
+                .as_deref(),
+            data_skipping_num_indexed_cols: self.table_properties().data_skipping_num_indexed_cols,
+        };
+        let logical = Arc::new(expected_stats_schema(
+            &self.logical_schema_without_partition_columns(),
+            &logical_config,
+            Some(&required_logical_columns),
+            None,
+        )?);
+        let physical =
+            self.build_expected_physical_stats_schema(Some(&required_physical_columns), None)?;
+
+        Ok(ExpectedStatsSchemas {
+            logical: strip_metadata(logical),
+            physical,
+        })
+    }
+
+    /// Generates the expected physical schema for file statistics.
     ///
     /// Engines can provide statistics for files written to the delta table, enabling
-    /// data skipping and other optimizations. Returns the physical stats schema wrapped in
-    /// an `ExpectedStatsSchemas`.
+    /// data skipping and other optimizations.
     ///
     /// The schema is structured as:
     /// ```text
@@ -323,11 +379,11 @@ impl TableConfiguration {
     /// <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#per-file-statistics>
     #[allow(unused)]
     #[internal_api]
-    pub(crate) fn build_expected_stats_schemas(
+    pub(crate) fn build_expected_physical_stats_schema(
         &self,
         required_physical_columns: Option<&[ColumnName]>,
         requested_physical_columns: Option<&[ColumnName]>,
-    ) -> DeltaResult<ExpectedStatsSchemas> {
+    ) -> DeltaResult<SchemaRef> {
         let physical_data_schema = self.physical_data_schema_without_partition_columns();
         let required_physical_stats_columns = self.required_physical_stats_columns();
         let config = StatsConfig {
@@ -342,9 +398,7 @@ impl TableConfiguration {
         )?);
         let physical_stats_schema = strip_metadata(physical_stats_schema);
 
-        Ok(ExpectedStatsSchemas {
-            physical: physical_stats_schema,
-        })
+        Ok(physical_stats_schema)
     }
 
     /// Returns the list of physical column names that should have statistics collected.
@@ -1957,7 +2011,7 @@ mod test {
     }
 
     #[test]
-    fn test_build_expected_stats_schemas_no_column_mapping() {
+    fn test_build_expected_physical_stats_schema_no_column_mapping() {
         let config = MockTableConfigurationBuilder::new()
             .with_schema(schema! {
                 nullable "col_a": LONG,
@@ -1968,14 +2022,12 @@ mod test {
 
         assert_eq!(config.column_mapping_mode(), ColumnMappingMode::None);
 
-        let stats_schemas = config.build_expected_stats_schemas(None, None).unwrap();
+        let stats_schema = config
+            .build_expected_physical_stats_schema(None, None)
+            .unwrap();
 
         // Verify field names are logical names
-        let min_values = stats_schemas
-            .physical
-            .field(MIN_VALUES)
-            .unwrap()
-            .data_type();
+        let min_values = stats_schema.field(MIN_VALUES).unwrap().data_type();
         if let DataType::Struct(inner) = min_values {
             assert!(inner.field("col_a").is_some());
             assert!(inner.field("col_b").is_some());
@@ -1985,7 +2037,7 @@ mod test {
     }
 
     #[test]
-    fn test_build_expected_stats_schemas_with_column_mapping() {
+    fn test_build_expected_physical_stats_schema_with_column_mapping() {
         // With column mapping, physical schema should have physical names
         let schema = schema_with_column_mapping();
         let config = MockTableConfigurationBuilder::new()
@@ -1996,14 +2048,12 @@ mod test {
 
         assert_eq!(config.column_mapping_mode(), ColumnMappingMode::Name);
 
-        let stats_schemas = config.build_expected_stats_schemas(None, None).unwrap();
+        let stats_schema = config
+            .build_expected_physical_stats_schema(None, None)
+            .unwrap();
 
         // Verify physical schema has physical names
-        let physical_min_values = stats_schemas
-            .physical
-            .field(MIN_VALUES)
-            .unwrap()
-            .data_type();
+        let physical_min_values = stats_schema.field(MIN_VALUES).unwrap().data_type();
         if let DataType::Struct(inner) = physical_min_values {
             assert!(
                 inner.field("phys_col_a").is_some(),
@@ -2020,7 +2070,7 @@ mod test {
     }
 
     #[test]
-    fn test_build_expected_stats_schemas_id_mode_has_no_parquet_field_ids() {
+    fn test_build_expected_physical_stats_schema_id_mode_has_no_parquet_field_ids() {
         // With column mapping mode `id`, make_physical() injects ParquetFieldId metadata for
         // data file reading. But the physical stats schema must NOT contain these field IDs
         // because stats are read from JSON commit files or checkpoint Parquet files, neither of
@@ -2036,14 +2086,12 @@ mod test {
 
         assert_eq!(config.column_mapping_mode(), ColumnMappingMode::Id);
 
-        let stats_schemas = config.build_expected_stats_schemas(None, None).unwrap();
+        let stats_schema = config
+            .build_expected_physical_stats_schema(None, None)
+            .unwrap();
 
         // Verify physical schema has physical names
-        let physical_min_values = stats_schemas
-            .physical
-            .field(MIN_VALUES)
-            .unwrap()
-            .data_type();
+        let physical_min_values = stats_schema.field(MIN_VALUES).unwrap().data_type();
         let DataType::Struct(inner) = physical_min_values else {
             panic!("Expected minValues to be a struct");
         };
@@ -2129,7 +2177,7 @@ mod test {
     }
 
     #[test]
-    fn test_build_expected_stats_schemas_excludes_partition_columns() {
+    fn test_build_expected_physical_stats_schema_excludes_partition_columns() {
         let config = MockTableConfigurationBuilder::new()
             .with_schema(partitioned_schema_with_column_mapping())
             .with_column_mapping(ColumnMappingMode::Name)
@@ -2137,14 +2185,11 @@ mod test {
             .with_protocol(MockProtocolBuilder::new().with_versions(2, 5).build())
             .build();
 
-        let stats_schemas = config.build_expected_stats_schemas(None, None).unwrap();
+        let stats_schema = config
+            .build_expected_physical_stats_schema(None, None)
+            .unwrap();
 
-        let DataType::Struct(inner) = stats_schemas
-            .physical
-            .field(MIN_VALUES)
-            .unwrap()
-            .data_type()
-        else {
+        let DataType::Struct(inner) = stats_schema.field(MIN_VALUES).unwrap().data_type() else {
             panic!("Expected minValues to be a struct");
         };
         assert!(

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1026,10 +1026,13 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// settings.
     #[allow(unused)]
     pub fn stats_schema(&self) -> DeltaResult<SchemaRef> {
-        let stats_schemas = self
+        let stats_schema = self
             .effective_table_config
-            .build_expected_stats_schemas(self.physical_clustering_columns.as_deref(), None)?;
-        Ok(stats_schemas.physical)
+            .build_expected_physical_stats_schema(
+                self.physical_clustering_columns.as_deref(),
+                None,
+            )?;
+        Ok(stats_schema)
     }
 
     /// Returns the list of column names that should have statistics collected.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expose the resolved read-side file-statistics schema through `Snapshot`. The new API returns
aligned logical and physical schemas, applies column mapping, excludes partition columns, and lets
callers include extra indexed columns beyond the configured statistics budget. It returns `None`
when the matching scan would not emit structured statistics.

Internal scan, checkpoint, and transaction paths continue to use the physical schema builder. The
logical and physical schemas now share one column-selection pass, keeping their field order and
shape aligned.

### This PR affects the following public APIs

- Adds `Snapshot::expected_stats_schemas`, returning aligned schemas when the scan emits structured
  statistics.
- Adds the logical schema to `ExpectedStatsSchemas` and marks the type `#[non_exhaustive]`.
- Renames the unstable `TableConfiguration::build_expected_stats_schemas` internal API to
  `build_expected_physical_stats_schema` and returns its physical `SchemaRef` directly.

## How was this change tested?

Added scan-schema consistency tests covering excluded columns, explicit nested stats columns,
partition columns, unresolved extras, empty stats selection, and no/name/id column mapping. The
tests also verify logical-to-physical field alignment and metadata removal.
