### PR TITLE
chore: Define and use impl From<PoisonError> for Error

### DIFF
--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -1,8 +1,8 @@
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 
 use delta_kernel::commit_range::{CommitAction, CommitRange, DeltaAction as KernelDeltaAction};
 use delta_kernel::snapshot::SnapshotRef;
-use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Error, Version};
+use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Version};
 use delta_kernel_ffi_macros::handle_descriptor;
 use url::Url;
 
@@ -281,14 +281,6 @@ pub struct FfiCommitActionsIterator {
     engine: Arc<dyn ExternEngine>,
 }
 
-impl FfiCommitActionsIterator {
-    fn lock_iter(&self) -> DeltaResult<MutexGuard<'_, CommitActionIter>> {
-        self.data
-            .lock()
-            .map_err(|_| Error::generic("poisoned commit-actions iterator mutex"))
-    }
-}
-
 #[handle_descriptor(target=FfiCommitActionsIterator, mutable=false, sized=true)]
 pub struct SharedCommitActionsIterator;
 
@@ -397,7 +389,7 @@ fn commit_range_commits_next_impl(
         commit_action: Handle<SharedCommitAction>,
     ),
 ) -> DeltaResult<bool> {
-    let mut iter = data.lock_iter()?;
+    let mut iter = data.data.lock()?;
     match iter.next().transpose()? {
         Some(commit_action) => {
             (engine_visitor)(engine_context, Arc::new(commit_action).into());

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -535,11 +535,7 @@ impl GlobalTracingState {
     /// `INFO`.
     fn register_metrics_callback(&mut self, callback: MetricsEventFn) -> DeltaResult<()> {
         self.ensure_installed()?;
-        *self
-            .metrics_callback
-            .lock()
-            .map_err(|_| Error::generic("Failed to lock metrics callback (mutex poisoned)."))? =
-            Some(callback);
+        *self.metrics_callback.lock()? = Some(callback);
         self.metrics_filter
             .as_ref()
             .ok_or_else(|| Error::generic("metrics filter not installed"))?
@@ -552,9 +548,7 @@ static TRACING_STATE: LazyLock<Mutex<GlobalTracingState>> =
     LazyLock::new(|| Mutex::new(GlobalTracingState::uninitialized()));
 
 fn setup_event_subscriber(callback: TracingEventFn, max_level: Level) -> DeltaResult<()> {
-    let mut state = TRACING_STATE
-        .lock()
-        .map_err(|_e| Error::generic("Poisoned mutex while setting up event subscriber"))?;
+    let mut state = TRACING_STATE.lock()?;
     state.register_event_callback(callback, max_level)
 }
 
@@ -567,10 +561,7 @@ fn setup_log_line_subscriber(
     with_level: bool,
     with_target: bool,
 ) -> DeltaResult<()> {
-    let mut state = TRACING_STATE
-        .lock()
-        .map_err(|_e| Error::generic("Poisoned mutex while setting up log_line_subscriber"))?;
-    state.register_log_line_callback(
+    TRACING_STATE.lock()?.register_log_line_callback(
         callback,
         max_level,
         format,
@@ -596,9 +587,7 @@ pub unsafe extern "C" fn enable_metrics_reporting(callback: MetricsEventFn) -> b
 }
 
 fn setup_metrics_reporter(callback: MetricsEventFn) -> DeltaResult<()> {
-    let mut state = TRACING_STATE
-        .lock()
-        .map_err(|_e| Error::generic("Poisoned mutex while setting up metrics reporter"))?;
+    let mut state = TRACING_STATE.lock()?;
     state.register_metrics_callback(callback)
 }
 

--- a/ffi/src/incremental_scan.rs
+++ b/ffi/src/incremental_scan.rs
@@ -234,7 +234,7 @@ pub unsafe extern "C" fn incremental_scan_stream_next_arrow(
 fn incremental_scan_stream_next_arrow_impl(
     stream: &FfiIncrementalScanStream,
 ) -> DeltaResult<*mut ScanMetadataArrowResult> {
-    let mut guard = lock_stream(stream)?;
+    let mut guard = stream.stream.lock()?;
     let Some(inner) = guard.as_mut() else {
         // The stream was already consumed by `into_summary` or dropped by a prior error.
         return Err(Error::generic(
@@ -293,20 +293,13 @@ pub unsafe extern "C" fn incremental_scan_stream_into_summary(
 fn incremental_scan_stream_into_summary_impl(
     stream: &FfiIncrementalScanStream,
 ) -> DeltaResult<Handle<SharedIncrementalScanSummary>> {
-    let inner = lock_stream(stream)?
+    let inner = stream
+        .stream
+        .lock()?
         .take()
         .ok_or_else(|| Error::generic("incremental scan stream was already consumed"))?;
     let summary = inner.into_summary()?;
     Ok(Arc::new(summary).into())
-}
-
-fn lock_stream(
-    stream: &FfiIncrementalScanStream,
-) -> DeltaResult<std::sync::MutexGuard<'_, Option<IncrementalScanStream>>> {
-    stream
-        .stream
-        .lock()
-        .map_err(|_| Error::generic("poisoned incremental scan stream mutex"))
 }
 
 /// The base (exclusive lower bound) version of the scanned range.

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -8,7 +8,7 @@ use delta_kernel::scan::state::{DvInfo, ScanFile};
 use delta_kernel::scan::{PartitionValuesOptions, Scan, ScanBuilder, ScanMetadata, StatsOptions};
 use delta_kernel::schema::MetadataValue;
 use delta_kernel::snapshot::SnapshotRef;
-use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Error, Expression, ExpressionRef};
+use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Expression, ExpressionRef};
 use delta_kernel_ffi_macros::handle_descriptor;
 use tracing::debug;
 use url::Url;
@@ -495,9 +495,7 @@ impl ScanMetadataIterator {
     /// Acquire the iterator's mutex, returning a guard the caller can drain. While the
     /// guard is alive, concurrent `scan_metadata_next` calls on the same handle block.
     pub(crate) fn lock_iter(&self) -> DeltaResult<std::sync::MutexGuard<'_, ScanMetadataIter>> {
-        self.data
-            .lock()
-            .map_err(|_| Error::generic("poisoned scan-metadata iterator mutex"))
+        Ok(self.data.lock()?)
     }
 }
 
@@ -1023,11 +1021,7 @@ pub unsafe extern "C" fn scan_metadata_next_arrow(
 fn scan_metadata_next_arrow_impl(
     data: &ScanMetadataIterator,
 ) -> DeltaResult<*mut ScanMetadataArrowResult> {
-    let mut iter = data
-        .data
-        .lock()
-        .map_err(|_| Error::generic("poisoned mutex"))?;
-
+    let mut iter = data.data.lock()?;
     match iter.next().transpose()? {
         Some(scan_metadata) => {
             let (engine_data, selection_vector) = scan_metadata.scan_files.into_parts();

--- a/ffi/src/table_changes.rs
+++ b/ffi/src/table_changes.rs
@@ -7,7 +7,7 @@ use delta_kernel::arrow::ffi::to_ffi;
 use delta_kernel::engine::arrow_data::EngineDataArrowExt;
 use delta_kernel::table_changes::scan::TableChangesScan;
 use delta_kernel::table_changes::TableChanges;
-use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, EngineData, Error, Version};
+use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, EngineData, Version};
 use delta_kernel_ffi_macros::handle_descriptor;
 use tracing::debug;
 use url::Url;
@@ -310,10 +310,7 @@ pub unsafe extern "C" fn scan_table_changes_next(
 }
 
 fn scan_table_changes_next_impl(data: &ScanTableChangesIterator) -> DeltaResult<*mut ArrowFFIData> {
-    let mut data = data
-        .data
-        .lock()
-        .map_err(|_| Error::generic("poisoned scan table changes iterator mutex"))?;
+    let mut data = data.data.lock()?;
 
     let Some(data) = data.next().transpose()? else {
         return Ok(std::ptr::null_mut());

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -593,11 +593,7 @@ impl CheckpointWriter {
             )? {
                 sidecar_metas.push(entry);
             }
-            let is_exhausted = splitter
-                .lock()
-                .map_err(|e| Error::internal_error(format!("sidecar splitter lock poisoned: {e}")))?
-                .is_exhausted();
-            if is_exhausted {
+            if splitter.lock()?.is_exhausted() {
                 break;
             }
         }
@@ -607,8 +603,7 @@ impl CheckpointWriter {
             .ok_or_else(|| {
                 Error::internal_error("sidecar splitter Arc should have no other references")
             })?
-            .into_inner()
-            .map_err(|e| Error::internal_error(format!("sidecar splitter lock poisoned: {e}")))?
+            .into_inner()?
             .into_non_file_batches();
 
         // Create sidecar action rows for the main checkpoint file. Each row populates only

--- a/kernel/src/checkpoint/sidecar/tests.rs
+++ b/kernel/src/checkpoint/sidecar/tests.rs
@@ -69,15 +69,14 @@ fn generate_checkpoint_parts(
             sidecar_index += 1;
         }
 
-        if splitter.lock().expect("splitter lock").is_exhausted() {
+        if splitter.lock()?.is_exhausted() {
             break;
         }
     }
 
     let non_file_batches = Arc::into_inner(splitter)
         .expect("splitter Arc should have no other references")
-        .into_inner()
-        .expect("splitter Mutex should not be poisoned")
+        .into_inner()?
         .into_non_file_batches();
 
     Ok(CheckpointParts {
@@ -664,12 +663,11 @@ async fn test_splitter_no_file_actions() -> DeltaResult<()> {
     let total_file_rows: usize = iter.map(|batch| batch.unwrap().len()).sum();
     assert_eq!(total_file_rows, 0, "should have no file-action rows");
 
-    assert!(splitter.lock().expect("splitter lock").is_exhausted());
+    assert!(splitter.lock()?.is_exhausted());
 
     let non_file_batches = Arc::into_inner(splitter)
         .expect("splitter Arc should have no other references")
-        .into_inner()
-        .expect("splitter Mutex should not be poisoned")
+        .into_inner()?
         .into_non_file_batches();
     verify_non_file_batches(
         &non_file_batches,

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -545,6 +545,12 @@ impl From<object_store::Error> for Error {
     }
 }
 
+impl<T> From<std::sync::PoisonError<T>> for Error {
+    fn from(_error: std::sync::PoisonError<T>) -> Self {
+        Self::internal_error("poisoned mutex")
+    }
+}
+
 /// This impl is needed so the `?` operator can auto-convert `Result<T, Infallible>` to
 /// `DeltaResult<T>`. For example, `TryFrom` impls for infallible conversions use `Infallible` as
 /// their error type, and this allows those results to be propagated with `?` in functions

--- a/kernel/src/metrics/metered_storage.rs
+++ b/kernel/src/metrics/metered_storage.rs
@@ -276,7 +276,7 @@ mod tests {
             _path: &Url,
             cancellation_token: Option<CancellationTokenRef>,
         ) -> DeltaResult<DeltaResultIteratorStatic<FileMeta>> {
-            *self.seen.lock().unwrap() = cancellation_token;
+            *self.seen.lock()? = cancellation_token;
             Ok(Box::new(std::iter::empty()))
         }
 
@@ -292,7 +292,7 @@ mod tests {
             _files: Vec<FileSlice>,
             cancellation_token: Option<CancellationTokenRef>,
         ) -> DeltaResult<DeltaResultIteratorStatic<Bytes>> {
-            *self.seen.lock().unwrap() = cancellation_token;
+            *self.seen.lock()? = cancellation_token;
             Ok(Box::new(std::iter::empty()))
         }
 

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1706,7 +1706,7 @@ impl ParquetHandler for RecordingParquetHandler {
         physical_schema: schema::SchemaRef,
         predicate: Option<PredicateRef>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        self.reads.lock().unwrap().push(RecordedParquetRead {
+        self.reads.lock()?.push(RecordedParquetRead {
             files: files.to_vec(),
             physical_schema: physical_schema.clone(),
             predicate: predicate.clone(),

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -3655,7 +3655,7 @@ mod tests {
             _actions: DeltaResultIterator<'_, FilteredEngineData>,
             commit_metadata: CommitMetadata,
         ) -> DeltaResult<CommitResponse> {
-            *self.captured.lock().unwrap() = Some(commit_metadata.in_commit_timestamp());
+            *self.captured.lock()? = Some(commit_metadata.in_commit_timestamp());
             Ok(CommitResponse::Conflict {
                 version: commit_metadata.version(),
             })
@@ -3740,8 +3740,7 @@ mod tests {
 
         // The ICT in CommitMetadata must be prev_ict + 1 (monotonicity), NOT the wall time.
         let captured = captured_ts
-            .lock()
-            .unwrap()
+            .lock()?
             .expect("should have captured a timestamp");
         assert_eq!(
             captured,


### PR DESCRIPTION
## What changes are proposed in this pull request?

As per title. 

The upshot is that code like this:
```rust
let value = self.lock().map_error(|_| Error::internal_error(...))?;
```

Can now just use `?` normally:
```rust
let value = self.lock()?;
```

This saves a surprising number of LoC across the various callsites, because `fmt` likes to wrap the `map_error` calls across several lines.

The main possible controversy of this change is that all error messages become the generic "poisoned mutex", and FFI no longer surfaces poisoned mutex errors as `Error::Generic`. The former seems fine, because `Error::Internal` anyway grabs a backtrace. The latter is arguably a Good Thing because the generic bucket is horribly over-used.

## How was this change tested?

Existing unit tests.