### PR TITLE
perf: bypass query plans for JSON reads

### DIFF
--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -4,9 +4,19 @@ pub(crate) mod apply_schema;
 
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+#[cfg(any(
+    test,
+    all(feature = "declarative-plans", feature = "default-engine-base")
+))]
+use std::io::{BufReader, Cursor};
 use std::ops::Range;
 use std::sync::{Arc, LazyLock, OnceLock};
 
+#[cfg(any(
+    test,
+    all(feature = "declarative-plans", feature = "default-engine-base")
+))]
+use bytes::Bytes;
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;
 use tracing::debug;
@@ -1560,6 +1570,25 @@ pub(crate) fn fixup_json_read(
 ) -> DeltaResult<ArrowEngineData> {
     let data = reorder_struct_array(batch.into(), reorder_indices, None, Some(file_location))?;
     Ok(data.into())
+}
+
+/// Parse line-delimited JSON bytes directly into Arrow batches matching `schema`.
+#[cfg(any(
+    test,
+    all(feature = "declarative-plans", feature = "default-engine-base")
+))]
+pub(crate) fn read_json_bytes(
+    data: Bytes,
+    schema: SchemaRef,
+    file_location: String,
+) -> DeltaResult<impl Iterator<Item = DeltaResult<ArrowEngineData>>> {
+    let json_schema = Arc::new(json_arrow_schema(&schema)?);
+    let reorder_indices = build_json_reorder_indices(&schema)?;
+    let json = ReaderBuilder::new(json_schema)
+        .with_coerce_primitive(true)
+        .build(BufReader::new(Cursor::new(data)))?
+        .map(move |data| fixup_json_read(data?, &reorder_indices, &file_location));
+    Ok(json)
 }
 
 /// Builds the [`ReorderIndex`] vec for post-processing JSON read batches.

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -2,15 +2,16 @@
 
 use std::sync::Arc;
 
+use bytes::Bytes;
 use tracing::debug;
 use url::Url;
 
-use crate::engine::arrow_utils;
-use crate::plans::{Operation, PlanBuilder, PlanExecutor};
+use crate::engine::arrow_utils::{self, read_json_bytes};
+use crate::plans::{IoOperation, Operation, PlanExecutor};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
-    FileSize, FilteredEngineData, JsonHandler, PredicateRef,
+    DeltaResult, DeltaResultIterator, DeltaResultIteratorStatic, EngineData, Error,
+    FileDataReadResultIterator, FileMeta, FileSize, FilteredEngineData, JsonHandler, PredicateRef,
 };
 
 /// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
@@ -51,12 +52,25 @@ impl JsonHandler for PlanBasedJsonHandler {
         physical_schema: SchemaRef,
         _predicate: Option<PredicateRef>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        // TODO: `_predicate` is dropped. Re-apply it as a Filter node over the scan; the
-        // single-node executor can then match the filter -> scan shape.
-        let query = PlanBuilder::scan_json(files.to_vec(), &[], physical_schema)?.build()?;
-        self.executor
-            .execute_op(Operation::QueryPlan(query))?
-            .into_data()
+        let locations = files
+            .iter()
+            .map(|file| file.location.clone())
+            .collect::<Vec<_>>();
+        let slices = locations
+            .iter()
+            .map(|location| (location.clone(), None))
+            .collect();
+        let buffers = self
+            .executor
+            .execute_op(Operation::IoOperation(IoOperation::read_bytes(slices)))?
+            .into_bytes()?;
+        let data = locations
+            .into_iter()
+            .zip(buffers)
+            .flat_map(move |(location, buffer)| {
+                parse_json_bytes(buffer, physical_schema.clone(), location.to_string())
+            });
+        Ok(Box::new(data))
     }
 
     fn write_json_file(
@@ -73,6 +87,22 @@ impl JsonHandler for PlanBasedJsonHandler {
         };
         debug!(%path, "PlanBasedJsonHandler delegating write_json_file to fallback handler");
         fallback.write_json_file(path, data, overwrite)
+    }
+}
+
+fn parse_json_bytes(
+    buffer: DeltaResult<Bytes>,
+    schema: SchemaRef,
+    location: String,
+) -> DeltaResultIteratorStatic<Box<dyn EngineData>> {
+    match buffer.and_then(|bytes| {
+        read_json_bytes(bytes, schema, location).map(|iter| {
+            Box::new(iter.map(|batch| batch.map(|data| Box::new(data) as Box<dyn EngineData>)))
+                as DeltaResultIteratorStatic<Box<dyn EngineData>>
+        })
+    }) {
+        Ok(data) => data,
+        Err(error) => Box::new(std::iter::once(Err(error))),
     }
 }
 
@@ -100,9 +130,21 @@ mod tests {
         JsonHandler as _, ParquetHandler as _,
     };
 
+    struct IoOnlyPlanExecutor(SyncPlanExecutor);
+
+    impl crate::plans::PlanExecutor for IoOnlyPlanExecutor {
+        fn execute_op(&self, op: crate::plans::Operation) -> DeltaResult<crate::plans::PlanResult> {
+            assert!(
+                matches!(&op, crate::plans::Operation::IoOperation(_)),
+                "JSON reads must bypass generic query-plan execution"
+            );
+            crate::plans::PlanExecutor::execute_op(&self.0, op)
+        }
+    }
+
     fn make_handler() -> PlanBasedJsonHandler {
         PlanBasedJsonHandler::new(
-            Arc::new(SyncPlanExecutor::default()),
+            Arc::new(IoOnlyPlanExecutor(SyncPlanExecutor::default())),
             Some(SyncEngine::new().json_handler()),
         )
     }

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -1,16 +1,11 @@
-use std::io::{BufReader, Cursor};
 use std::sync::Arc;
 
 use bytes::Bytes;
 use url::Url;
 
 use super::{put_bytes, read_files_arrow};
-use crate::arrow::json::ReaderBuilder;
 use crate::engine::arrow_data::ArrowEngineData;
-use crate::engine::arrow_utils::{
-    build_json_reorder_indices, fixup_json_read, json_arrow_schema, parse_json as arrow_parse_json,
-    to_json_bytes,
-};
+use crate::engine::arrow_utils::{parse_json as arrow_parse_json, read_json_bytes, to_json_bytes};
 use crate::engine_data::FilteredEngineData;
 use crate::object_store::DynObjectStore;
 use crate::schema::SchemaRef;
@@ -35,13 +30,7 @@ pub(super) fn try_create_from_json(
     _predicate: Option<PredicateRef>,
     file_location: String,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ArrowEngineData>>> {
-    let json_schema = Arc::new(json_arrow_schema(&schema)?);
-    let reorder_indices = build_json_reorder_indices(&schema)?;
-    let json = ReaderBuilder::new(json_schema)
-        .with_coerce_primitive(true)
-        .build(BufReader::new(Cursor::new(data)))?
-        .map(move |data| fixup_json_read(data?, &reorder_indices, &file_location));
-    Ok(json)
+    read_json_bytes(data, schema, file_location)
 }
 
 impl JsonHandler for SyncJsonHandler {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Read JSON files in `PlanBasedJsonHandler` through the typed `ReadBytes` I/O operation and decode
the returned bytes directly with Arrow JSON. This avoids constructing and executing a generic
single-node query plan for JSON scans while preserving the generic query-plan path for other plan
shapes.

The Arrow JSON byte decoder is shared with `SyncJsonHandler`. A focused test wraps the plan
executor and rejects `QueryPlan` operations, proving that JSON reads take only the typed I/O path.

In a local CommitRange benchmark over 1,000 one-action commit files (50 warmups, 10 measured
iterations, release/O3 native build), the median fell from 3.616 s with generic driver-local plan
execution to 0.788 s with direct JSON, a 4.59x speedup. Both variants launched zero Spark jobs.
The remaining cost includes three scans per commit in the benchmarked CommitRange call path.

## How was this change tested?

- `cargo test -p delta_kernel --features declarative-plans engine::plans::json::tests::test_read_json_files`
- Repository pre-commit checks (formatting, Clippy, and tests)
